### PR TITLE
Vort hunter bug fix

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_ezo_vorthunter/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_ezo_vorthunter/init.lua
@@ -373,7 +373,7 @@ function ENT:CustomOnThink()
 
 		local trMove = util.TraceLine({
 			start = self:GetPos() + self:OBBCenter(),
-			endpos = self:GetEnemy():GetPos() + self:GetEnemy():OBBCenter(),
+			endpos = self:GetEnemy():GetPos() + self:GetEnemy():WorldSpaceCenter(),
 			filter = self
 		})
 


### PR DESCRIPTION
Same as last fix for arc hunter, changing vector used to WorldSpaceCenter()
From the search I did it seems like there's only 1 line here that needs to get changed like this instead of 2 like archunters
