### PR TITLE
berserker movespeed buff

### DIFF
--- a/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
@@ -47,3 +47,9 @@ PERK.Hooks.Horde_PrecomputePerkLevelBonus = function (ply)
         ply:Horde_SetPerkLevelBonus("berserker_base", math.min(0.20, 0.008 * ply:Horde_GetLevel(HORDE.Class_Berserker)))
     end
 end
+
+hook.Add("Horde_PlayerMoveBonus", "Horde_BerserkerSpeed", function (ply, bonus_walk, bonus_run)
+    if not ply:Horde_GetPerk("berserker_base") then return end
+    bonus_walk.increase = bonus_walk.increase + 0.3
+    bonus_run.increase = bonus_run.increase + 0.3
+end)


### PR DESCRIPTION
idea was thrown around before to give berserker an innate speed boost similar to samurai but less strong since they have a perk that boosts movespeed

• +30% innate movespeed bonus