### PR TITLE
Small Patch for Psycho

### DIFF
--- a/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ulpa_filter.lua
@@ -6,7 +6,7 @@ GADGET.Cooldown = 0
 GADGET.Active = false
 GADGET.Params = {
     [1] = { value = 25 },
-    [2] = { value = 50, percent = true },
+    [2] = { value = 0.5, percent = true },
 }
 GADGET.Hooks = {}
 

--- a/gamemodes/horde/gamemode/perks/psycho/psycho_grudge.lua
+++ b/gamemodes/horde/gamemode/perks/psycho/psycho_grudge.lua
@@ -20,7 +20,7 @@ end
 
 PERK.Hooks.Horde_PlayerMoveBonus = function (ply, bonus_walk, bonus_run)
     if ply:Horde_GetPerk("psycho_grudge") then
-        local increase = math.min(0.5, math.max(0, (0.01 * (1 - ply:Health() / ply:GetMaxHealth()))))
+        local increase = math.min(0.5, math.max(0, (1 - ply:Health() / ply:GetMaxHealth())))
         bonus_walk.increase = bonus_walk.increase + increase
         bonus_run.increase = bonus_run.increase + increase
     end

--- a/gamemodes/horde/gamemode/perks/psycho/psycho_grudge.lua
+++ b/gamemodes/horde/gamemode/perks/psycho/psycho_grudge.lua
@@ -14,7 +14,7 @@ PERK.Hooks = {}
 
 PERK.Hooks.Horde_OnPlayerCriticalCheck = function (ply, npc, bonus, hitgroup, dmginfo, crit_bonus)
     if ply:Horde_GetPerk("psycho_grudge") then
-        crit_bonus.increase = crit_bonus.increase + 0.01 * (math.max(0, 1 - ply:Health() / ply:GetMaxHealth()))
+        crit_bonus.increase = crit_bonus.increase + (math.max(0, 1 - ply:Health() / ply:GetMaxHealth()))
     end
 end
 


### PR DESCRIPTION
### Small fix regarding ULPA and Psycho's Grudge perk
- Fixed a description error of ULPA saying 5000% instead of 50% debuff resist.
- Fixed Psycho's Grudge perk giving 1% of the intended movement speed and crit chance bonus.