### PR TITLE
China Lake 3rd-Person position fix & Draw/Holster time buff

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_chinalake.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_chinalake.lua
@@ -56,6 +56,11 @@ SWEP.MaxRecoilBlowback = 2
 SWEP.ShotgunReload = true
 SWEP.ManualAction = true
 
+-- Function to prevent post-reload cycling
+SWEP.Hook_PostReload = function(wep)
+    wep.SetNeedCycle(false)
+end
+
 -- SWEP.Delay = 60 / 300 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
@@ -190,8 +195,8 @@ SWEP.Animations = {
         LHIKIn = 0.2,
         LHIKOut = 0.95,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Back", t = 28 / 30},
-            {s = "ArcCW_BO1.CL_Fwd", t = 30 / 30},
+            {s = "ArcCW_BO1.CL_Back", t = 27 / 30},
+            {s = "ArcCW_BO1.CL_Fwd", t = 29 / 30},
         },
     },
     ["fire"] = {
@@ -220,7 +225,7 @@ SWEP.Animations = {
         Source = {
             "pump",
         },
-        Time = 68 / 50,
+        Time = 69 / 50,
         SoundTable = {
             {s = "ArcCW_BO1.CL_Back", t = 26 / 50},
             {s = "ArcCW_BO1.CL_Fwd", t = 38 / 50},

--- a/gamemodes/horde/entities/weapons/arccw_horde_chinalake.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_chinalake.lua
@@ -24,8 +24,10 @@ SWEP.ViewModel = "models/horde/weapons/arccw/c_bo1_chinalake.mdl"
 SWEP.WorldModel = "models/horde/weapons/arccw/c_bo1_chinalake.mdl"
 SWEP.MirrorVMWM = true
 SWEP.WorldModelOffset = {
-    pos = Vector(-5, 5, 15),
-    ang = Angle(-90, 10, 180),
+    pos = Vector(2, 5, -6),
+    ang = Angle(-16, 0, 180),
+    bone = "ValveBiped.Bip01_R_Hand",
+    scale = 1
 }
 SWEP.ViewModelFOV = 60
 
@@ -173,20 +175,22 @@ SWEP.Animations = {
     },
     ["draw"] = {
         Source = "draw",
+        Time = 1
         LHIK = true,
         LHIKIn = 0.2,
         LHIKOut = 0.2,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Sight", t = 22 / 30}
+            {s = "ArcCW_BO1.CL_Sight", t = 22 / 50}
         },
     },
     ["holster"] = {
         Source = "holster",
+        Time = 1
         LHIK = true,
         LHIKIn = 0.2,
         LHIKOut = 0.1,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Sight", t = 20 / 30}
+            {s = "ArcCW_BO1.CL_Sight", t = 20 / 40}
         },
     },
     ["ready"] = {


### PR DESCRIPTION
Forgot to carry the world positioning over from the Black Ops Pack. It ended up using the M32's hold position (because that was the original basis for the weapon). I also sped up the swap to/swap from timers based on feedback regarding their slowness.

Hopefully this is the final patch for the China Lake?