### PR TITLE
Emp nade nerf and hemo nade buff, hevzombie battery drop rarity decreased

### DIFF
--- a/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
@@ -65,11 +65,11 @@ function ENT:Explode()
         attacker = self:GetOwner()
     end
 
-    for _, e in pairs(ents.FindInSphere(self:GetPos(), 200)) do
+    for _, e in pairs(ents.FindInSphere(self:GetPos(), 175)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
-            for i = 1, 20 do
+            for i = 1, 18 do
                 local dmginfo = DamageInfo()
-                dmginfo:SetDamage(8)
+                dmginfo:SetDamage(7)
                 dmginfo:SetDamageType(DMG_SHOCK)
                 dmginfo:SetAttacker(attacker)
                 dmginfo:SetInflictor(self)

--- a/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
@@ -65,7 +65,7 @@ function ENT:Explode()
         attacker = self:GetOwner()
     end
 
-    for _, e in pairs(ents.FindInSphere(self:GetPos(), 175)) do
+    for _, e in pairs(ents.FindInSphere(self:GetPos(), 200)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
             for i = 1, 13 do
                 local dmginfo = DamageInfo()

--- a/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
@@ -67,9 +67,9 @@ function ENT:Explode()
 
     for _, e in pairs(ents.FindInSphere(self:GetPos(), 175)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
-            for i = 1, 18 do
+            for i = 1, 12 do
                 local dmginfo = DamageInfo()
-                dmginfo:SetDamage(7)
+                dmginfo:SetDamage(8)
                 dmginfo:SetDamageType(DMG_SHOCK)
                 dmginfo:SetAttacker(attacker)
                 dmginfo:SetInflictor(self)

--- a/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
@@ -67,7 +67,7 @@ function ENT:Explode()
 
     for _, e in pairs(ents.FindInSphere(self:GetPos(), 200)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
-            for i = 1, 13 do
+            for i = 1, 15 do
                 local dmginfo = DamageInfo()
                 dmginfo:SetDamage(8)
                 dmginfo:SetDamageType(DMG_SHOCK)

--- a/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
@@ -67,7 +67,7 @@ function ENT:Explode()
 
     for _, e in pairs(ents.FindInSphere(self:GetPos(), 175)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
-            for i = 1, 12 do
+            for i = 1, 13 do
                 local dmginfo = DamageInfo()
                 dmginfo:SetDamage(8)
                 dmginfo:SetDamageType(DMG_SHOCK)

--- a/gamemodes/horde/entities/entities/arccw_thr_hemo/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_hemo/shared.lua
@@ -70,11 +70,11 @@ function ENT:Explode()
     end
 
     local dmginfo = DamageInfo()
-    dmginfo:SetDamage(180)
+    dmginfo:SetDamage(170)
     dmginfo:SetDamageType(DMG_SLASH)
     dmginfo:SetAttacker(attacker)
     dmginfo:SetInflictor(self)
-    util.BlastDamageInfo(dmginfo, self:GetPos(), 150)
+    util.BlastDamageInfo(dmginfo, self:GetPos(), 240)
 
     local ed = EffectData()
     ed:SetOrigin(self:GetPos())

--- a/gamemodes/horde/entities/entities/npc_vj_ezt_shotbie/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_ezt_shotbie/init.lua
@@ -34,7 +34,7 @@ ENT.HasBloodDecal = true -- Does it spawn a decal when damaged?
 ENT.HasBloodPool = false -- Does it have a blood pool?
 ENT.DropWeaponOnDeath = false
 ENT.HasItemDropsOnDeath = true 
-ENT.ItemDropsOnDeathChance = 15
+ENT.ItemDropsOnDeathChance = 8
 ENT.ItemDropsOnDeath_EntityList = {"item_battery"}
 
 ---------------------------------------------------------------------------------------------------------------------------------------------

--- a/gamemodes/horde/entities/entities/npc_vj_ezt_weapbie/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_ezt_weapbie/init.lua
@@ -39,7 +39,7 @@ ENT.AnimTbl_GrenadeAttack = {"ThrowItem"} -- Grenade Attack Animations
 ENT.GrenadeAttackEntity = "npc_grenade_frag" -- The entity that the SNPC throws | Half Life 2 Grenade: "npc_grenade_frag"
 ENT.DropWeaponOnDeath = false
 ENT.HasItemDropsOnDeath = true 
-ENT.ItemDropsOnDeathChance = 15
+ENT.ItemDropsOnDeathChance = 8
 ENT.ItemDropsOnDeath_EntityList = {"item_battery"}
 
 -- ====== Flinching Code ====== --

--- a/gamemodes/horde/entities/weapons/arccw_horde_nade_emp.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_nade_emp.lua
@@ -18,7 +18,7 @@ SWEP.Trivia_Mechanism = "Electromanetic Pulse"
 SWEP.Trivia_Country = "Combine"
 SWEP.Trivia_Year = 2010
 SWEP.Primary.MaxAmmo = 9
-
+SWEP.ForceDefaultAmmo = 0
 SWEP.Slot = 4
 
 SWEP.NotForNPCs = true


### PR DESCRIPTION
fix to the emp nade to have its ammo properly set on buy (previously undefined and gave 4 grenades everytime emp nades were bought, leading to early game stock piling and emp spam)

slightly nerfed the emp nade's damage, and blast radius a bit to make it less dominant.

buffed hemo nades blast radius and slightly reduced damage to make them marginally less shit

decreased rarity of battery drops to make them more feasible to encounter