### PR TITLE
Added halos to medic class

### DIFF
--- a/gamemodes/horde/gamemode/perks/medic/medic_base.lua
+++ b/gamemodes/horde/gamemode/perks/medic/medic_base.lua
@@ -14,15 +14,33 @@ PERK.Params = {
 }
 
 PERK.Hooks = {}
+
+local function getHealthColor( health )
+    local hue = math.Clamp(( health / 100 ) * 120, 0, 175)
+    return HSVToColor( hue, 1, 1 )
+end
+
 PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if SERVER and perk == "medic_base" then
         ply:Horde_SetHealthRegenPercentage(0.01)
+    end
+    if perk == "medic_base" then
+        hook.Add("PreDrawHalos", "Player health outlines", function()
+            local HurtPlayers = {}
+            for _, user in ipairs(player.GetAll()) do
+                if user:Health() > 0 and user:Health() < user:GetMaxHealth() then
+                    table.insert(HurtPlayers, 1, user)
+                    halo.Add(HurtPlayers, getHealthColor(user:Health()), 2, 2, 1, true, false)
+                end
+            end
+        end)
     end
 end
 
 PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
     if SERVER and perk == "medic_base" then
         ply:Horde_SetHealthRegenPercentage(0)
+        hook.Remove("PreDrawHalos", "Player health outlines")
     end
 end
 


### PR DESCRIPTION
Halo applies when > 0 hp and < max hp
Predrawhalo hook gets removed when changing class so the halos dont persist if you change class