### PR TITLE
Faster Javelin lock

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_javelin.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_javelin.lua
@@ -219,7 +219,7 @@ function SWEP:Hook_ShouldNotSight()
     return true
 end
 
-SWEP.LockDuration = 1.25
+SWEP.LockDuration = 0.5
 sound.Add({
     name = "JAVELIN_LOCK",
     channel = 16,


### PR DESCRIPTION
Reduced lock on time required before firing javelin to make it feel less sluggish and hard to use against fast zombies