### PR TITLE
Carcass buffs

### DIFF
--- a/gamemodes/horde/entities/entities/horde_aas_perfume/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_aas_perfume/shared.lua
@@ -128,6 +128,14 @@ function ENT:Think()
                 ent:Horde_AddHypertrophyStack(true)
             end
         end
+		
+        local dmg = DamageInfo()
+        dmg:SetAttacker(self.Owner)
+        dmg:SetInflictor(self)
+        dmg:SetDamageType(DMG_NERVEGAS)
+        dmg:SetDamage(50)
+        dmg:SetDamageCustom(HORDE.DMG_PLAYER_FRIENDLY)
+        util.BlastDamageInfo(dmg, self:GetPos(), 200)
 
         if self:WaterLevel() > 2 then self:Remove() return end
 

--- a/gamemodes/horde/entities/entities/projectile_horde_aas_perfume/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_aas_perfume/shared.lua
@@ -12,8 +12,8 @@ AddCSLuaFile()
 ENT.Model = "models/spitball_medium.mdl"
 ENT.Ticks = 0
 ENT.FuseTime = 10
-ENT.CollisionGroup = COLLISION_GROUP_PROJECTILE
-ENT.CollisionGroupType = COLLISION_GROUP_PROJECTILE
+ENT.CollisionGroup = COLLISION_GROUP_PLAYER_MOVEMENT
+ENT.CollisionGroupType = COLLISION_GROUP_PLAYER_MOVEMENT
 ENT.Removing = nil
 
 if SERVER then
@@ -34,7 +34,7 @@ function ENT:Initialize()
 
     timer.Simple(0.1, function()
         if !IsValid(self) then return end
-        self:SetCollisionGroup(COLLISION_GROUP_PROJECTILE)
+        self:SetCollisionGroup(COLLISION_GROUP_PLAYER_MOVEMENT)
     end)
 end
 

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_aas_perfume.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_aas_perfume.lua
@@ -1,13 +1,14 @@
 PERK.PrintName = "Tren Perfume"
 PERK.Description =
-[[Adds {1} maximum Hypertrophy stacks.
-Press R to shoot a spore that provides Hypertrophy to players in an area.
+[[Adds {1} maximum Hypertrophy stacks. Press R to shoot a lingering spore cloud.
+Cloud provides Hypertrophy to players and deals {4} Poison damage in an area.
 Effect lasts for {2} seconds and has a cooldown of {3} seconds.]]
 PERK.Icon = "materials/perks/carcass/aas_perfume.png"
 PERK.Params = {
     [1] = {value = 2},
     [2] = {value = 5},
     [3] = {value = 10},
+    [4] = {value = 50},
 }
 PERK.Hooks = {}
 

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
@@ -7,7 +7,7 @@ Complexity: HIGH
 
 {4} chance to gain Hypertrophy when you hit an enemy ({5} chance on headshot).
 100% chance to gain Hypertrophy when you are hit.
-Hypertrophy reduces Physical damage taken by {6}.
+Hypertrophy reduces damage taken by {6}.
 Hypertrophy provides 2% health regen per second.
 
 Equipped with Carcass Biosystem.
@@ -16,9 +16,9 @@ LMB: Punch
 Hold for a charged punch that deals increased damage in an area.]]
 PERK.Icon = "materials/subclasses/carcass.png"
 PERK.Params = {
-    [1] = {percent = true, base = 0, level = 0.02, max = 0.5, classname = "Carcass"},
-    [2] = {value = 0.01, percent = true},
-    [3] = {value = 0.25, percent = true},
+    [1] = {percent = true, base = 0.25, level = 0.02, max = 0.75, classname = "Carcass"},
+    [2] = {value = 0.02, percent = true},
+    [3] = {value = 0.75, percent = true},
     [4] = {value = 0.5, percent = true},
     [5] = {value = 0.75, percent = true},
     [6] = {value = 0.05, percent = true},
@@ -42,7 +42,7 @@ end
 
 PERK.Hooks.Horde_OnSetMaxHealth = function(ply, bonus)
     if SERVER and ply:Horde_GetPerk("carcass_base") then
-        bonus.increase = bonus.increase + ply:Horde_GetPerkLevelBonus("carcass_base")
+        bonus.increase = bonus.increase + 0.25 + ply:Horde_GetPerkLevelBonus("carcass_base")
     end
 end
 

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
@@ -2,7 +2,7 @@ PERK.PrintName = "Pneumatic Legs"
 PERK.Description =
 [[Adds {1} maximum Hypertrophy stacks.
 Press SPACE in air to descend, dealing area Physical damage based on your speed.
-{2} reduced fall damage taken.]]
+Gain immunity to fall damage.]]
 PERK.Icon = "materials/perks/carcass/pneumatic_legs.png"
 PERK.Params = {
     [1] = {value = 1},
@@ -27,8 +27,8 @@ end
 
 PERK.Hooks.Horde_GetFallDamage = function(ply, speed, bonus)
     if ply:Horde_GetPerk("carcass_pneumatic_legs") then
-        bonus.less = bonus.less * 0.1
-        local dmg = math.max(0, math.ceil(0.2418 * speed - 141.75)) * 2
+        bonus.less = bonus.less * 0
+        local dmg = math.max(0, math.ceil(0.2418 * speed - 141.75)) * 4
         if dmg < 10 then return end
         local dmginfo = DamageInfo()
         dmginfo:SetAttacker(ply)

--- a/gamemodes/horde/gamemode/status/buff/sv_hypertrophy.lua
+++ b/gamemodes/horde/gamemode/status/buff/sv_hypertrophy.lua
@@ -72,8 +72,8 @@ function plymeta:Horde_SetHypertrophyEnabled(enabled)
 end
 
 hook.Add("Horde_OnPlayerDamageTaken", "Horde_HypertrophyStackDamage", function (ply, dmginfo, bonus)
-    if ply:Horde_GetHypertrophyStack() > 0 and HORDE:IsPhysicalDamage(dmginfo) then
-        bonus.less = bonus.less * (1 - ply:Horde_GetHypertrophyStack() * 0.05)
+    if ply:Horde_GetHypertrophyStack() > 0 then
+	   bonus.resistance = bonus.resistance + (ply:Horde_GetHypertrophyStack() * 0.05)
     end
 end)
 


### PR DESCRIPTION
Made Hypertrophy give global resist rather than physical resist, made the resist give a flat bonus rather than multiply

Gave +25 max health as a base perk for Carcass (still gets +2 max health per level, up to 175), fixed base perk incorrectly displaying level bonus as +1 max health per level (should be +2)

Pneumatic Legs now gives total immunity to fall damage, buffed scaling multiplier from 2x to 4x (~150-250 damage if used correctly)

Tren Perfume now does 50 Poison damage every time it pulses, changed projectile collision type to COLLISION_GROUP_PLAYER_MOVEMENT
