### PR TITLE
Berserker, Carcass, Gadgets and Cleaning

### DIFF
--- a/gamemodes/horde/gamemode/gadgets/gadget_agility_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_agility_booster.lua
@@ -1,11 +1,9 @@
 GADGET.PrintName = "Agility Booster"
-GADGET.Description = "{1} increased movement speed."
+GADGET.Description = "25% increased movement speed."
 GADGET.Icon = "items/gadgets/agility_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)

--- a/gamemodes/horde/gamemode/gadgets/gadget_agility_shard.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_agility_shard.lua
@@ -1,13 +1,11 @@
 GADGET.PrintName = "Agility Shard"
-GADGET.Description = "{1} increased movement speed for 30 seconds."
+GADGET.Description = "20% increased movement speed for 30 seconds."
 GADGET.Icon = "items/gadgets/agility_shard.png"
 GADGET.Droppable = true
 GADGET.Once = true
 GADGET.Cooldown = 0
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 0.2, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_arctic_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_arctic_plating.lua
@@ -3,14 +3,12 @@ GADGET.Description = "40% increased Cold damage resistance."
 GADGET.Icon = "items/gadgets/arctic_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
-GADGET.Params = {
-    [1] = {value = 0.20, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_arctic_plating"  then return end
     if HORDE:IsColdDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.40
+        bonus.resistance = bonus.resistance + 0.4
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_armor_fusion.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_armor_fusion.lua
@@ -3,9 +3,7 @@ GADGET.Description = [[When toggled, drains your health and recovers armor up to
 GADGET.Icon = "items/gadgets/armor_fusion.png"
 GADGET.Cooldown = 1
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 0.5, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_assassin_optics.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_assassin_optics.lua
@@ -6,9 +6,7 @@ GADGET.Icon = "items/gadgets/assassin_optics.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 3
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_barbeque.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_barbeque.lua
@@ -6,9 +6,7 @@ GADGET.Icon = "items/gadgets/barbeque.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Active = false
-GADGET.Params = {
-    [1] = {value = 5},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnEnemyKilled = function(victim, killer, wpn)

--- a/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
@@ -4,11 +4,7 @@ GADGET.Icon = "items/gadgets/berserk_armor.png"
 GADGET.Duration = 10
 GADGET.Cooldown = 20
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-    [2] = {value = 0.25, percent = true},
-    [3] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_blast_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_blast_plating.lua
@@ -3,14 +3,12 @@ GADGET.Description = "40% increased Blast damage resistance."
 GADGET.Icon = "items/gadgets/blast_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
-GADGET.Params = {
-    [1] = {value = 0.20, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_blast_plating" then return end
     if HORDE:IsBlastDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.40
+        bonus.resistance = bonus.resistance + 0.4
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_butane_can.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_butane_can.lua
@@ -4,9 +4,7 @@ GADGET.Icon = "items/gadgets/butane_can.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 20
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 375},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_chakra.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_chakra.lua
@@ -1,13 +1,10 @@
 GADGET.PrintName = "Chakra"
-GADGET.Description =
-[[Removes all debuff buildups and debuffs.
-Recover 10 health.]]
+GADGET.Description = "Reduces debuff buildup by 20%.\n\nOn use:\nRemoves all debuff buildups and debuffs.\nRecover 10 health."
 GADGET.Icon = "items/gadgets/chakra.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 5
 GADGET.Active = true
-GADGET.Params = {
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)
@@ -22,4 +19,9 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     sound.Play("items/medshot4.wav", ply:GetPos())
     local healinfo = HealInfo:New({amount=10, healer=ply})
     HORDE:OnPlayerHeal(ply, healinfo)
+end
+
+GADGET.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus, inflictor)
+    if ply:Horde_GetGadget() ~= "gadget_chakra" then return end
+        bonus.less = bonus.less * 0.8
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_cleansing_shard.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_cleansing_shard.lua
@@ -1,12 +1,10 @@
 GADGET.PrintName = "Cleansing Shard"
-GADGET.Description = "Recover {1} health.\nRemoves all status effects."
+GADGET.Description = "Recover 10 health.\nRemoves all status effects."
 GADGET.Icon = "items/gadgets/cleansing_shard.png"
 GADGET.Droppable = true
 GADGET.Once = true
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 10},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_corporate_mindset.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_corporate_mindset.lua
@@ -1,12 +1,8 @@
 GADGET.PrintName = "Corporate Mindset"
-GADGET.Description =
-[["Set goals. Have a ten year plan. Invest. Wake up Early. CEO Mindset."
-
-Greatly increases skull tokens drop chance.]]
+GADGET.Description = "Set goals. Have a ten year plan. Invest. Wake up Early. CEO Mindset.\n\nIncreases skull tokens drop chance by 1000%!"
 GADGET.Icon = "items/gadgets/corporate_mindset.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Active = false
-GADGET.Params = {
-}
+GADGET.Params = {}
 GADGET.Hooks = {}

--- a/gamemodes/horde/gamemode/gadgets/gadget_damage_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_damage_booster.lua
@@ -3,9 +3,7 @@ GADGET.Description = "25% increased Global damage."
 GADGET.Icon = "items/gadgets/damage_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)

--- a/gamemodes/horde/gamemode/gadgets/gadget_damage_shard.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_damage_shard.lua
@@ -1,13 +1,11 @@
 GADGET.PrintName = "Damage Shard"
-GADGET.Description = "{1} increased Global damage for 30 seconds."
+GADGET.Description = "25% increased Global damage for 30 seconds."
 GADGET.Icon = "items/gadgets/damage_shard.png"
 GADGET.Droppable = true
 GADGET.Once = true
 GADGET.Active = true
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_death_mark.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_death_mark.lua
@@ -9,9 +9,7 @@ GADGET.Icon = "items/gadgets/death_mark.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 2
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 0.15, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_detoxifier.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_detoxifier.lua
@@ -3,14 +3,12 @@ GADGET.Description = "40% increased Poison damage resistance."
 GADGET.Icon = "items/gadgets/detoxifier.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
-GADGET.Params = {
-    [1] = {value = 0.40, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_detoxifier"  then return end
     if HORDE:IsPoisonDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.40
+        bonus.resistance = bonus.resistance + 0.4
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_diamond_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_diamond_plating.lua
@@ -1,11 +1,9 @@
 GADGET.PrintName = "Diamond Plating"
-GADGET.Description = "{1} increased Physical damage resistance."
+GADGET.Description = "15% increased Physical damage resistance."
 GADGET.Icon = "items/gadgets/diamond_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 0.15, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)

--- a/gamemodes/horde/gamemode/gadgets/gadget_elixir.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_elixir.lua
@@ -1,6 +1,5 @@
 GADGET.PrintName = "Elixir"
-GADGET.Description = [[Recovers 100% of your health.
-Removes all status effects.]]
+GADGET.Description = "Recovers 100% of your health.\nRemoves all status effects."
 GADGET.Icon = "items/gadgets/elixir.png"
 GADGET.Droppable = true
 GADGET.Active = true

--- a/gamemodes/horde/gamemode/gadgets/gadget_energy_shield.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_energy_shield.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Energy Shield"
-GADGET.Description = "Gain 50 barrier on use."
+GADGET.Description = "Gain 75 barrier on use."
 GADGET.Icon = "items/gadgets/energy_shield.png"
 GADGET.Cooldown = 5
 GADGET.Active = true
@@ -11,5 +11,5 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     if CLIENT then return end
     if ply:Horde_GetGadget() ~= "gadget_energy_shield" then return end
     ply:EmitSound("horde/gadgets/energy_shield_on.ogg")
-    ply:Horde_AddBarrierStack(50)
+    ply:Horde_AddBarrierStack(75)
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_exoskeleton.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_exoskeleton.lua
@@ -1,18 +1,12 @@
 GADGET.PrintName = "Exoskeleton"
 GADGET.Icon = "items/gadgets/exoskeleton.png"
-GADGET.Description =
-[[Using the active ability activates a short boost
-
-You cannot run
-Passively increases Global damage resistance by {1}]]
+GADGET.Description = "Using the active ability activates a short boost\n\nYou cannot run\nPassively increases Global damage resistance by 20%"
 
 GADGET.Duration = 0
 GADGET.Cooldown = 5
 GADGET.Active = true
 
-GADGET.Params = {
-    [1] = { value = 0.2, percent = true },
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function ( ply )

--- a/gamemodes/horde/gamemode/gadgets/gadget_exoskeleton.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_exoskeleton.lua
@@ -4,7 +4,7 @@ GADGET.Description =
 [[Using the active ability activates a short boost
 
 You cannot run
-Passively increases Global damage resistance by {2}]]
+Passively increases Global damage resistance by {1}]]
 
 GADGET.Duration = 0
 GADGET.Cooldown = 5

--- a/gamemodes/horde/gamemode/gadgets/gadget_flash.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_flash.lua
@@ -1,13 +1,12 @@
 GADGET.PrintName = "Flash"
 GADGET.Description = [[Dashes forward, on your next melee attack dealing a 200 slash damage explosion.
-Provides a short invincibility frame.]]
+Provides a short invincibility frame.
+90% reduced fall damage taken until you land on the ground.]]
 GADGET.Icon = "items/gadgets/flash.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
-GADGET.Params = {
-    [1] = { value = 100 },
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function( ply )
@@ -20,6 +19,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function( ply )
     local vel = dir * 8000
     ply.Horde_NextAttack_Flash = true
     ply.Horde_Invincible = true
+    ply.Flash_Fall_Damage_Prevention = true
 
     timer.Simple( 0, function()
         ply:SetLocalVelocity( vel )
@@ -61,4 +61,18 @@ GADGET.Hooks.Horde_OnPlayerDamageTaken = function( ply, dmginfo, bonus )
     if not ply.Horde_Invincible then return end
     dmginfo:SetDamage( 0 )
     return true
+end
+
+GADGET.Hooks.Horde_GetFallDamage = function(ply, speed, bonus)
+    if ply:Horde_GetGadget() ~= "gadget_flash" then return end
+    if not ply.Flash_Fall_Damage_Prevention then return end
+    bonus.less = bonus.less * 0.1
+    ply.Flash_Fall_Damage_Prevention = nil
+end
+
+GADGET.Hooks.PlayerTick = function (ply, mv)
+    if not ply.Flash_Fall_Damage_Prevention or not ply:Alive() then return end
+    if ply:IsOnGround() and not ply.Horde_In_Flash then
+        ply.Flash_Fall_Damage_Prevention = nil
+    end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_heat_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_heat_plating.lua
@@ -3,14 +3,12 @@ GADGET.Description = "40% increased Fire damage resistance."
 GADGET.Icon = "items/gadgets/heat_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
-GADGET.Params = {
-    [1] = {value = 0.20, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_heat_plating"  then return end
     if HORDE:IsFireDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.40
+        bonus.resistance = bonus.resistance + 0.4
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_ied.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ied.lua
@@ -3,16 +3,14 @@ GADGET.Icon = "items/gadgets/ied.png"
 GADGET.Description =
 [[Drops an Improvised Explosive Device on the ground.
 IED explodes when an enemy comes in range.
-You have {1} IED charges. An IED recharges after detonation.]]
+You have 5 IED charges. An IED recharges after detonation.]]
 
 GADGET.Duration = 0
 GADGET.Cooldown = 0.5
 GADGET.Active = true
 GADGET.Charges = 5
 
-GADGET.Params = {
-    [1] = { value = 5 },
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function ( ply )

--- a/gamemodes/horde/gamemode/gadgets/gadget_omnislash.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_omnislash.lua
@@ -1,15 +1,13 @@
 GADGET.PrintName = "Omnislash"
 GADGET.Description = [[Phasing out of reality and repeatedly slashes the target enemy.
-Each slash deals {1} damage.
+Each slash deals 50 damage.
 Bounces to a nearby target if the main target is dead.
 You are invulnerable during Omnislash.]]
 GADGET.Icon = "items/gadgets/omnislash.png"
 GADGET.Duration = 4
 GADGET.Cooldown = 15
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 50},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 local function SpawnPlayer(ply, ply_pos, ply_angles, armor)

--- a/gamemodes/horde/gamemode/gadgets/gadget_ouroboros.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ouroboros.lua
@@ -9,9 +9,7 @@ For each 1% health missing, increase your damage by 0.8%.]]
 GADGET.Icon = "items/gadgets/ouroboros.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 5},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnSetGadget = function (ply, gadget)

--- a/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_ballistic.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_ballistic.lua
@@ -4,9 +4,7 @@ GADGET.Icon = "items/gadgets/projectile_launcher_ballistic.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 150},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_blast.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_blast.lua
@@ -4,10 +4,7 @@ GADGET.Icon = "items/gadgets/projectile_launcher_blast.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 100},
-    [2] = {value = 3},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_cryo.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_cryo.lua
@@ -5,9 +5,7 @@ GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
 GADGET.Droppable = true
-GADGET.Params = {
-    [1] = {value = 150},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_fire.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_fire.lua
@@ -4,9 +4,7 @@ GADGET.Icon = "items/gadgets/projectile_launcher_fire.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 20},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_heal.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_heal.lua
@@ -4,10 +4,7 @@ GADGET.Icon = "items/gadgets/projectile_launcher_heal.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 75},
-    [2] = {value = 25},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_shock.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_projectile_launcher_shock.lua
@@ -4,9 +4,7 @@ GADGET.Icon = "items/gadgets/projectile_launcher_shock.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 125},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/gadgets/gadget_resistance_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_resistance_booster.lua
@@ -3,9 +3,7 @@ GADGET.Description = "25% increased Global damage resistance. \n50% less debuff 
 GADGET.Icon = "items/gadgets/resistance_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)

--- a/gamemodes/horde/gamemode/gadgets/gadget_shock_plating.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_shock_plating.lua
@@ -3,14 +3,12 @@ GADGET.Description = "40% increased Lightning damage resistance."
 GADGET.Icon = "items/gadgets/shock_plating.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 10
-GADGET.Params = {
-    [1] = {value = 0.20, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_shock_plating"  then return end
     if HORDE:IsLightningDamage(dmginfo) then
-        bonus.resistance = bonus.resistance + 0.40
+        bonus.resistance = bonus.resistance + 0.4
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_steroid.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_steroid.lua
@@ -5,9 +5,7 @@ GADGET.Icon = "items/gadgets/steroid.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Active = false
-GADGET.Params = {
-    [1] = {value = 0.25, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerHeal = function(ply, healinfo)

--- a/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
@@ -1,15 +1,10 @@
 GADGET.PrintName = "ULPA Filter"
-GADGET.Description =
-[[{1} increased maximum armor.
-{2} less debuff buildup.]]
+GADGET.Description = "Adds 25 to maximum armor.\n50% less debuff buildup."
 GADGET.Icon = "items/gadgets/ulpa_filter.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Active = false
-GADGET.Params = {
-    [1] = { value = 0.25, percent = true },
-    [2] = { value = 0.5, percent = true },
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnPlayerDebuffApply = function ( ply, debuff, bonus, inflictor )

--- a/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
@@ -1,14 +1,14 @@
 GADGET.PrintName = "ULPA Filter"
 GADGET.Description =
-[[25% increased maximum armor.
-50% less debuff buildup.]]
+[[{1} increased maximum armor.
+{2} less debuff buildup.]]
 GADGET.Icon = "items/gadgets/ulpa_filter.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Active = false
 GADGET.Params = {
-    [1] = {value = 0.2, percent = true},
-    [2] = {value = 0.25, percent = true},
+    [1] = { value = 0.25, percent = true },
+    [2] = { value = 0.5, percent = true },
 }
 GADGET.Hooks = {}
 
@@ -31,6 +31,6 @@ end
 
 GADGET.Hooks.Horde_OnSetMaxArmor = function (ply, bonus)
     if SERVER and ply:Horde_GetGadget() == "gadget_ulpa_filter" then
-        bonus.increase = bonus.increase + 0.25
+            bonus.increase = bonus.increase + 0.25
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
@@ -12,25 +12,25 @@ GADGET.Params = {
 }
 GADGET.Hooks = {}
 
-GADGET.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus, inflictor)
+GADGET.Hooks.Horde_OnPlayerDebuffApply = function ( ply, debuff, bonus, inflictor )
     if ply:Horde_GetGadget() ~= "gadget_ulpa_filter" then return end
-        bonus.less = bonus.less * 0.5
+    bonus.less = bonus.less * 0.5
 end
 
-GADGET.Hooks.Horde_OnSetGadget = function (ply, gadget)
+GADGET.Hooks.Horde_OnSetMaxArmor = function ( ply, bonus )
     if SERVER and ply:Horde_GetGadget() == "gadget_ulpa_filter" then
-        ply:Horde_SetMaxArmor()
+        bonus.add = bonus.add + 25
     end
 end
 
-GADGET.Hooks.Horde_OnUnsetGadget = function (ply, gadget)
-    if SERVER and ply:Horde_GetGadget() == "gadget_ulpa_filter" then
-        ply:Horde_SetMaxArmor()
+GADGET.Hooks.Horde_OnSetGadget = function ( ply, gadget )
+    if SERVER and gadget == "gadget_ulpa_filter" then
+        ply:SetMaxArmor( ply:GetMaxArmor() + 25 )
     end
 end
 
-GADGET.Hooks.Horde_OnSetMaxArmor = function (ply, bonus)
-    if SERVER and ply:Horde_GetGadget() == "gadget_ulpa_filter" then
-            bonus.increase = bonus.increase + 0.25
+GADGET.Hooks.Horde_OnUnsetGadget = function ( ply, gadget )
+    if SERVER and gadget == "gadget_ulpa_filter" then
+        ply:SetMaxArmor( ply:GetMaxArmor() - 25 )
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_ultimate_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ultimate_booster.lua
@@ -6,9 +6,7 @@ GADGET.Description = [[15% increased movement speed.
 GADGET.Icon = "items/gadgets/ultimate_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 0.15, percent = true},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)

--- a/gamemodes/horde/gamemode/gadgets/gadget_vitality_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_vitality_booster.lua
@@ -1,11 +1,9 @@
 GADGET.PrintName = "Vitality Booster"
-GADGET.Description = "+50 to maximum health."
+GADGET.Description = "Adds 50 to maximum health."
 GADGET.Icon = "items/gadgets/vitality_booster.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
-GADGET.Params = {
-    [1] = {value = 25},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_OnSetMaxHealth = function (ply, bonus)

--- a/gamemodes/horde/gamemode/gadgets/gadget_vitality_shard.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_vitality_shard.lua
@@ -1,12 +1,10 @@
 GADGET.PrintName = "Vitality Shard"
-GADGET.Description = "Recover {1} health."
+GADGET.Description = "Recover 25 health."
 GADGET.Icon = "items/gadgets/vitality_shard.png"
 GADGET.Droppable = true
 GADGET.Once = true
 GADGET.Active = true
-GADGET.Params = {
-    [1] = {value = 25},
-}
+GADGET.Params = {}
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)

--- a/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
@@ -4,52 +4,53 @@ The Berserker class is a melee-centered class that can be played both offensivel
 Complexity: HIGH
 
 {1} increased Slashing and Blunt damage. ({2} per level, up to {3}).
-{4} increased Global damage resistance. ({5} per level, up to {6}).
+{1} increased Global damage resistance. ({2} per level, up to {3}).
+{4} increased Movement Speed and +2 damage block.
 
-Aerial Parry: Jump to reduce Physical damage taken by {7}.]]
+Aerial Parry: Jump to reduce Physical damage taken by {5}.]]
 PERK.Params = {
-    [1] = {percent = true, level = 0.008, max = 0.20, classname = HORDE.Class_Berserker},
-    [2] = {value = 0.008, percent = true},
-    [3] = {value = 0.20, percent = true},
-    [4] = {percent = true, level = 0.008, max = 0.20, classname = HORDE.Class_Berserker},
-    [5] = {value = 0.008, percent = true},
-    [6] = {value = 0.20, percent = true},
-    [7] = {value = 0.65, percent = true},
+    [1] = { percent = true, level = 0.008, max = 0.20, classname = HORDE.Class_Berserker },
+    [2] = { value = 0.008, percent = true },
+    [3] = { value = 0.20, percent = true },
+    [4] = { value = 0.2, percent = true },
+    [5] = { value = 0.65, percent = true },
 }
 
 PERK.Hooks = {}
-PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
+
+PERK.Hooks.Horde_OnSetPerk = function( ply, perk )
     if SERVER and perk == "berserker_base" then
         ply:Horde_SetAerialGuardEnabled(1)
     end
 end
 
-PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
+PERK.Hooks.Horde_OnUnsetPerk = function( ply, perk )
     if SERVER and perk == "berserker_base" then
         ply:Horde_SetAerialGuardEnabled(0)
     end
 end
 
-PERK.Hooks.Horde_OnPlayerDamageTaken = function(ply, dmginfo, bonus)
-    if not ply:Horde_GetPerk("berserker_base")  then return end
-    bonus.resistance = bonus.resistance + ply:Horde_GetPerkLevelBonus("berserker_base")
+PERK.Hooks.Horde_OnPlayerDamageTaken = function( ply, dmginfo, bonus )
+    if not ply:Horde_GetPerk( "berserker_base" )  then return end
+    bonus.resistance = bonus.resistance + ply:Horde_GetPerkLevelBonus( "berserker_base" )
+    bonus.block = bonus.block + 2
 end
 
-PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
-    if not ply:Horde_GetPerk("berserker_base") then return end
+PERK.Hooks.Horde_OnPlayerDamage = function ( ply, npc, bonus, hitgroup, dmginfo )
+    if not ply:Horde_GetPerk( "berserker_base" ) then return end
     if HORDE:IsSlashDamage(dmginfo) or HORDE:IsBluntDamage(dmginfo) then
-        bonus.increase = bonus.increase + ply:Horde_GetPerkLevelBonus("berserker_base")
+        bonus.increase = bonus.increase + ply:Horde_GetPerkLevelBonus( "berserker_base" )
     end
 end
 
-PERK.Hooks.Horde_PrecomputePerkLevelBonus = function (ply)
+PERK.Hooks.Horde_PrecomputePerkLevelBonus = function ( ply )
     if SERVER then
-        ply:Horde_SetPerkLevelBonus("berserker_base", math.min(0.20, 0.008 * ply:Horde_GetLevel(HORDE.Class_Berserker)))
+        ply:Horde_SetPerkLevelBonus( "berserker_base", math.min(0.20, 0.008 * ply:Horde_GetLevel(HORDE.Class_Berserker)) )
     end
 end
 
 hook.Add("Horde_PlayerMoveBonus", "Horde_BerserkerSpeed", function (ply, bonus_walk, bonus_run)
     if not ply:Horde_GetPerk("berserker_base") then return end
-    bonus_walk.increase = bonus_walk.increase + 0.3
-    bonus_run.increase = bonus_run.increase + 0.3
+    bonus_walk.increase = bonus_walk.increase + 0.2
+    bonus_run.increase = bonus_run.increase + 0.2
 end)

--- a/gamemodes/horde/gamemode/perks/berserker/berserker_bushido.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_bushido.lua
@@ -2,20 +2,21 @@ PERK.PrintName = "Bushido"
 PERK.Description = "{1} increased Slashing damage.\n{2} increased movement speed."
 PERK.Icon = "materials/perks/bushido.png"
 PERK.Params = {
-    [1] = {value = 0.25, percent = true},
-    [2] = {value = 0.25, percent = true},
+    [1] = { value = 0.3, percent = true },
+    [2] = { value = 0.2, percent = true },
 }
 
 PERK.Hooks = {}
+
 PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
     if not ply:Horde_GetPerk("berserker_bushido")  then return end
     if HORDE:IsSlashDamage(dmginfo) then
-        bonus.increase = bonus.increase + 0.25
+        bonus.increase = bonus.increase + 0.3
     end
 end
 
 PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
     if not ply:Horde_GetPerk("berserker_bushido") then return end
-    bonus_walk.increase = bonus_walk.increase + 0.25
-    bonus_run.increase = bonus_run.increase + 0.25
+    bonus_walk.increase = bonus_walk.increase + 0.2
+    bonus_run.increase = bonus_run.increase + 0.2
 end

--- a/gamemodes/horde/gamemode/perks/berserker/berserker_savagery.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_savagery.lua
@@ -2,11 +2,12 @@ PERK.PrintName = "Savagery"
 PERK.Description = "{1} increased Blunt damage.\n{2} increased maximum health."
 PERK.Icon = "materials/perks/savagery.png"
 PERK.Params = {
-    [1] = {value = 0.25, percent = true},
-    [2] = {value = 0.25, percent = true},
+    [1] = { value = 0.3, percent = true },
+    [2] = { value = 0.25, percent = true },
 }
 
 PERK.Hooks = {}
+
 PERK.Hooks.Horde_OnSetMaxHealth = function(ply, bonus)
     if SERVER and ply:Horde_GetPerk("berserker_savagery") then
         bonus.increase = bonus.increase + 0.25
@@ -16,6 +17,6 @@ end
 PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
     if not ply:Horde_GetPerk("berserker_savagery")  then return end
     if HORDE:IsBluntDamage(dmginfo) then
-        bonus.increase = bonus.increase + 0.25
+        bonus.increase = bonus.increase + 0.3
     end
 end

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_aas_perfume.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_aas_perfume.lua
@@ -5,17 +5,18 @@ Cloud provides Hypertrophy to players and deals {4} Poison damage in an area.
 Effect lasts for {2} seconds and has a cooldown of {3} seconds.]]
 PERK.Icon = "materials/perks/carcass/aas_perfume.png"
 PERK.Params = {
-    [1] = {value = 2},
-    [2] = {value = 5},
-    [3] = {value = 10},
-    [4] = {value = 50},
+    [1] = { value = 2 },
+    [2] = { value = 5 },
+    [3] = { value = 8 },
+    [4] = { value = 50 },
 }
+
 PERK.Hooks = {}
 
 PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if SERVER and perk == "carcass_aas_perfume" then
         ply:Horde_SetMaxHypertrophyStack(ply:Horde_GetMaxHypertrophyStack() + 2)
-        ply:Horde_SetPerkCooldown(10)
+        ply:Horde_SetPerkCooldown(8)
         net.Start("Horde_SyncActivePerk")
             net.WriteUInt(HORDE.Status_AAS_Perfume, 8)
             net.WriteUInt(1, 3)
@@ -36,7 +37,7 @@ end
 PERK.Hooks.Horde_UseActivePerk = function (ply)
     if not ply:Horde_GetPerk("carcass_aas_perfume") then return end
     local active_weapon = ply:GetActiveWeapon()
-    if not active_weapon:IsValid() or not active_weapon:GetClass() == "horde_carcass" then return false end
+    if not active_weapon:IsValid() or active_weapon:GetClass() ~= "horde_carcass" then return false end
     local res = active_weapon:AAS_Perfume()
     if res then return true end
 end

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
@@ -3,12 +3,12 @@ PERK.Description = [[
 The Carcass class uses its high health and regeneration for various effects.
 Complexity: HIGH
 
-{1} increased maximum health. ({2} per level, up to {3}).
+{1} increased maximum health. ({2} + {3} per level, up to {4}).
 
-{4} chance to gain Hypertrophy when you hit an enemy ({5} chance on headshot).
+{5} chance to gain Hypertrophy when you hit an enemy ({6} chance on headshot).
 100% chance to gain Hypertrophy when you are hit.
-Hypertrophy reduces damage taken by {6}.
-Hypertrophy provides 2% health regen per second.
+Each Hypertrophy stack reduces damage taken by {7}.
+Each Hypertrophy stack regenerates {8} health per second.
 
 Equipped with Carcass Biosystem.
 Cannot use any other weapons other than medkits because your hands are fucked.
@@ -16,12 +16,14 @@ LMB: Punch
 Hold for a charged punch that deals increased damage in an area.]]
 PERK.Icon = "materials/subclasses/carcass.png"
 PERK.Params = {
-    [1] = {percent = true, base = 0.25, level = 0.02, max = 0.75, classname = "Carcass"},
-    [2] = {value = 0.02, percent = true},
-    [3] = {value = 0.75, percent = true},
-    [4] = {value = 0.5, percent = true},
-    [5] = {value = 0.75, percent = true},
-    [6] = {value = 0.05, percent = true},
+    [1] = { percent = true, base = 0.25, level = 0.02, max = 0.75, classname = "Carcass" },
+    [2] = { value = 0.25, percent = true },
+    [3] = { value = 0.02, percent = true },
+    [4] = { value = 0.75, percent = true },
+    [5] = { value = 0.5, percent = true },
+    [6] = { value = 0.75, percent = true },
+    [7] = { value = 0.05, percent = true },
+    [8] = { value = 0.02, percent = true },
 }
 PERK.Hooks = {}
 

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_grappendix.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_grappendix.lua
@@ -1,16 +1,30 @@
 PERK.PrintName = "Grappendix"
 PERK.Description =
 [[{1} increased maximum health.
+Adds {2} maximum Hypertrophy stack.
 Press RMB to use your appendix as a grapple hook.
 Drains your health when in use.]]
 PERK.Icon = "materials/perks/carcass/grappendix.png"
 PERK.Params = {
-    [1] = {value = 0.15, percent = true},
+    [1] = { value = 0.2, percent = true },
+    [2] = { value = 1 },
 }
 PERK.Hooks = {}
 
 PERK.Hooks.Horde_OnSetMaxHealth = function(ply, bonus)
     if SERVER and ply:Horde_GetPerk("carcass_grappendix") then
-        bonus.increase = bonus.increase + 0.15
+        bonus.increase = bonus.increase + 0.2
+    end
+end
+
+PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
+    if SERVER and perk == "carcass_anabolic_gland" then
+        ply:Horde_SetMaxHypertrophyStack(ply:Horde_GetMaxHypertrophyStack() + 1)
+    end
+end
+
+PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
+    if SERVER and perk == "carcass_anabolic_gland" then
+        ply:Horde_SetMaxHypertrophyStack(ply:Horde_GetMaxHypertrophyStack() - 1)
     end
 end

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_tactical_spleen.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_tactical_spleen.lua
@@ -5,8 +5,8 @@ Grants a spleen that negates all debuffs when buildup is full.
 The spleen regenerates every {2} seconds.]]
 PERK.Icon = "materials/perks/carcass/tactical_spleen.png"
 PERK.Params = {
-    [1] = {value = 0.2, percent = true},
-    [2] = {value = 5},
+    [1] = { value = 0.2, percent = true },
+    [2] = { value = 5 },
 }
 PERK.Hooks = {}
 

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -720,7 +720,7 @@ function HORDE:GetDefaultItemsData()
     {Survivor=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_survivor.png", {Survivor=30}, 1)
     HORDE:CreateItem("Equipment", "Assault Vest", "armor_assault", 1000, 0, "Distinguished Assault armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Ballistic damage resistance.",
     {Assault=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_assault.png", {Assault=30}, 1)
-    HORDE:CreateItem("Equipment", "Bulldozer Suit", "armor_heavy", 1000, 0, "Distinguished Heavy armor.\n\nFills up 125% of your armor bar.\nIncreases max armor by 25%.",
+    HORDE:CreateItem("Equipment", "Bulldozer Suit", "armor_heavy", 1000, 0, "Distinguished Heavy armor.\n\nFills up 125% of your armor bar.\n\nIncreases max armor by 25%.",
     {Heavy=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=125}, "items/armor_heavy.png", {Heavy=30}, 1)
     HORDE:CreateItem("Equipment", "Hazmat Suit", "armor_medic", 1000, 0, "Distinguished Medic armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Poison damage resistance.",
     {Medic=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_medic.png", {Medic=30}, 1)

--- a/gamemodes/horde/gamemode/status/buff/sv_neuron_stabilizer.lua
+++ b/gamemodes/horde/gamemode/status/buff/sv_neuron_stabilizer.lua
@@ -49,13 +49,15 @@ end
 function plymeta:Horde_SetNeuronStabilizerEnabled(enabled)
     self.Horde_NeuronStabilizerEnabled = enabled
     local id = self:SteamID()
-    if enabled then
+    if enabled and self:Horde_GetPerk("specops_base") then
         self.Horde_NeuronStabilizerRegenCooldown = 0
         self.Horde_NeuronStabilizerRegenTotal = 0
         timer.Create("Horde_NeuronStabilizerRegen" .. id, 0.5, 0, function ()
             if not IsValid( self ) then return end
             self.Horde_NeuronStabilizerRegenTotal = self.Horde_NeuronStabilizerRegenTotal + 1
-            if not self:IsValid() then timer.Remove("Horde_NeuronStabilizerRegen" .. id) return end
+            if not self:IsValid() or not self:Horde_GetPerk("specops_base") then
+                self.Horde_NeuronStabilizerEnabled = disabled
+                timer.Remove("Horde_NeuronStabilizerRegen" .. id) return end
             if self.Horde_NeuronStabilizerRegenCooldown <= self.Horde_NeuronStabilizerRegenTotal then
                 self:Horde_AddNeuronStabilizerStack()
                 self.Horde_NeuronStabilizerRegenCooldown = self.Horde_NeuronStabilizerRegenTotal + 2

--- a/gamemodes/horde/gamemode/status/buff/sv_warden_aura.lua
+++ b/gamemodes/horde/gamemode/status/buff/sv_warden_aura.lua
@@ -1,15 +1,15 @@
-local entmeta = FindMetaTable("Entity")
-local plymeta = FindMetaTable("Player")
+local entmeta = FindMetaTable( "Entity" )
+local plymeta = FindMetaTable( "Player" )
 
 function entmeta:Horde_AddWardenAura()
     if self.Horde_WardenAura then self:Horde_RemoveWardenAura() end
-    local ent = ents.Create("horde_warden_aura")
+    local ent = ents.Create( "horde_warden_aura" )
     ent:SetPos(self:GetPos())
     ent:SetParent(self)
-    if self:GetNWEntity("HordeOwner"):IsPlayer() then
-        ent:Horde_SetAuraRadius(self:GetNWEntity("HordeOwner"):Horde_GetWardenAuraRadius() * self:GetNWEntity("HordeOwner"):Horde_GetPerkLevelBonus("warden_base"))
+    if self:GetNWEntity( "HordeOwner" ):IsPlayer() then
+        ent:Horde_SetAuraRadius(self:GetNWEntity( "HordeOwner" ):Horde_GetWardenAuraRadius() * self:GetNWEntity( "HordeOwner" ):Horde_GetPerkLevelBonus( "warden_base" ))
     else
-        ent:Horde_SetAuraRadius(self:Horde_GetWardenAuraRadius() * self:Horde_GetPerkLevelBonus("warden_base"))
+        ent:Horde_SetAuraRadius(self:Horde_GetWardenAuraRadius() * self:Horde_GetPerkLevelBonus( "warden_base" ))
         timer.Simple(0, function() self:Horde_AddWardenAuraEffects(self) end)
     end
     ent:Spawn()
@@ -26,7 +26,7 @@ function entmeta:Horde_RemoveWardenAura()
             timer.Simple(0, function()
                 if not IsValid(self) then return end
                 self:Horde_RemoveWardenAuraEffects()
-            end)
+            end )
         end
     end
 end
@@ -75,7 +75,7 @@ function plymeta:Horde_AddWardenAuraEffects(provider)
     if not provider or not IsValid( provider ) or not self:Alive() then return end
 
     if HORDE:IsWatchTower(provider) then
-        self.Horde_WardenAuraProvider = provider:GetNWEntity("HordeOwner")
+        self.Horde_WardenAuraProvider = provider:GetNWEntity( "HordeOwner" )
     else
         self.Horde_WardenAuraProvider = provider
     end
@@ -89,7 +89,7 @@ function plymeta:Horde_AddWardenAuraEffects(provider)
     if self.Horde_WardenAuraProvider:Horde_GetEnableWardenAuraInoculation() then
         self.Horde_WardenAuraInoculation = true
     end
-    net.Start("Horde_SyncStatus")
+    net.Start( "Horde_SyncStatus" )
         net.WriteUInt(HORDE.Status_WardenAura, 8)
         net.WriteUInt(1, 8)
     net.Send(self)
@@ -101,7 +101,7 @@ function plymeta:Horde_RemoveWardenAuraEffects()
     self.Horde_WardenAuraHealthRegen = nil
     self.Horde_WardenAuraDamageBonus = nil
     self.Horde_WardenAuraInoculation = nil
-    net.Start("Horde_SyncStatus")
+    net.Start( "Horde_SyncStatus" )
         net.WriteUInt(HORDE.Status_WardenAura, 8)
         net.WriteUInt(0, 8)
     net.Send(self)
@@ -110,27 +110,26 @@ function plymeta:Horde_RemoveWardenAuraEffects()
     end
 end
 
-hook.Add("Horde_OnPlayerDamageTaken", "Horde_WardenAuraDamageTaken", function(ply, dmginfo, bonus)
+hook.Add( "Horde_OnPlayerDamageTaken", "Horde_WardenAuraDamageTaken", function(ply, dmginfo, bonus)
     if ply.Horde_WardenAuraDamageBlock then
         if ply.Horde_WardenAuraProvider.Horde_EnableWardenAuraBuffBonus then
-            bonus.block = 3
+            bonus.block = bonus.block + 3
         else
-            bonus.block = 2
+            bonus.block = bonus.block + 2
         end
     end
-end)
+end )
 
 hook.Add("Horde_OnPlayerDebuffApply", "Horde_WardenAuraInoculation", function (ply, debuff, bonus, inflictor)
-    if ply.Horde_WardenAuraInoculation then
-        if debuff == HORDE.Status_Ignite or debuff == HORDE.Status_Frostbite or debuff == HORDE.Status_Shock then
-            if ply.Horde_WardenAuraProvider.Horde_EnableWardenAuraBuffBonus then
-                bonus.less = bonus.less * 0.5
-            else
-                bonus.less = bonus.less * 0.75
-            end
+    if not ply.Horde_WardenAuraInoculation then return end
+    if debuff == HORDE.Status_Ignite or debuff == HORDE.Status_Frostbite or debuff == HORDE.Status_Shock then
+        if ply.Horde_WardenAuraProvider.Horde_EnableWardenAuraBuffBonus then
+            bonus.less = bonus.less * 0.5
+        else
+            bonus.less = bonus.less * 0.75
         end
     end
-end)
+end )
 
 hook.Add("PlayerTick", "Horde_WardenAuraHealthRegen", function(ply, mv)
     if not ply.Horde_WardenAuraHealthRegen then return end
@@ -145,7 +144,7 @@ hook.Add("PlayerTick", "Horde_WardenAuraHealthRegen", function(ply, mv)
         HORDE:OnPlayerHeal(ply, healinfo, true)
         ply.Horde_WardenAuraHealthRegenCurTime = CurTime()
     end
-end)
+end )
 
 hook.Add("Horde_OnPlayerDamage", "Horde_WardenAuraDamage", function (ply, npc, bonus, hitgroup, dmginfo)
     if ply.Horde_WardenAuraDamageBonus and dmginfo:GetInflictor():GetClass() ~= "entityflame" and dmginfo:GetDamage() >= 8 then
@@ -155,13 +154,13 @@ hook.Add("Horde_OnPlayerDamage", "Horde_WardenAuraDamage", function (ply, npc, b
         end
         bonus.base_add = bonus.base_add + amount
     end
-end)
+end )
 
 hook.Add("Horde_ResetStatus", "Horde_WardenAuraEffectsReset", function(ply)
     ply:Horde_RemoveWardenAuraEffects()
     ply.Horde_WardenAuraHealthRegenCurTime = CurTime()
-end)
+end )
 
 hook.Add("DoPlayerDeath", "Horde_WardenAuraDoPlayerDeath", function(victim)
     victim:Horde_RemoveWardenAura()
-end)
+end )

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -304,6 +304,27 @@ concommand.Add("horde_testing_gorlami", function (ply, cmd, args)
     end
 end)
 
+concommand.Add( "horde_testing_jessipepsi", function ( ply, cmd, args )
+    if GetConVar( "horde_enable_sandbox" ):GetInt() == 0 then
+        Horde:SendNotificationSandboxOnly( ply )
+        return
+    end
+    if ply:IsAdmin() then
+        local amount = tonumber( args[1] )
+        if not amount then
+            amount = 15000
+        else
+            amount = math.floor( amount )
+        end
+        ply:Horde_AddSkullTokens( amount )
+        ply:Horde_AddMoney( amount )
+        ply:Horde_SyncEconomy()
+        RunConsoleCommand( "horde_testing_disable_level_restrictions" )
+        RunConsoleCommand( "horde_testing_free_perks", 0 )
+        RunConsoleCommand( "horde_testing_unlimited_class_change", 1 )
+    end
+end )
+
 concommand.Add("horde_testing_give_money", function (ply, cmd, args)
     if GetConVar("horde_enable_sandbox"):GetInt() == 0 then
         HORDE:SendNotificationSandboxOnly(ply)

--- a/gamemodes/horde/gamemode/sv_economy.lua
+++ b/gamemodes/horde/gamemode/sv_economy.lua
@@ -350,7 +350,8 @@ hook.Add("PlayerSpawn", "Horde_Economy_Sync", function (ply)
             end
         end
     end
-
+    -- Reapply armor bonus if present
+    ply:Horde_SetMaxArmor()
     ply:Horde_SyncEconomy()
     if ply:Alive() and not (HORDE.start_game and HORDE.current_break_time <= 0) then
         HORDE:GiveStarterWeapons(ply)
@@ -665,10 +666,14 @@ net.Receive("Horde_BuyItem", function (len, ply)
                 if item.class == "armor100" or item.class == "armor150" then
                     if ply:Armor() >= ply:GetMaxArmor() then return end
                 elseif item.class == "armor_heavy" then
-                    if armortag ~= true then
-                        ply:SetMaxArmor( ply:GetMaxArmor() + 25 )
+                    if not ply.Horde_HasHeavyArmor then -- Check if the player has already purchased heavy armor
+                        ply.Horde_HasHeavyArmor = true  -- Set the flag to indicate heavy armor has been purchased
+                        hook.Add("Horde_OnSetMaxArmor", "Horde_HeavyArmorBonus", function(ply, bonus)
+                            if ply.Horde_HasHeavyArmor then
+                                bonus.add = bonus.add + 25
+                            end
+                        end )
                     end
-                    armortag = true
                     if ply:Armor() >= ply:GetMaxArmor() then return end
                 else
                     ply.Horde_Special_Armor = item.class

--- a/gamemodes/horde/gamemode/sv_playerlifecycle.lua
+++ b/gamemodes/horde/gamemode/sv_playerlifecycle.lua
@@ -682,6 +682,10 @@ hook.Add("PlayerSpawn", "Horde_PlayerInitialSpawn", function(ply)
     end
 end)
 
+hook.Add( "PlayerSpawn", "Horde_ReapplyArmorBonus", function(ply)
+    ply:Horde_SetMaxArmor()
+end )
+
 hook.Add("Move", "Horde_PlayerMove", function (ply, mv)
     if ply:Horde_GetClass() then
         ply:SetJumpPower(150)


### PR DESCRIPTION
### Brawler's Buffs - Melee Balance patch
**Berserker:**
- Updated description to include damage block and movement speed additions
- Added a +2 base damage block 
- Reduced the movement speed bonus of +30% down to +20%
- T2 perk Bushido: Movement speed bonus reduced from +25% to +20%
- T2 perk Bushido: Slash Damage bonus increased from +25% to +30%
- T2 perk Savagery: Blunt Damage bonus increased from +25% to +30%

**Carcass:**
- T1 perk Grappendix: Max health bonus increased from +15% to +20%
- T1 perk Grappendix: Now gives +1 Hypertrophy stack
- T4 perk Perfume: Cooldown reduced from 10 seconds to 8 seconds

**Gadgets:**
- Chakra: Now gives a passive 20% debuff resistance
- Flash: Fall damage reduced by 90% until you land
- Energy Shield: Barrier amount increased from 50 to 75

Removed a bunch of params that are not being used in the code and just wasting space