### PR TITLE
Headshot explosion fixes

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_blight/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_blight/init.lua
@@ -47,6 +47,9 @@ function ENT:CustomOnInitialize()
 end
 
 function ENT:CustomOnDeath_BeforeCorpseSpawned(dmginfo, hitgroup)
+
+    if hitgroup == 1 then return end -- 1 = Head
+	
     local e = EffectData()
         e:SetOrigin(self:GetPos())
     util.Effect("blight_explosion", e, true, true)

--- a/gamemodes/horde/entities/entities/npc_vj_horde_blight/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_blight/init.lua
@@ -48,7 +48,10 @@ end
 
 function ENT:CustomOnDeath_BeforeCorpseSpawned(dmginfo, hitgroup)
 
-    if hitgroup == 1 then return end -- 1 = Head
+    if hitgroup == HITGROUP_HEAD then 
+	self.HasDeathRagdoll = true
+	return
+    end 
 	
     local e = EffectData()
         e:SetOrigin(self:GetPos())

--- a/gamemodes/horde/entities/entities/npc_vj_horde_exploder/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_exploder/init.lua
@@ -47,6 +47,9 @@ function ENT:CustomOnInitialize()
 end
 
 function ENT:CustomOnDeath_BeforeCorpseSpawned(dmginfo, hitgroup)
+
+    if hitgroup == 1 then return end -- 1 = Head
+	
     local e = EffectData()
         e:SetOrigin(self:GetPos())
     util.Effect("exploder_explosion", e, true, true)

--- a/gamemodes/horde/entities/entities/npc_vj_horde_exploder/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_exploder/init.lua
@@ -48,7 +48,10 @@ end
 
 function ENT:CustomOnDeath_BeforeCorpseSpawned(dmginfo, hitgroup)
 
-    if hitgroup == 1 then return end -- 1 = Head
+    if hitgroup == HITGROUP_HEAD then 
+	self.HasDeathRagdoll = true
+	return
+    end 
 	
     local e = EffectData()
         e:SetOrigin(self:GetPos())


### PR DESCRIPTION
Simple changes to remove explosions on headshot kills. I'm pretty sure this was supposed to already exist? I think it's in a tip somewhere and was likely a thing that got changed by gorlami at some point /shrug