### PR TITLE
Ghost / misc weapon changes / fixes

### DIFF
--- a/gamemodes/horde/entities/entities/projectile_horde_antlion_bile/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_antlion_bile/shared.lua
@@ -11,8 +11,8 @@ AddCSLuaFile()
 
 ENT.Model = "models/spitball_medium.mdl"
 ENT.Ticks = 0
-ENT.CollisionGroup = COLLISION_GROUP_PROJECTILE
-ENT.CollisionGroupType = COLLISION_GROUP_PROJECTILE
+ENT.CollisionGroup = COLLISION_GROUP_PLAYER_MOVEMENT
+ENT.CollisionGroupType = COLLISION_GROUP_PLAYER_MOVEMENT
 ENT.Removing = nil
 ENT.StartPos = nil
 ENT.PlaySoundTimer = 0
@@ -41,7 +41,7 @@ function ENT:Initialize()
     self.PlaySoundTimer = CurTime()
     self.StartPos = self:GetPos()
 
-    self:SetCollisionGroup(COLLISION_GROUP_PROJECTILE)
+    self:SetCollisionGroup(COLLISION_GROUP_PLAYER_MOVEMENT)
     self.ExplodeTimer = CurTime() + 2
     self.StartTime = CurTime()
     end

--- a/gamemodes/horde/entities/entities/projectile_horde_apollo_projectile/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_apollo_projectile/shared.lua
@@ -9,8 +9,8 @@ ENT.Spawnable 			= false
 AddCSLuaFile()
 
 ENT.Model = "models/dav0r/hoverball.mdl"
-ENT.CollisionGroup = COLLISION_GROUP_PASSABLE_DOOR
-ENT.CollisionGroupType = COLLISION_GROUP_PASSABLE_DOOR
+ENT.CollisionGroup = COLLISION_GROUP_PLAYER_MOVEMENT
+ENT.CollisionGroupType = COLLISION_GROUP_PLAYER_MOVEMENT
 ENT.Removing = nil
 ENT.StartPos = nil
 ENT.PlaySoundTimer = 0
@@ -101,14 +101,14 @@ function ENT:PhysicsCollide(data, phys)
 		dmg:SetDamageType(DMG_BURN)
 		dmg:SetAttacker(self.Owner)
 		dmg:SetInflictor(self)
-		dmg:SetDamage(50)
+		dmg:SetDamage(60)
 		dmg:SetDamagePosition(self:GetPos())
 
 
 		self:FireBullets({
 			Attacker = owner,
 			Inflitor = self,
-			Damage = 50,
+			Damage = 60,
 			Tracer = 0,
 			Distance = 4000,
 			Dir = data.HitPos - self:GetPos(),

--- a/gamemodes/horde/entities/entities/projectile_horde_ar2_projectile/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_ar2_projectile/shared.lua
@@ -9,8 +9,8 @@ ENT.Spawnable 			= false
 AddCSLuaFile()
 
 ENT.Model = "models/effects/combineball.mdl"
-ENT.CollisionGroup = COLLISION_GROUP_PASSABLE_DOOR
-ENT.CollisionGroupType = COLLISION_GROUP_PASSABLE_DOOR
+ENT.CollisionGroup = COLLISION_GROUP_PLAYER_MOVEMENT
+ENT.CollisionGroupType = COLLISION_GROUP_PLAYER_MOVEMENT
 ENT.Removing = nil
 ENT.StartPos = nil
 ENT.PlaySoundTimer = 0

--- a/gamemodes/horde/entities/entities/projectile_horde_flaregun_flare/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_flaregun_flare/shared.lua
@@ -9,8 +9,8 @@ ENT.Spawnable 			= false
 AddCSLuaFile()
 
 ENT.Model = "models/crossbow_bolt.mdl"
-ENT.CollisionGroup = COLLISION_GROUP_PROJECTILE
-ENT.CollisionGroupType = COLLISION_GROUP_PROJECTILE
+ENT.CollisionGroup = COLLISION_GROUP_PLAYER_MOVEMENT
+ENT.CollisionGroupType = COLLISION_GROUP_PLAYER_MOVEMENT
 ENT.Removing = nil
 
 function ENT:Draw()
@@ -46,7 +46,7 @@ function ENT:Initialize()
 
         timer.Simple(0, function()
             if !IsValid(self) then return end
-            self:SetCollisionGroup(COLLISION_GROUP_PROJECTILE)
+            self:SetCollisionGroup(COLLISION_GROUP_PLAYER_MOVEMENT)
         end)
 
         timer.Simple(2,function()

--- a/gamemodes/horde/entities/weapons/arccw_horde_357.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_357.lua
@@ -28,8 +28,8 @@ SWEP.MirrorVMWM = false
 SWEP.WorldModel = "models/weapons/w_357.mdl"
 SWEP.ViewModelFOV = 65
 
-SWEP.Damage = 25
-SWEP.DamageMin = 20
+SWEP.Damage = 60
+SWEP.DamageMin = 50
 SWEP.RangeMin = 500 * 0.025  -- GAME UNITS * 0.025 = METRES
 SWEP.Range = 1250 * 0.025  -- GAME UNITS * 0.025 = METRES
 SWEP.Penetration = 4

--- a/gamemodes/horde/entities/weapons/arccw_horde_apollo.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_apollo.lua
@@ -26,7 +26,7 @@ SWEP.ViewModel = "models/horde/weapons/c_apollo.mdl"
 SWEP.WorldModel = "models/horde/weapons/c_apollo.mdl"
 SWEP.ViewModelFOV = 65
 
-SWEP.Damage = 55
+SWEP.Damage = 60
 SWEP.DamageMin = 42 -- damage done at maximum range
 SWEP.Range = 50 -- in METRES
 SWEP.Penetration = 10
@@ -45,8 +45,9 @@ SWEP.TracerCol = Color(255, 25, 25)
 SWEP.TracerWidth = 3
 
 SWEP.Recoil = 0.2
-SWEP.RecoilSide = 0.75
-SWEP.RecoilRise = 1
+SWEP.RecoilSide = 0.2
+SWEP.RecoilRise = 0.2
+SWEP.RecoilPunch = 0
 
 SWEP.Delay = 60 / 600 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
@@ -65,9 +66,9 @@ SWEP.Firemodes = {
 SWEP.NPCWeaponType = "weapon_ar2"
 SWEP.NPCWeight = 100
 
-SWEP.AccuracyMOA = 12 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 200 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 75
+SWEP.AccuracyMOA = 100 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
+SWEP.HipDispersion = 300 -- inaccuracy added by hip firing.
+SWEP.MoveDispersion = 0
 
 SWEP.Primary.Ammo = "ar2" -- what ammo type the gun uses
 SWEP.MagID = "type2" -- the magazine pool this gun draws from

--- a/gamemodes/horde/entities/weapons/arccw_horde_ar15.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ar15.lua
@@ -46,7 +46,7 @@ SWEP.RecoilSide = 0.260
 SWEP.RecoilRise = 0.1
 SWEP.RecoilPunch = 2.5
 
-SWEP.Delay = 0.15 -- 60 / RPM.
+SWEP.Delay = 0.1 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
     {

--- a/gamemodes/horde/entities/weapons/arccw_horde_ar2.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ar2.lua
@@ -44,9 +44,10 @@ SWEP.TracerNum = 1 -- tracer every X
 SWEP.TracerCol = Color(255, 25, 25)
 SWEP.TracerWidth = 3
 
-SWEP.Recoil = 0.5
-SWEP.RecoilSide = 0.75
-SWEP.RecoilRise = 1
+SWEP.Recoil = 0.2
+SWEP.RecoilSide = 0.2
+SWEP.RecoilRise = 0.2
+SWEP.RecoilPunch = 0
 
 SWEP.Delay = 60 / 600 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
@@ -65,8 +66,8 @@ SWEP.NPCWeaponType = "weapon_ar2"
 SWEP.NPCWeight = 100
 
 SWEP.AccuracyMOA = 12 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 550 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 300
+SWEP.HipDispersion = 350 -- inaccuracy added by hip firing.
+SWEP.MoveDispersion = 200
 
 SWEP.Primary.Ammo = "ar2" -- what ammo type the gun uses
 SWEP.MagID = "type2" -- the magazine pool this gun draws from

--- a/gamemodes/horde/entities/weapons/arccw_horde_awp.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_awp.lua
@@ -40,10 +40,9 @@ SWEP.Primary.ClipSize = 10 -- DefaultClip is automatically set.
 
 SWEP.PhysBulletMuzzleVelocity = 1400
 
-SWEP.Recoil = 3.300
-SWEP.RecoilSide = 0.550
-SWEP.RecoilRise = 0.1
-SWEP.RecoilPunch = 2.5
+SWEP.VisualRecoilMult = 0
+SWEP.Recoil = 0.5
+SWEP.RecoilSide = 0
 
 SWEP.ManualAction = true
 SWEP.NoLastCycle = true -- do not cycle on last shot
@@ -443,9 +442,3 @@ sound.Add({
     sound = "arccw_go/awp/awp_boltback.wav"
 })
 
-function SWEP:Hook_OnDeploy()
-    timer.Simple(0, function ()
-        if !IsValid(self) then return end
-        self:Attach(1, "go_optic_awp")
-    end)
-end

--- a/gamemodes/horde/entities/weapons/arccw_horde_fal.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_fal.lua
@@ -7,7 +7,6 @@ SWEP.Base = "arccw_mw2_abase"
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
-SWEP.CamAttachment = 3
 
 SWEP.PrintName = "FN FAL (Horde)"
 SWEP.Trivia_Class = "Assault Rifle"
@@ -27,8 +26,8 @@ SWEP.WorldModelOffset = {
 }
 SWEP.ViewModelFOV = 65
 
-SWEP.Damage = 85
-SWEP.DamageMin = 80
+SWEP.Damage = 65
+SWEP.DamageMin = 55
 SWEP.RangeMin = 1000 * 0.025  -- GAME UNITS * 0.025 = METRES
 SWEP.Range = 1500 * 0.025  -- GAME UNITS * 0.025 = METRES
 SWEP.Penetration = 7
@@ -46,9 +45,12 @@ SWEP.Recoil = 0.7
 SWEP.RecoilSide = 0.7
 SWEP.RecoilRise = 0.2
 
-SWEP.Delay = 60 / 600 -- 60 / RPM.
+SWEP.Delay = 0.15 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
+    {
+        Mode = 2,
+    },
     {
         Mode = 1,
     },
@@ -149,7 +151,6 @@ SWEP.AttachmentElements = {
 
 SWEP.ExtraSightDist = 5
 
-SWEP.RejectAttachments = {["go_homemade_auto"] = true, ["go_perk_burst"] = true}
 SWEP.Attachments = {
     {
         PrintName = "Optic",

--- a/gamemodes/horde/entities/weapons/arccw_horde_g3.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_g3.lua
@@ -46,7 +46,7 @@ SWEP.RecoilSide = 0.550
 SWEP.RecoilRise = 0.1
 SWEP.RecoilPunch = 0.2
 
-SWEP.Delay = 60 / 550 -- 60 / RPM.
+SWEP.Delay = 0.23 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
     {
@@ -283,7 +283,6 @@ SWEP.WorldModelOffset = {
 
 SWEP.MirrorVMWM = true
 
-SWEP.RejectAttachments = {["go_homemade_auto"] = true, ["go_perk_burst"] = true}
 SWEP.Attachments = {
     {
         PrintName = "Optic",

--- a/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
@@ -225,11 +225,11 @@ SWEP.Attachments = {
     },
     {
         PrintName = "Ammo Type",
-        Slot = "ammo_bullet"
+        Slot = "go_ammo"
     },
     {
         PrintName = "Perk",
-        Slot = {"go_perk"}
+        Slot = "go_perk"
     },
     {
         PrintName = "Camouflage",

--- a/gamemodes/horde/entities/weapons/arccw_horde_m1911.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m1911.lua
@@ -1,0 +1,400 @@
+if not ArcCWInstalled then return end
+if CLIENT then
+    SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_mw2_m1911")
+    killicon.Add("arccw_horde_m1911", "arccw/weaponicons/arccw_mw2_m1911", Color(0, 0, 0, 255))
+end
+
+SWEP.Base = "arccw_mw2_abase"
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - MW2"
+SWEP.AdminOnly = false
+
+SWEP.PrintName = "M1911 .45"
+SWEP.Trivia_Class = "Handgun"
+SWEP.Trivia_Desc = "Semi-automatic (single fire)"
+
+SWEP.Slot = 1
+
+SWEP.UseHands = true
+
+SWEP.ViewModel = "models/weapons/arccw/fesiugmw2/c_colt45.mdl"
+SWEP.MirrorVMWM = true
+SWEP.WorldModelOffset = {
+    pos = Vector(-9, 3, -3.5),
+    ang = Angle(-7, 0, 180),
+    scale = 1.25
+}
+SWEP.WorldModel = "models/weapons/w_pist_p228.mdl"
+SWEP.ViewModelFOV = 65
+
+SWEP.Damage = 65
+SWEP.DamageMin = 50
+SWEP.Range = 350 * 0.025  -- GAME UNITS * 0.025 = METRES
+SWEP.Penetration = 3
+SWEP.DamageType = DMG_BULLET
+SWEP.ShootEntity = nil -- entity to fire, if any
+
+
+SWEP.ChamberSize = 1
+SWEP.Primary.ClipSize = 8 -- DefaultClip is automatically set.
+SWEP.ExtendedClipSize = 12
+SWEP.ReducedClipSize = 6
+
+SWEP.VisualRecoilMult = 0
+SWEP.Recoil = 0.5
+SWEP.RecoilSide = 0.5
+SWEP.RecoilRise = 0.5
+
+SWEP.Delay = 0.079 -- 60 / RPM.
+SWEP.Num = 1 -- number of shots per trigger pull.
+SWEP.Firemodes = {
+    {
+        Mode = 1,
+    },
+    {
+        Mode = 0
+    }
+}
+
+SWEP.NPCWeaponType = {"weapon_pistol"}
+SWEP.NPCWeight = 100
+
+SWEP.AccuracyMOA = 15 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
+SWEP.HipDispersion = 200 -- inaccuracy added by hip firing.
+SWEP.MoveDispersion = 180
+
+SWEP.Primary.Ammo = "pistol" -- what ammo type the gun uses
+
+SWEP.ShootVol = 120 -- volume of shoot sound
+SWEP.ShootPitch = 90 -- pitch of shoot sound
+
+SWEP.ShootSound =			"weapons/fesiugmw2/fire/usp45.wav"
+--SWEP.DistantShootSound =	"weapons/fesiugmw2/fire_distant/usp45.wav"
+SWEP.ShootSoundSilenced =	"weapons/fesiugmw2/fire/usp45_sil.wav"
+
+SWEP.MuzzleEffect = "muzzleflash_4"
+SWEP.ShellModel = "models/shells/shell_9mm.mdl"
+SWEP.ShellScale = 1
+SWEP.ShellRotateAngle = Angle(0, 90, 0)
+
+SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
+SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
+
+SWEP.SpeedMult = 1
+SWEP.SightedSpeedMult = 0.8
+SWEP.SightTime = 0.125
+
+
+SWEP.BulletBones = { -- the bone that represents bullets in gun/mag
+    -- [0] = "bulletchamber",
+    -- [1] = "bullet1"
+}
+
+SWEP.IronSightStruct = {
+    Pos = Vector(-2.025, 2, 1.55),
+    Ang = Angle(-1.2, -0.1, 0),
+    ViewModelFOV = 65,
+    Magnification = 1,
+}
+
+SWEP.HoldtypeHolstered = "normal"
+SWEP.HoldtypeActive = "revolver"
+SWEP.HoldtypeSights = "revolver"
+
+SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2
+
+SWEP.ActivePos = Vector(0, 0, 1)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+SWEP.CustomizePos = Vector(3, 0, -1)
+SWEP.CustomizeAng = Angle(10, 19, 0)
+
+SWEP.CrouchPos = Vector(-2.764, -0.927, -0.202)
+SWEP.CrouchAng = Angle(1.12, -1, -21.444)
+
+SWEP.HolsterPos = Vector(1, 0, 1)
+SWEP.HolsterAng = Angle(-10, 12, 0)
+
+SWEP.SprintPos = Vector(0, 0, 1)
+SWEP.SprintAng = Angle(0, 0, 0)
+
+SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
+SWEP.BarrelOffsetHip = Vector(2, 0, -2)
+
+SWEP.BarrelLength = 18
+
+SWEP.ExtraSightDist = 5
+
+-----[ Tactical knife sheet ]------
+	SWEP.CanBash				= true -- Tac knife will save us
+	--SWEP.MeleeDamage			= 100
+	--SWEP.MeleeRange				= 16
+	--SWEP.MeleeDamageType		= DMG_CLUB
+	--SWEP.MeleeTime				= 0.8
+	SWEP.MeleeGesture			= ACT_HL2MP_GESTURE_RANGE_ATTACK_KNIFE
+	--SWEP.MeleeAttackTime		= 0.079
+	SWEP.MeleeMissSound			= ""
+	SWEP.MeleeHitSound			= "MW2Common.Melee.HitWorld"
+	SWEP.MeleeHitNPCSound		= "MW2Common.Melee.HitFleshy_Slice"
+
+SWEP.AttachmentElements = {
+    ["altirons"] = {
+        Override_IronSightStruct = {
+            Pos = Vector(-1.71, -2.346, 0),
+            Ang = Angle(0.6, 0, 0),
+            ViewModelFOV = 65,
+            Magnification = 1,
+        },
+        VMBodygroups = {{ind = 1, bg = 1}}, -- m1911 is an old fart and doesn't have the knife bone all the way back so we hide it in qc and show it here instead
+        WMBodygroups = {},
+    },
+}
+
+SWEP.Attachments = {
+    {
+        PrintName = "Muzzle",
+        DefaultAttName = "Standard Muzzle",
+        Slot = "muzzle",
+        Bone = "tag_weapon",
+        Offset = {
+            vpos = Vector(4.5, 0, 0.9),
+            vang = Angle(0, 0, 0),
+            wpos = Vector(26.648, 0.782, -8.042),
+            wang = Angle(-9.79, 0, 180)
+        },
+		VMScale = Vector(1, 0.6, 0.6),
+    },
+    {
+        PrintName = "Tactical",
+        Slot = "tac",
+        Bone = "tag_weapon",
+        Offset = {
+            vpos = Vector(2.7, 0, 0),
+            vang = Angle(0, 0, 0),
+        },
+    },
+    {
+        PrintName = "Fire Group",
+        Slot = "fcg",
+        DefaultAttName = "Standard FCG"
+    },
+    {
+        PrintName = "Ammo Type",
+        Slot = "go_ammo"
+    },
+    {
+        PrintName = "Perk",
+        Slot = "go_perk"
+    },
+}
+
+
+SWEP.Hook_SelectReloadAnimation = function(wep, anim)
+    if wep.Attachments[2].Installed == "mw2_tacticalknife" then
+        return anim .. "_knife"
+    end
+end
+SWEP.Hook_TranslateAnimation = function(wep, anim)
+    if wep.Attachments[2].Installed == "mw2_tacticalknife" then
+        return anim .. "_knife"
+    end
+end
+
+SWEP.Animations = {
+    ["idle"] = {
+        Source = "idle",
+        Time = 2/30
+    },
+    ["idle_empty"] = {
+        Source = "idle_empty",
+        Time = 2/30
+    },
+    ["enter_sprint"] = {
+        Source = "sprint_in",
+        Time = 11/30
+    },
+    ["idle_sprint"] = {
+        Source = "sprint_loop",
+        Time = 31/40
+    },
+    ["exit_sprint"] = {
+        Source = "sprint_out",
+        Time = 11/30
+    },
+    ["draw"] = {
+        Source = "pullout",
+        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
+        Time = 20/24 /4,
+        LHIK = true,
+        LHIKIn = 0,
+        LHIKOut = 0.35,
+    },
+    ["holster"] = {
+        Source = "putaway",
+        Time = 32/30 /4,
+        LHIK = true,
+        LHIKIn = 0,
+        LHIKOut = 0.35,
+    },
+    ["fire"] = {
+        Source = "fire",
+        Time = 20/30,
+        ShellEjectAt = 0,
+    },
+    ["fire_iron"] = {
+        Source = "fire_ads",
+        Time = 13/30,
+        ShellEjectAt = 0,
+    },
+    ["fire_empty"] = {
+        Source = "lastfire",
+        Time = 21/30,
+        ShellEjectAt = 0,
+    },
+    ["fire_iron_empty"] = {
+        Source = "lastfire",
+        Time = 21/30,
+        ShellEjectAt = 0,
+    },
+    ["reload"] = {
+        Source = "reload",
+        Time = 51/30,
+        TPAnim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
+        SoundTable = {
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_lift_v1.wav", 		t = 0/24},
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipout_v1.wav", 	t = 9/24},
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipin_v1.wav", 	t = 22/24},
+					},
+        Checkpoints = {24, 67},
+        FrameRate = 30,
+        LHIK = true,
+        LHIKIn = 0.5,
+        LHIKOut = 0.4,
+    },
+    ["reload_empty"] = {
+        Source = "reload_empty",
+        Time = 60/30,
+        TPAnim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
+        SoundTable = {
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_lift_v1.wav", 		t = 0/30},
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipout_v1.wav", 	t = 9/24},
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipin_v1.wav", 	t = 22/24},
+						{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_chamber_v1.wav", 	t = 36/24},
+					},
+        Checkpoints = {24, 67, 91},
+        FrameRate = 37,
+        LHIK = true,
+        LHIKIn = 0.5,
+        LHIKOut = 0.6,
+    },
+---------------------------------------------------------
+--------- LE TACTICAL KNIFE XDXDXDXD---------------------
+---------------------------------------------------------
+		["idle_knife"] = {
+			Source = "idle_knife",
+			Time = 300/30
+		},
+		["idle_empty_knife"] = {
+			Source = "idle_knife",
+			Time = 300/30
+		},
+		["enter_sprint_knife"] = {
+			Source = "sprint_in_knife",
+			Time = 10/30
+		},
+		["idle_sprint_knife"] = {
+			Source = "sprint_loop_knife",
+			Time = 30/40
+		},
+		["exit_sprint_knife"] = {
+			Source = "sprint_out_knife",
+			Time = 10/30
+		},
+		["fire_knife"] = {
+			Source = "fire_knife",
+			Time = 8/30,
+			ShellEjectAt = 0,
+		},
+		["fire_iron_knife"] = {
+			Source = "fire_ads_knife",
+			Time = 8/30,
+			ShellEjectAt = 0,
+		},
+		["fire_empty_knife"] = {
+			Source = "lastfire_knife",
+			Time = 8/30,
+			ShellEjectAt = 0,
+		},
+		["fire_iron_empty_knife"] = {
+			Source = "lastfire_knife",
+			Time = 8/30,
+			ShellEjectAt = 0,
+		},
+		["draw_knife"] = {
+			Source = "pullout_knife",
+			SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
+			Time = 29/30 /4,
+			LHIK = true,
+			LHIKIn = 0,
+			LHIKOut = 0.35,
+		},
+		["holster_knife"] = {
+			Source = "putaway_knife",
+			Time = 31/30 /4,
+			LHIK = true,
+			LHIKIn = 0,
+			LHIKOut = 0.35,
+		},
+		["draw_empty_knife"] = {
+			Source = "pullout_knife",
+			SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
+			Time = 29/30 /4,
+			LHIK = true,
+			LHIKIn = 0,
+			LHIKOut = 0.35,
+		},
+		["holster_empty_knife"] = {
+			Source = "putaway_knife",
+			Time = 31/30 /4,
+			LHIK = true,
+			LHIKIn = 0,
+			LHIKOut = 0.35,
+		},
+		["reload_knife"] = {
+			Source = "reload_knife",
+			Time = 51/24,
+			TPAnim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
+			SoundTable = {
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_lift_v1.wav", 	t = 0},
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipout_v1.wav", 	t = 7/24},
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipin_v1.wav", 	t = 25/24},
+						},
+			Checkpoints = {24, 97},
+			FrameRate = 30,
+			LHIK = true,
+			LHIKIn = 0.5,
+			LHIKOut = 0.4,
+		},
+		["reload_empty_knife"] = {
+			Source = "reload_empty_knife",
+			Time = 46/24,
+			TPAnim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
+			SoundTable = {
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_lift_v1.wav", 	t = 0},
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipout_v1.wav", 	t = 6/24},
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_clipin_v1.wav", 	t = 25/24},
+							{s = "weapons/fesiugmw2/foley/wpfoly_colt1911_reload_chamber_v1.wav", 	t = 37/24},
+						},
+			Checkpoints = {24, 97, 131},
+			FrameRate = 37,
+			LHIK = true,
+			LHIKIn = 0.5,
+			LHIKOut = 0.6,
+		},
+		["bash_knife"] = {
+			Source = "melee_knife",
+			SoundTable = {{s = "MW2Common.Melee.Swing", 		t = 0}},
+			Time = 97/120 / 1.6, -- damn you universal
+			LHIK = true,
+		},
+}

--- a/gamemodes/horde/entities/weapons/arccw_horde_medic_rifle.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_medic_rifle.lua
@@ -41,10 +41,10 @@ SWEP.Primary.ClipSize = 10 -- DefaultClip is automatically set.
 
 --SWEP.PhysBulletMuzzleVelocity = 1400
 
-SWEP.Recoil = 1.500
-SWEP.RecoilSide = 0.550
+SWEP.Recoil = 1
+SWEP.RecoilSide = 0.2
 SWEP.RecoilRise = 0.1
-SWEP.RecoilPunch = 2.5
+SWEP.RecoilPunch = 0
 
 SWEP.ManualAction = true
 SWEP.NoLastCycle = true -- do not cycle on last shot

--- a/gamemodes/horde/entities/weapons/arccw_horde_scarh.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_scarh.lua
@@ -29,8 +29,8 @@ SWEP.ViewModelFOV = 60
 
 SWEP.DefaultBodygroups = "00000000000"
 
-SWEP.Damage = 74
-SWEP.DamageMin = 60 -- damage done at maximum range
+SWEP.Damage = 55
+SWEP.DamageMin = 40 -- damage done at maximum range
 SWEP.Range = 150 -- in METRES
 SWEP.Penetration = 23
 SWEP.DamageType = DMG_BULLET
@@ -47,9 +47,12 @@ SWEP.RecoilSide = 0.345
 SWEP.RecoilRise = 0.1
 SWEP.RecoilPunch = 0.2
 
-SWEP.Delay = 60 / 650 -- 60 / RPM.
+SWEP.Delay = 0.11 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
+     {
+        Mode = 2,
+    },
     {
         Mode = 1,
     },
@@ -319,7 +322,6 @@ SWEP.WorldModelOffset = {
 
 SWEP.MirrorVMWM = true
 
-SWEP.RejectAttachments = {["go_homemade_auto"] = true, ["go_perk_burst"] = true}
 SWEP.Attachments = {
     {
         PrintName = "Optic",

--- a/gamemodes/horde/entities/weapons/arccw_horde_shotgun.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_shotgun.lua
@@ -32,9 +32,9 @@ SWEP.WorldModelOffset = {
 
 SWEP.DefaultBodygroups = "000000000000"
 
-SWEP.Damage = 8
-SWEP.DamageMin = 4 -- damage done at maximum range
-SWEP.Num = 6
+SWEP.Damage = 10
+SWEP.DamageMin = 6 -- damage done at maximum range
+SWEP.Num = 7
 SWEP.Range = 31 -- in METRES
 SWEP.Penetration = 1
 SWEP.DamageType = DMG_BULLET

--- a/gamemodes/horde/entities/weapons/arccw_horde_ssg08.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ssg08.lua
@@ -41,10 +41,10 @@ SWEP.Primary.ClipSize = 10 -- DefaultClip is automatically set.
 
 SWEP.PhysBulletMuzzleVelocity = 1400
 
-SWEP.Recoil = 1.500
-SWEP.RecoilSide = 0.550
+SWEP.Recoil = 1
+SWEP.RecoilSide = 0.2
 SWEP.RecoilRise = 0.1
-SWEP.RecoilPunch = 2.5
+SWEP.RecoilPunch = 0
 
 SWEP.ManualAction = true
 SWEP.NoLastCycle = true -- do not cycle on last shot

--- a/gamemodes/horde/entities/weapons/arccw_horde_striker.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_striker.lua
@@ -286,7 +286,7 @@ SWEP.Animations = {
     },
     ["sgreload_start"] = {
         Source = "reload_start",
-        Time = 43/40,
+        Time = 23/40,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
         SoundTable = {
                         {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_lift_v1.wav", 		t = 0},
@@ -297,7 +297,7 @@ SWEP.Animations = {
     },
     ["sgreload_insert"] = {
         Source = "reload_loop",
-        Time = 13/40,
+        Time = 8/40,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
         SoundTable = {
                         {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_shell_v1.wav", 		t = 3/40},

--- a/gamemodes/horde/entities/weapons/arccw_horde_winchester.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_winchester.lua
@@ -34,8 +34,8 @@ SWEP.WorldModelOffset = {
 --}
 SWEP.ViewModelFOV = 65
 
-SWEP.Damage = 100
-SWEP.DamageMin = 90
+SWEP.Damage = 150
+SWEP.DamageMin = 125
 SWEP.Range = 1500 * 0.025  -- GAME UNITS * 0.025 = METRES
 SWEP.Penetration = 1
 SWEP.DamageType = DMG_BULLET

--- a/gamemodes/horde/entities/weapons/weapon_horde_medkit.lua
+++ b/gamemodes/horde/entities/weapons/weapon_horde_medkit.lua
@@ -53,7 +53,7 @@ function SWEP:PrimaryAttack()
 
 	local tr = util.TraceLine( {
 		start = self:GetOwner():GetShootPos(),
-		endpos = self:GetOwner():GetShootPos() + self:GetOwner():GetAimVector() * 100,
+		endpos = self:GetOwner():GetShootPos() + self:GetOwner():GetAimVector() * 150,
 		filter = self:GetOwner()
 	} )
 
@@ -83,7 +83,7 @@ function SWEP:PrimaryAttack()
 
 		self:TakePrimaryAmmo( need )
 
-        local healinfo = HealInfo:New({amount=need, healer=self:GetOwner()})
+        local healinfo = HealInfo:New({amount=ent:GetMaxHealth() * 0.2, healer=self:GetOwner()})
 		if ent:IsPlayer() then
 			HORDE:OnPlayerHeal(ent, healinfo)
 		else
@@ -120,7 +120,7 @@ function SWEP:SecondaryAttack()
 
 		self:TakePrimaryAmmo( need )
 
-        local healinfo = HealInfo:New({amount=need, healer=self:GetOwner()})
+        local healinfo = HealInfo:New({amount=ent:GetMaxHealth() * 0.2, healer=self:GetOwner()})
 
 		HORDE:OnPlayerHeal(ent, healinfo)
 

--- a/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
@@ -17,7 +17,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     sound.Play("horde/gadgets/berserk_on.ogg", ply:GetPos())
     sound.Play("horde/gadgets/berserk_in.ogg", ply:GetPos())
     ply.Horde_HasGuts = true
-    ply:ScreenFade(SCREENFADE.IN, Color(200, 50, 50, 50), 0.1, 8)
+    ply:ScreenFade(SCREENFADE.IN, Color(200, 50, 50, 50), 0.1, 10)
     timer.Simple(10, function()
         if ply:IsValid() then ply.Horde_HasGuts = nil end
     end)

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -250,7 +250,7 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_go_p250"].infusions = ballistic_infusions_light
     HORDE.items["arccw_go_r8"].infusions = ballistic_infusions_light
     HORDE.items["arccw_go_deagle"].infusions = ballistic_infusions_light
-    HORDE.items["arccw_mw2_m1911"].infusions = ballistic_infusions_light
+    HORDE.items["arccw_horde_m1911"].infusions = ballistic_infusions_light
     HORDE.items["arccw_horde_anaconda"].infusions = ballistic_infusions_light
     HORDE.items["arccw_go_cz75"].infusions = ballistic_infusions_light
     HORDE.items["arccw_go_m9"].infusions = ballistic_infusions_light
@@ -376,8 +376,8 @@ function HORDE:GetDefaultItemsData()
     HORDE:CreateItem("Pistol",     "Medic 9mm",       "arccw_horde_medic_9mm", 75,  1, "Modified 9mm that provides ranged healing.\n\nPress B or ZOOM to fire healing darts.\nHealing dart recharges every 1 second.",
     {Medic=true}, 2, -1, nil, "items/weapon_medic_9mm.png", nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON}, nil, {"Medic"})
     HORDE:CreateItem("Pistol",     "357",            "arccw_horde_357",        100,  2, "Colt python magnum pistol.\nUsed by Black Mesa security guards.",
-    {Ghost=true}, 3, -1, nil, "items/hl2/weapon_357.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Ghost", "Gunslinger"})
-    HORDE:CreateItem("Pistol",     "Flare Gun",      "arccw_horde_flaregun",   100,  2, "Orion Safety Flare Gun.\nIgnites enemies and deals Fire damage.",
+    {Ghost=true}, 2, -1, nil, "items/hl2/weapon_357.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Ghost", "Gunslinger"})
+    HORDE:CreateItem("Pistol",     "Flare Gun",      "arccw_horde_flaregun",   100,  2, "Orion Safety Flare Gun.\nIgnites enemies and deals Fire damage. \nDraws from reserve ammo rather than reloading manually.",
     {Cremator=true}, 1, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE}, nil, {"Cremator"})
     HORDE:CreateItem("Pistol",     "Glock",          "arccw_go_glock",    750,  2, "Glock 18.\nSemi-automatic pistols manufactured in Austrian.",
     {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
@@ -389,7 +389,7 @@ function HORDE:GetDefaultItemsData()
     {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Pistol",     "R8",             "arccw_go_r8",       750,  2, "R8 Revolver.\nDelivers a highly accurate and powerful round,\nbut at the expense of a lengthy trigger-pull.",
     {Survivor=true, Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "M1911",          "arccw_mw2_m1911",   750,  2, "Colt 1911.\nStandard-issue sidearm for the United States Armed Forces.",
+    HORDE:CreateItem("Pistol",     "M1911",          "arccw_horde_m1911",   750,  2, "Colt 1911.\nStandard-issue sidearm for the United States Armed Forces.",
     {Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Pistol",     "Deagle",         "arccw_go_deagle",   750,  2, "Night Hawk .50C.\nAn iconic pistol that is diffcult to master.",
     {Survivor=true, Ghost=true}, 5, -1, nil, nil, {Ghost=1}, nil, {HORDE.DMG_BALLISTIC})
@@ -438,8 +438,8 @@ function HORDE:GetDefaultItemsData()
     HORDE:CreateItem("SMG",        "Vector Medic PDW","arccw_horde_vector",3000, 6, "KRISS Vector Gen I equipped with a medical dart launcher.\nUses an unconventional blowback system that results in its high firerate.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 12 health and has a 1.5 second cooldown.",
     {Medic=true}, 8, -1, nil, nil, {Medic=3}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
 
-    HORDE:CreateItem("Shotgun",    "Pump-Action",    "arccw_horde_shotgun",100, 3, "A standard 12-gauge shotgun.",
-    {Warden=true, Engineer=true, Cremator=true}, 6, -1, nil, "items/hl2/weapon_shotgun.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Warden"})
+    HORDE:CreateItem("Shotgun",    "Pump-Action",    "arccw_horde_shotgun",100, 2, "A standard 12-gauge shotgun.",
+    {Warden=true, Engineer=true, Cremator=true}, 2, -1, nil, "items/hl2/weapon_shotgun.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Warden"})
     HORDE:CreateItem("Shotgun",    "Nova",           "arccw_go_nova",     1000, 4, "Benelli Nova.\nItalian pump-action 12-gauge shotgun.",
     {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Shotgun",    "M870",           "arccw_go_870",      1500, 4, "Remington 870 Shotgun.\nManufactured in the United States.",
@@ -486,7 +486,7 @@ function HORDE:GetDefaultItemsData()
     {Survivor=true, Ghost=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "SSG08",          "arccw_horde_ssg08",     2500, 6, "Steyr SSG 08.\nAustrian bolt-action sniper rifle developed and produced by Steyr Mannlicher.\nProvides unparalled mobility as a sniper rifle.",
     {Survivor=true, Ghost=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "SCAR-H",         "arccw_horde_scarh",       2500, 7, "FN SCAR-H.\nAn assault rifle developed by Belgian manufacturer FN Herstal.",
+    HORDE:CreateItem("Rifle",      "SCAR-H",         "arccw_horde_scarh",       2750, 7, "FN SCAR-H.\nAn assault rifle developed by Belgian manufacturer FN Herstal.",
     {Survivor=true,  Ghost=true}, 15, -1, nil, nil, {Ghost=2}, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "G3",             "arccw_horde_g3",      3000, 8, "G3 Battle Rifle.\nA 7.62×51mm NATO, select-fire battle rifle developed by H&K.",
     {Ghost=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
@@ -556,7 +556,7 @@ function HORDE:GetDefaultItemsData()
     --{Demolition=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
     --HORDE:CreateItem("Explosive",  "Static Mine",  "horde_static_mine",  2000,  5, "Combine reactive mines that hovers in air.\nExplode when enemies come in proximity.\nYou can plant at most 5 reactive mines.",
     --{Demolition=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "M79 GL",         "arccw_horde_m79",    2000,  6, "M79 Grenade Launcher.\nShoots 40x46mm grenades the explodes on impact.",
+    HORDE:CreateItem("Explosive",  "M79 GL",         "arccw_horde_m79",    1500,  5, "M79 Grenade Launcher.\nShoots 40x46mm grenades the explodes on impact.",
     {Demolition=true, Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
     HORDE:CreateItem("Explosive",  "Sticky Launcher",  "horde_sticky_launcher", 2500,  7, "Sticky grenade launcher.\nLaunches grenades that stick to surfaces and entities.\n\nRMB to detonate.",
     {Demolition=true}, 50, -1, nil, nil, {Demolition=2}, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})


### PR DESCRIPTION
Medkit now heals for 20% of max health rather than a flat 20, increased range by 50%

Edited Flare Gun's description to mention the new reserve ammo mechanic, fixed projectile collision group

Fixed Apollo's projectile collision group, buffed Apollo damage to 60, reduced recoil, adjusted accuracy a bit to compensate

Fixed OSIPR's projectile collision group, reduced recoil, buffed moving / hip accuracy

Fixed M16A4 Grenadier not being able to use bullet types

Buffed M1911 damage to 65-50, increased chamber size to 1, fixed not being able to use bullet types / perks

Buffed AR15 firerate to 0.1

Buffed Pump-Action damage to 10x7 (70) - 6x7 (42), reduced weight to 2, reduced ammo cost to 2

Buffed 357 damage to 60-50, reduced ammo cost to 2

Reduced recoil on AWSM, removed code that forced you to equip the scope on equip

Ghost's semi-auto weapons now have access to full auto and burst weapon perks

Scar-H firerate ~0.092 > 0.11, added full-auto firing mode, reduced damage to 55-40 to compensate, increased price to 2750

G3 firerate 0.109 > 0.23

FN FAL firerate 0.1 > 0.15, added full auto, reduced damage to 65-55 to compensate

Reduced M79 price to 1500, reduced weight to 5

Buffed Winchester LAR damage to 150-125

Buffed Striker's reload speed

Changed Antlion's projectile collision type to COLLISION_GROUP_PLAYER_MOVEMENT (does not collide with players)

Reduced the recoil of the SSG08 (medic and normal)

Fixed Berserker Armor's screen color effect lasting for 8 seconds instead of 10 seconds