### PR TITLE
Gadget reworks part 1

### DIFF
--- a/gamemodes/horde/gamemode/gadgets/gadget_arctic_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_arctic_plating.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Arctic Plating"
-GADGET.Description = "20% increased Cold damage resistance."
+GADGET.Description = "40% increased Cold damage resistance."
 GADGET.Icon = "items/gadgets/arctic_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
@@ -11,6 +11,6 @@ GADGET.Hooks = {}
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_arctic_plating"  then return end
     if HORDE:IsColdDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.20
+        bonus.resistance = bonus.resistance + 0.40
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_armor_fusion.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_armor_fusion.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Armor Fusion"
-GADGET.Description = [[When toggled, drains your health and recovers armor up to {1} of your maximum armor.]]
+GADGET.Description = [[When toggled, drains your health and recovers armor up to 50% of your maximum armor.]]
 GADGET.Icon = "items/gadgets/armor_fusion.png"
 GADGET.Cooldown = 1
 GADGET.Active = true
@@ -11,28 +11,43 @@ GADGET.Hooks = {}
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     if CLIENT then return end
     if ply:Horde_GetGadget() ~= "gadget_armor_fusion" then return end
-    ply:EmitSound("buttons/combine_button5.wav")
+	
     local id = ply:SteamID()
     if ply.Horde_ArmorFusion then
         ply.Horde_ArmorFusion = nil
+		ply:EmitSound("items/suitchargeno1.wav")
         timer.Remove("Horde_ArmorFusion" .. id)
     else
         ply.Horde_ArmorFusion = true
+		ply:EmitSound("buttons/combine_button5.wav")
         timer.Remove("Horde_ArmorFusion" .. id)
         timer.Create("Horde_ArmorFusion" .. id, 0.2, 0, function ()
-            if !ply:IsValid() then
+            if !ply:IsValid() or !ply:Alive() then
                 timer.Remove("Horde_ArmorFusion" .. id)
                 return
             end
 
-            if (not ply.Horde_ArmorFusion) or (ply:Armor() >= ply:GetMaxArmor() * 0.5) or (ply:Health() <= 1) then
+            if (not ply.Horde_ArmorFusion) then
                 timer.Remove("Horde_ArmorFusion" .. id)
                 ply.Horde_ArmorFusion = nil
                 return
             end
-
-            ply:SetHealth(ply:Health() - 1)
-            ply:SetArmor(ply:Armor() + 1)
+			
+			if ply:Health() > (ply:GetMaxHealth() * 0.5) and ply:Armor() < (ply:GetMaxArmor() * 0.5) then
+			ply:SetHealth(ply:Health() - 1)
+			if ply:Armor() <= (ply:GetMaxArmor() * 0.5) then
+            ply:SetArmor(math.min(ply:GetMaxArmor() * 0.5, ply:Armor() + 1))
+			end
+			end
         end)
     end
 end
+
+GADGET.Hooks.Horde_OnUnsetGadget = function (ply, gadget)
+    if CLIENT then return end
+    if gadget ~= "gadget_armor_fusion" then return end
+    local id = ply:SteamID()
+	ply.Horde_ArmorFusion = nil
+    timer.Remove("Horde_ArmorFusion" .. id)
+end
+

--- a/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
@@ -1,8 +1,8 @@
 GADGET.PrintName = "Berserker Armor"
 GADGET.Description = "25% increased damage.\n25% increased Global damage resistance.\n25% increased movespeed."
 GADGET.Icon = "items/gadgets/berserk_armor.png"
-GADGET.Duration = 8
-GADGET.Cooldown = 30
+GADGET.Duration = 10
+GADGET.Cooldown = 20
 GADGET.Active = true
 GADGET.Params = {
     [1] = {value = 0.25, percent = true},
@@ -18,7 +18,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     sound.Play("horde/gadgets/berserk_in.ogg", ply:GetPos())
     ply.Horde_HasGuts = true
     ply:ScreenFade(SCREENFADE.IN, Color(200, 50, 50, 50), 0.1, 8)
-    timer.Simple(8, function()
+    timer.Simple(10, function()
         if ply:IsValid() then ply.Horde_HasGuts = nil end
     end)
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_blast_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_blast_plating.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Blast Plating"
-GADGET.Description = "20% increased Blast damage resistance."
+GADGET.Description = "40% increased Blast damage resistance."
 GADGET.Icon = "items/gadgets/blast_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
@@ -11,6 +11,6 @@ GADGET.Hooks = {}
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_blast_plating" then return end
     if HORDE:IsBlastDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.20
+        bonus.resistance = bonus.resistance + 0.40
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_detoxifier.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_detoxifier.lua
@@ -1,16 +1,16 @@
 GADGET.PrintName = "Detoxifier"
-GADGET.Description = "20% increased Poison damage resistance."
+GADGET.Description = "40% increased Poison damage resistance."
 GADGET.Icon = "items/gadgets/detoxifier.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Params = {
-    [1] = {value = 0.20, percent = true},
+    [1] = {value = 0.40, percent = true},
 }
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_detoxifier"  then return end
     if HORDE:IsPoisonDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.20
+        bonus.resistance = bonus.resistance + 0.40
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_energy_shield.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_energy_shield.lua
@@ -1,7 +1,7 @@
 GADGET.PrintName = "Energy Shield"
-GADGET.Description = "Gain 15 armor, up to maximum armor regen limit."
+GADGET.Description = "Gain 50 barrier on use."
 GADGET.Icon = "items/gadgets/energy_shield.png"
-GADGET.Cooldown = 10
+GADGET.Cooldown = 5
 GADGET.Active = true
 GADGET.Params = {
 }
@@ -9,11 +9,7 @@ GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     if CLIENT then return end
-    if ply:Horde_GetGadget() ~= "gadget_energy_shield" or (not ply.Horde_ArmorRegenMax) then return end
+    if ply:Horde_GetGadget() ~= "gadget_energy_shield" then return end
     ply:EmitSound("horde/gadgets/energy_shield_on.ogg")
-    local amax = ply.Horde_ArmorRegenMax * ply:GetMaxArmor()
-    if ply:Armor() > amax then
-        return
-    end
-    ply:SetArmor(math.min(amax, ply:Armor() + 15))
+    ply:Horde_AddBarrierStack(50)
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_hardening_injection.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_hardening_injection.lua
@@ -2,7 +2,7 @@ GADGET.PrintName = "Hardening Injection"
 GADGET.Description = "50% reduced movement speed.\n25% increased Global damage resistance.\n25% increased Physical damage resistance."
 GADGET.Icon = "items/gadgets/hardening_injection.png"
 GADGET.Duration = 5
-GADGET.Cooldown = 25
+GADGET.Cooldown = 15
 GADGET.Active = true
 GADGET.Params = {
 }

--- a/gamemodes/horde/gamemode/gadgets/gadget_heat_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_heat_plating.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Heat Plating"
-GADGET.Description = "20% increased Fire damage resistance."
+GADGET.Description = "40% increased Fire damage resistance."
 GADGET.Icon = "items/gadgets/heat_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
@@ -11,6 +11,6 @@ GADGET.Hooks = {}
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_heat_plating"  then return end
     if HORDE:IsFireDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.20
+        bonus.resistance = bonus.resistance + 0.40
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_neuro_amplifier.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_neuro_amplifier.lua
@@ -1,6 +1,6 @@
 GADGET.PrintName = "Neuro Amplifier"
 GADGET.Description =
-[[Adrenaline also increases 6% evasion.]]
+[[Gain 50% evasion.]]
 GADGET.Icon = "items/gadgets/neuro_amplifier.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
@@ -10,7 +10,7 @@ GADGET.Params = {
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmg, bonus)
-    if SERVER and ply:Horde_GetAdrenalineStack() > 0 and ply:Horde_GetGadget() == "gadget_neuro_amplifier" then
-        bonus.evasion = bonus.evasion + ply:Horde_GetAdrenalineStack() * 0.06
+    if ply:Horde_GetGadget() == "gadget_neuro_amplifier" then
+        bonus.evasion = bonus.evasion + 0.5
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_omnislash.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_omnislash.lua
@@ -46,7 +46,14 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     })
 
     local ent = tr.Entity
+	
+    if not ent:IsValid() then
+	ply:EmitSound("items/suitchargeno1.wav")
+	ply:Horde_SetGadgetCooldown(1)
+	return end
+	
     if HORDE:IsEnemy(ent) then
+        ply:Horde_SetGadgetCooldown(15)
         local ply_pos = ply:GetPos()
         local ply_angles = ply:GetAngles()
         ply:Spectate(OBS_MODE_CHASE)

--- a/gamemodes/horde/gamemode/gadgets/gadget_resistance_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_resistance_booster.lua
@@ -1,14 +1,19 @@
 GADGET.PrintName = "Resistance Booster"
-GADGET.Description = "20% increased Global damage resistance."
+GADGET.Description = "25% increased Global damage resistance. \n50% less debuff buildup."
 GADGET.Icon = "items/gadgets/resistance_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Params = {
-    [1] = {value = 0.2, percent = true},
+    [1] = {value = 0.25, percent = true},
 }
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_resistance_booster" then return end
-    bonus.resistance = bonus.resistance + 0.2
+    bonus.resistance = bonus.resistance + 0.25
+end
+
+GADGET.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus, inflictor)
+    if ply:Horde_GetGadget() ~= "gadget_resistance_booster" then return end
+        bonus.less = bonus.less * 0.5
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_shock_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_shock_plating.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Shock Plating"
-GADGET.Description = "20% increased Lightning damage resistance."
+GADGET.Description = "40% increased Lightning damage resistance."
 GADGET.Icon = "items/gadgets/shock_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
@@ -11,6 +11,6 @@ GADGET.Hooks = {}
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_shock_plating"  then return end
     if HORDE:IsLightningDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.20
+        bonus.resistance = bonus.resistance + 0.40
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
@@ -1,7 +1,7 @@
 GADGET.PrintName = "ULPA Filter"
 GADGET.Description =
-[[{1} increased maximum armor.
-{2} reduced buildups from all sources while you have armor.]]
+[[25% increased maximum armor.
+50% less debuff buildup.]]
 GADGET.Icon = "items/gadgets/ulpa_filter.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
@@ -14,9 +14,7 @@ GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus, inflictor)
     if ply:Horde_GetGadget() ~= "gadget_ulpa_filter" then return end
-    if ply:Armor() > 0 then
-        bonus.less = bonus.less * 0.75
-    end
+        bonus.less = bonus.less * 0.5
 end
 
 GADGET.Hooks.Horde_OnSetGadget = function (ply, gadget)
@@ -33,6 +31,6 @@ end
 
 GADGET.Hooks.Horde_OnSetMaxArmor = function (ply, bonus)
     if SERVER and ply:Horde_GetGadget() == "gadget_ulpa_filter" then
-        bonus.increase = bonus.increase + 0.2
+        bonus.increase = bonus.increase + 0.25
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_ultimate_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ultimate_booster.lua
@@ -1,8 +1,8 @@
 GADGET.PrintName = "Ultimate Booster"
-GADGET.Description = [[{1} increased movement speed.
-{1} increased maximum health.
-{1} increased Global damage.
-{1} increased Global damage resistance.]]
+GADGET.Description = [[15% increased movement speed.
+25% increased maximum health. 15% increased Global damage.
+15% increased Global damage resistance.
+25% less debuff buildup.]]
 GADGET.Icon = "items/gadgets/ultimate_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
@@ -20,7 +20,7 @@ end
 GADGET.Hooks.Horde_OnSetMaxHealth = function (ply, bonus)
     if CLIENT then return end
     if ply:Horde_GetGadget() ~= "gadget_ultimate_booster" then return end
-    bonus.increase = bonus.increase + 0.15
+    bonus.increase = bonus.increase + 0.25
 end
 
 GADGET.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
@@ -31,4 +31,9 @@ end
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_ultimate_booster" then return end
     bonus.resistance = bonus.resistance + 0.15
+end
+
+GADGET.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus, inflictor)
+    if ply:Horde_GetGadget() ~= "gadget_ultimate_booster" then return end
+        bonus.less = bonus.less * 0.75
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_vitality_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_vitality_booster.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Vitality Booster"
-GADGET.Description = "+25 to maximum health."
+GADGET.Description = "+50 to maximum health."
 GADGET.Icon = "items/gadgets/vitality_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
@@ -11,5 +11,5 @@ GADGET.Hooks = {}
 GADGET.Hooks.Horde_OnSetMaxHealth = function (ply, bonus)
     if CLIENT then return end
     if ply:Horde_GetGadget() ~= "gadget_vitality_booster" then return end
-    bonus.add = bonus.add + 25
+    bonus.add = bonus.add + 50
 end

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -171,7 +171,7 @@ function HORDE:GetDefaultGadgets()
     HORDE:CreateGadgetItem("gadget_energy_shield", 2000, 1, {Heavy=true}, {Heavy=5})
     HORDE:CreateGadgetItem("gadget_hardening_injection", 2500, 1, {Heavy=true}, {Heavy=10})
     HORDE:CreateGadgetItem("gadget_exoskeleton", 2750, 3, {Heavy=true}, {Heavy=15})
-    HORDE:CreateGadgetItem("gadget_ulpa_filter", 3000, 2, {Heavy=true}, {Heavy=20})
+    HORDE:CreateGadgetItem("gadget_ulpa_filter", 3000, 1, {Heavy=true}, {Heavy=20})
     HORDE:CreateGadgetItem("gadget_armor_fusion",    3000, 2, {Heavy=true}, {Heavy=25})
 
     HORDE:CreateGadgetItem("gadget_proximity_defense", 2000, 1, {Demolition=true}, {Demolition=5})


### PR DESCRIPTION
Buffed Resistance Booster to 25% resist, now gives 50% debuff buildup reduction

Buffed Ultimate Booster to give +25 max health and 25% less debuff buildup reduction

Buffed Vitality Booster to +50 max health

Reduced Hardening Injection cooldown to 15 seconds

Buffed ULPA Filter to 50% less debuff buildup and no longer requires armor to be active for the effect, increased maximum armor boost to 25%, reduced weight to 1

Reworked Energy Shield to give 50 barrier on use instead of giving armor up to your armor regen limit, reduced cooldown to 5 seconds

Reworked Armor Fusion to function as a toggle

Buffed Berserker Armor to 10 second duration, 20 second cooldown

Added QOL cooldown change to Omnislash if no target is found

Buffed elemental resist gadgets to 40%

Reworked Neuro Amplifier to give 50% evasion at all times