### PR TITLE
Removing charge penalties

### DIFF
--- a/gamemodes/horde/gamemode/status/sh_mind.lua
+++ b/gamemodes/horde/gamemode/status/sh_mind.lua
@@ -52,9 +52,9 @@ function plymeta:Horde_GetMindRegenTick()
 end
 hook.Add("Horde_PlayerMoveBonus", "Horde_ChargingPenalty", function (ply, bonus_walk, bonus_run)
     if ply.Horde_SpellCharging then
-        bonus_run.more = bonus_run.more * 0.64
-        bonus_walk.more = bonus_walk.more * 0.8
-        ply:SetJumpPower(100)
+        --bonus_run.more = bonus_run.more * 0.64
+        --bonus_walk.more = bonus_walk.more * 0.8
+        --ply:SetJumpPower(100)
     end
 end)
 


### PR DESCRIPTION
Getting slowed down drastically while charging makes the game feel really clunky and isn't consistent with how demolition can sprint while shooting explosives