### PR TITLE
SLAM abuse and Sticky Launcher bug

### DIFF
--- a/gamemodes/horde/entities/entities/npc_satchel_horde/init.lua
+++ b/gamemodes/horde/entities/entities/npc_satchel_horde/init.lua
@@ -117,7 +117,4 @@ function ENT:Use(ply)
     self:EmitSound(defuse, 60)
     self:Remove()
     ply:GiveAmmo(1, "slam", true)
-    if not IsValid(ply:GetWeapon(self.SWEP)) then
-        ply:Give(self.SWEP, true)
-    end
 end

--- a/gamemodes/horde/entities/entities/npc_satchel_horde/init.lua
+++ b/gamemodes/horde/entities/entities/npc_satchel_horde/init.lua
@@ -106,6 +106,7 @@ end
 local defuse = Sound("ambient/machines/pneumatic_drill_3.wav")
 function ENT:Use(ply)
     local owner = self:GetHordeOwner()
+    if not ply:HasWeapon(self.SWEP) then return end
     if reuse:GetBool() == false then return end
     if IsValid(owner) and owner ~= ply then return end    -- feel free to steal disconnected player mines
 

--- a/gamemodes/horde/entities/entities/npc_tripmine_horde/init.lua
+++ b/gamemodes/horde/entities/entities/npc_tripmine_horde/init.lua
@@ -124,6 +124,7 @@ end
 local defuse = Sound("ambient/machines/pneumatic_drill_3.wav")
 function ENT:Use(ply)
     local owner = self:GetHordeOwner()
+    if not ply:HasWeapon(self.SWEP) then return end
     if reuse:GetBool() == false then return end
     if self:GetTriggered() then return end
     if IsValid(owner) and owner ~= ply then return end    -- feel free to steal disconnected player mines

--- a/gamemodes/horde/entities/entities/npc_tripmine_horde/init.lua
+++ b/gamemodes/horde/entities/entities/npc_tripmine_horde/init.lua
@@ -136,7 +136,4 @@ function ENT:Use(ply)
     self:EmitSound(defuse, 60)
     self:Remove()
     ply:GiveAmmo(1, "slam", true)
-    if not IsValid(ply:GetWeapon(self.SWEP)) then
-        ply:Give(self.SWEP, true)
-    end
 end

--- a/gamemodes/horde/entities/weapons/horde_sticky_launcher.lua
+++ b/gamemodes/horde/entities/weapons/horde_sticky_launcher.lua
@@ -157,7 +157,9 @@ function SWEP:PrimaryAttack()
                 end
                 table.insert(self.Stickies, entity)
                 if table.Count(self.Stickies) > 8 then
-                    self.Stickies[1]:Remove()
+					if IsValid(self.Stickies[1]) then -- without this we try to remove a null entity under a few circumstances and break everything :^)
+						self.Stickies[1]:Remove()
+					end
                     table.remove(self.Stickies, 1)
                 end
             end

--- a/gamemodes/horde/entities/weapons/horde_sticky_launcher.lua
+++ b/gamemodes/horde/entities/weapons/horde_sticky_launcher.lua
@@ -157,9 +157,7 @@ function SWEP:PrimaryAttack()
                 end
                 table.insert(self.Stickies, entity)
                 if table.Count(self.Stickies) > 8 then
-					if IsValid(self.Stickies[1]) then -- without this we try to remove a null entity under a few circumstances and break everything :^)
-						self.Stickies[1]:Remove()
-					end
+                    SafeRemoveEntity(self.Stickies[1])
                     table.remove(self.Stickies, 1)
                 end
             end


### PR DESCRIPTION
* Removed the ability for deployed SLAMs to give you the SWEP back (abusable for infinite money).
* Fixed Sticky Launcher bug that occurred when some of your previously launched sticky bombs were removed by something other than the launcher.