### PR TITLE
minor weapon buffs

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_mp40.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mp40.lua
@@ -27,7 +27,7 @@ SWEP.ViewModelFOV = 60
 
 SWEP.DefaultBodygroups = "000000000000"
 
-SWEP.Damage = 30
+SWEP.Damage = 31
 SWEP.DamageMin = 24 -- damage done at maximum range
 SWEP.Range = 75 -- in METRES
 SWEP.Penetration = 4
@@ -45,7 +45,7 @@ SWEP.RecoilSide = 0.05
 SWEP.RecoilRise = 0.15
 SWEP.RecoilPunch = 2
 
-SWEP.Delay = 60 / 525 -- 60 / RPM.
+SWEP.Delay = 60 / 600 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
     {
@@ -127,74 +127,6 @@ SWEP.CustomizeAng = Angle(5, 30, 30)
 SWEP.BarrelLength = 24
 
 SWEP.AttachmentElements = {
-    ["nors"] = {
-        VMBodygroups = {{ind = 4, bg = 1}},
-        WMBodygroups = {{ind = 4, bg = 1}},
-    },
-    ["nofh"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-        WMBodygroups = {{ind = 1, bg = 1}},
-    },
-    ["ubrms"] = {
-        NameChange = "MP7A2",
-        VMBodygroups = {{ind = 3, bg = 1}},
-        WMBodygroups = {{ind = 3, bg = 1}},
-    },
-    ["go_mp7_mag_20"] = {
-        VMBodygroups = {
-            {ind = 2, bg = 1},
-        },
-        WMBodygroups = {
-            {ind = 2, bg = 1},
-        },
-    },
-    ["go_mp7_mag_40"] = {
-        VMBodygroups = {
-            {ind = 2, bg = 2},
-        },
-        WMBodygroups = {
-            {ind = 2, bg = 2},
-        },
-    },
-    ["go_mp7_stock_in"] = {
-        VMBodygroups = {
-            {ind = 5, bg = 1},
-        },
-        WMBodygroups = {
-            {ind = 5, bg = 1},
-        },
-    },
-    ["go_mp7_stock_basilisk"] = {
-        VMBodygroups = {
-            {ind = 5, bg = 2},
-        },
-        WMBodygroups = {
-            {ind = 5, bg = 2},
-        },
-    },
-    ["go_mp7_stock_contractor"] = {
-        VMBodygroups = {
-            {ind = 5, bg = 3},
-        },
-        WMBodygroups = {
-            {ind = 5, bg = 3},
-        },
-    },
-    ["go_stock"] = {
-        VMBodygroups = {
-            {ind = 5, bg = 4},
-        },
-        VMElements = {
-            {
-                Model = "models/weapons/arccw_go/atts/stock_buftube.mdl",
-                Bone = "v_weapon.mp7_Parent",
-                Offset = {
-                    pos = Vector(0, -2.75, -4.75),
-                    ang = Angle(90, 0, -90),
-                },
-            }
-        },
-    },
 }
 
 SWEP.ExtraSightDist = 10
@@ -216,8 +148,9 @@ SWEP.Attachments = {
         Offset = {
             vpos = Vector(-0.55, -2, -5),
             vang = Angle(90, 0, -90),
+            wpos = Vector(-0.55, -2, -5),
+            wang = Angle(90, 0, -90),
         },
-        InstalledEles = {"nors"},
     },
     {
         PrintName = "Tactical",
@@ -226,6 +159,8 @@ SWEP.Attachments = {
         Offset = {
             vpos = Vector(-1, 0.2, 4),
             vang = Angle(90, 0, 0),
+            wpos = Vector(-0.55, -2, -5),
+            wang = Angle(90, 0, -90),
         },
     },
     {
@@ -236,8 +171,9 @@ SWEP.Attachments = {
         Offset = {
             vpos = Vector(-0.5, -1.3, 12),
             vang = Angle(90, 0, -90),
+            wpos = Vector(-0.55, -2, -5),
+            wang = Angle(90, 0, -90),
         },
-        InstalledEles = {"nofh"},
     },
     {
         PrintName = "Ammo Type",

--- a/gamemodes/horde/entities/weapons/arccw_horde_skorpion.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_skorpion.lua
@@ -34,8 +34,8 @@ SWEP.ViewModelFOV = 60
 
 SWEP.DefaultBodygroups = "0000000"
 
-SWEP.Damage = 26
-SWEP.DamageMin = 20 -- damage done at maximum range
+SWEP.Damage = 30
+SWEP.DamageMin = 22 -- damage done at maximum range
 SWEP.Range = 80
 SWEP.RangeMin = 15
 
@@ -221,7 +221,7 @@ SWEP.Attachments = {
         VMScale = Vector(0.9, 0.9, 0.9),
         Bone = "tag_weapon",
         Offset = {
-            
+
             vpos = Vector(5.3, -0.1, 0.83), -- offset that the attachment will be relative to the bone
             vang = Angle(0, 0, 0),
             wpos = Vector(8, 0.4, -4.5),
@@ -401,7 +401,7 @@ SWEP.Animations = {
             {s = "ArcCW_BO1.Skorpion_BoltBack", t = 75 / 35},
             {s = "ArcCW_BO1.Skorpion_BoltFwd", t = 81 / 35},
         },
-       
+
     },
     ["reload_empty_stock"] = {
         Source = "reload_empty",

--- a/gamemodes/horde/entities/weapons/arccw_horde_tec9.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_tec9.lua
@@ -13,3 +13,6 @@ SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_pist_tec9.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_pist_tec9.mdl"
+
+SWEP.Damage = 42
+SWEP.DamageMin = 12

--- a/gamemodes/horde/entities/weapons/arccw_horde_uzi.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_uzi.lua
@@ -45,7 +45,7 @@ SWEP.Recoil = 0.60
 SWEP.RecoilSide = 0.55
 SWEP.RecoilRise = 0
 
-SWEP.Delay = 0.09 -- 60 / RPM.
+SWEP.Delay = 60 / 950-- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
     {
@@ -168,7 +168,7 @@ SWEP.Attachments = {
             wpos = Vector(12.057, 4.317, -3.858),
             wang = Angle(-3.074, -23.004, 0)
         },
-		VMScale = Vector(1, 1, 1),
+        VMScale = Vector(1, 1, 1),
     },
     {
         PrintName = "Underbarrel",
@@ -212,7 +212,7 @@ SWEP.Attachments = {
         Slot = "mw2_wepcamo",
         FreeSlot = true,
     },
-	{
+    {
         PrintName = "Charm",
         Slot = "charm",
         FreeSlot = true,
@@ -229,23 +229,23 @@ SWEP.Attachments = {
 SWEP.Animations = {
     ["idle"] = {
         Source = "idle",
-        Time = 0/30,
+        Time = 0 / 30,
     },
     ["enter_sprint"] = {
         Source = "sprint_in",
-        Time = 11/30
+        Time = 11 / 30
     },
     ["idle_sprint"] = {
         Source = "sprint_loop",
-        Time = 31/40
+        Time = 31 / 40
     },
     ["exit_sprint"] = {
         Source = "sprint_out",
-        Time = 11/30
+        Time = 11 / 30
     },
     ["draw"] = {
         Source = "pullout",
-        Time = 26/30,
+        Time = 26 / 30,
         SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
         LHIK = true,
         LHIKIn = 0,
@@ -253,48 +253,48 @@ SWEP.Animations = {
     },
     ["holster"] = {
         Source = "putaway",
-        Time = 14/30,
+        Time = 14 / 30,
         LHIK = true,
         LHIKIn = 0.3,
         LHIKOut = 0.3,
     },
     ["fire"] = {
         Source = "fire",
-        Time = 7/30,
+        Time = 7 / 30,
         ShellEjectAt = 0,
     },
     ["fire_iron"] = {
         Source = "fire_ads",
-        Time = 7/30,
+        Time = 7 / 30,
         ShellEjectAt = 0,
     },
     ["reload"] = {
         Source = "reload",
-        Time = 76/30,
+        Time = 76 / 30,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SMG1,
         SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_lift_v1.wav", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipout_v2.wav", 	t = 15/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipin_v1.wav", 	t = 56/30},
-					},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_lift_v1.wav", 	t = 0 / 30},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipout_v2.wav", 	t = 15 / 30},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipin_v1.wav", 	t = 56 / 30},
+                    },
         LHIK = true,
-	LHIKEaseIn = 0.31,
+        LHIKEaseIn = 0.31,
         LHIKIn = 0.4,
         LHIKEaseOut = 0.25,
         LHIKOut = 0.3,
     },
     ["reload_empty"] = {
         Source = "reload_empty",
-        Time = 102/30,
+        Time = 102 / 30,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SMG1,
         SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_lift_v1.wav", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipout_v2.wav", 	t = 15/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipin_v1.wav", 	t = 56/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_chamber_v1.wav", 	t = 76/30},
-					},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_lift_v1.wav", 	t = 0 / 30},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipout_v2.wav", 	t = 15 / 30},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_clipin_v1.wav", 	t = 56 / 30},
+                        {s = "weapons/fesiugmw2/foley/wpfoly_miniuzi_reload_chamber_v1.wav", 	t = 76 / 30},
+                    },
         LHIK = true,
-	LHIKEaseIn = 0.31,
+        LHIKEaseIn = 0.31,
         LHIKIn = 0.4,
         LHIKEaseOut = 0.25,
         LHIKOut = 0.3,


### PR DESCRIPTION
minor buffs include:
• Skorpion damage increased from 26 -> 30
• TEC-9's close range damage is increased from 28 -> 42 • TEC-9's long range damage lowered from 21 ->12
• UZI's firerate increased from 667 -> 950
• MP40's damage increased from 30 -> 31
• MP40's firerate increased from 525 -> 600

these changes should hopefully make the skorpion more worth its pricetag, and much more viable, instead of just being a glock clone, without obsoleting the other low tier smgs that're slightly more expensive (also because the uzi's firerate was kinda shit lets be real, the firerate is still lower than the mac-10's so it shouldn't usurp higher tier smgs that deal more damage outright)

the TEC-9 should now serve a godamn purpose and actually make it worth unlocking and using, I took the mentality that the csgo TEC-9 has where its much much more powerful at close range than at medium to longer distances, the harsh difference in damage max and min should atleast keep that behavior in play when the longer range barrel is equipped while still keeping it viable at further distances