### PR TITLE
Molotov rebalance

### DIFF
--- a/gamemodes/horde/entities/entities/arccw_horde_fire/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_horde_fire/shared.lua
@@ -30,7 +30,7 @@ function entmeta:Horde_AddEffect_Molotov(ent)
     timer.Create("Horde_MolotovEffect" .. id, 0.5, 0, function ()
         if not self:IsValid() then timer.Remove("Horde_MolotovEffect" .. id) return end
         local d = DamageInfo()
-        d:SetDamage(25)
+        d:SetDamage(13)
         d:SetAttacker(ent.Owner)
         d:SetInflictor(ent)
         d:SetDamageType(DMG_BURN)

--- a/gamemodes/horde/entities/weapons/arccw_horde_nade_molotov.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_nade_molotov.lua
@@ -42,7 +42,7 @@ SWEP.FuseTime = false
 
 SWEP.Throwing = true
 
-SWEP.Primary.ClipSize = 1
+SWEP.Primary.ClipSize = 4
 
 
 SWEP.MuzzleVelocity = 1000


### PR DESCRIPTION
Lowered damage by half
Increased max amount you can have

By lowering the damage it means you can't farm money with molotovs so it shouldn't matter how many you can buy