### PR TITLE
Carcass fixes / buffs, disabled healing screen flash

### DIFF
--- a/gamemodes/horde/gamemode/perks/carcass/carcass_twin_heart.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_twin_heart.lua
@@ -6,7 +6,7 @@ The heart stores health over time, up to {2} of your maximum health.]]
 PERK.Icon = "materials/perks/carcass/twin_heart.png"
 PERK.Params = {
     [1] = {value = 0.25, percent = true},
-    [2] = {value = 0.3, percent = true},
+    [2] = {value = 1, percent = true},
     --[3] = {value = 30},
 }
 PERK.Hooks = {}
@@ -20,9 +20,9 @@ end
 PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if SERVER and perk == "carcass_twin_heart" then
         ply:Horde_SetPerkCooldown(1)
-        ply.Horde_TwinHeartStack = 0
+        ply.Horde_TwinHeartStack = ply:GetMaxHealth()
         local id = ply:SteamID()
-        timer.Create("Horde_TwinHeartStacking" .. id, 1, 0, function ()
+        timer.Create("Horde_TwinHeartStacking" .. id, 0.1, 0, function ()
             if !ply:IsValid() then
                 timer.Remove("Horde_TwinHeartStacking" .. id)
                 return
@@ -30,9 +30,9 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
 
             if ply.TwinHeartToggleOn == true then return end
 
-            if ply.Horde_TwinHeartStack >= ply:GetMaxHealth() * 0.3 then return end
+            if ply.Horde_TwinHeartStack >= ply:GetMaxHealth() then return end
 
-            ply.Horde_TwinHeartStack = math.min(ply:GetMaxHealth() * 0.3, ply.Horde_TwinHeartStack + 1)
+            ply.Horde_TwinHeartStack = math.min(ply:GetMaxHealth(), ply.Horde_TwinHeartStack + 1)
             net.Start("Horde_SyncStatus")
                 net.WriteUInt(HORDE.Status_Twin_Heart, 8)
                 net.WriteUInt(ply.Horde_TwinHeartStack, 8)

--- a/gamemodes/horde/gamemode/sh_horde.lua
+++ b/gamemodes/horde/gamemode/sh_horde.lua
@@ -62,6 +62,7 @@ CreateConVar("horde_enable_class_models", 1, FCVAR_ARCHIVE, "Enables ammo UI.")
 if CLIENT then
     CreateClientConVar("horde_disable_default_gadget_use_key", 0, FCVAR_ARCHIVE, "Disable default key bind for active gadgets.")
     CreateClientConVar("horde_pickup_weapons", "1", true, true, "Allows the pickup of dropped weapons when walking over them.")
+    CreateClientConVar("horde_heal_flash", "1", true, true, "Allows for a player's screen to flash to notify them when they're being healed.")
 end
 
 if SERVER then

--- a/gamemodes/horde/gamemode/sv_economy.lua
+++ b/gamemodes/horde/gamemode/sv_economy.lua
@@ -421,7 +421,7 @@ hook.Add("PlayerCanPickupWeapon", "Horde_Economy_Pickup", function (ply, wpn)
         wpn.newlyGainedWep = true  
         wpn.lastWeaponHolder = ply  
     end
-    if ply:GetInfo("horde_pickup_weapons") == 0 and wpn.lastWeaponHolder ~= ply then return false end
+    if ply:GetInfoNum("horde_pickup_weapons", 1) == 0 and wpn.lastWeaponHolder ~= ply then return false end
     if HORDE.items[wpn:GetClass()] then
         local item = HORDE.items[wpn:GetClass()]
         if (ply:Horde_GetWeight() - item.weight < 0) then

--- a/gamemodes/horde/gamemode/sv_heal.lua
+++ b/gamemodes/horde/gamemode/sv_heal.lua
@@ -86,7 +86,6 @@ function HORDE:OnPlayerHeal(ply, healinfo, silent)
         healer:Horde_AddHealAmount(healinfo:GetHealAmount())
         return
     end
-    ply:ScreenFade(SCREENFADE.IN, Color(50, 200, 50, 10), 0.3, 0)
     if healer ~= ply then
         healer:Horde_AddMoney(math.min(healinfo:GetHealAmount()*0.75))
         healer:Horde_SyncEconomy()

--- a/gamemodes/horde/gamemode/sv_heal.lua
+++ b/gamemodes/horde/gamemode/sv_heal.lua
@@ -86,6 +86,9 @@ function HORDE:OnPlayerHeal(ply, healinfo, silent)
         healer:Horde_AddHealAmount(healinfo:GetHealAmount())
         return
     end
+    if ply:GetInfoNum("horde_heal_flash", 1) == 1 then
+    ply:ScreenFade(SCREENFADE.IN, Color(50, 200, 50, 10), 0.3, 0)
+    end
     if healer ~= ply then
         healer:Horde_AddMoney(math.min(healinfo:GetHealAmount()*0.75))
         healer:Horde_SyncEconomy()


### PR DESCRIPTION
Fixed Carcass's weapon not making sounds properly for the Grappendix

Buffed Twin Heart max stack capacity to 100% of max health and changed stack regen time to 0.1 seconds, will not drain stacks if health is equal to or above max health, added a sound indicator to enabling / disabling the perk, now sets your stacks to max when setting the perk, now disables itself if you have Decay

Disabled the green screen flash whenever you get healed per a poll