### PR TITLE
Heal money nerf

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_nade_stun.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_nade_stun.lua
@@ -35,7 +35,7 @@ SWEP.WorldModelOffset = {
     ang = Angle(-10, 0, 180)
 }
 
-SWEP.FuseTime = 1.25
+SWEP.FuseTime = 1.55
 
 SWEP.Throwing = true
 

--- a/gamemodes/horde/gamemode/sv_heal.lua
+++ b/gamemodes/horde/gamemode/sv_heal.lua
@@ -88,7 +88,7 @@ function HORDE:OnPlayerHeal(ply, healinfo, silent)
     end
     ply:ScreenFade(SCREENFADE.IN, Color(50, 200, 50, 10), 0.3, 0)
     if healer ~= ply then
-        healer:Horde_AddMoney(3)
+        healer:Horde_AddMoney(1)
         healer:Horde_SyncEconomy()
         net.Start("Horde_RenderHealer")
             net.WriteString(healer:GetName())


### PR DESCRIPTION
Money for healing decreased from 3 > 1 per tick (heal clouds less op)
