### PR TITLE
fix for hr_underbase enemy spawns

### DIFF
--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -28,6 +28,10 @@ local horde_boss_critical = nil
 
 HORDE.horde_active_holdzones = nil
 
+HORDE.MapSpawnDistributionOverrides = {
+    ["hr_underbase"] = HORDE.SPAWN_UNIFORM
+ }
+
 local entmeta = FindMetaTable("Entity")
 function entmeta:Horde_SetMostRecentAttacker(attacker)
 	self.most_recent_attacker = attacker
@@ -107,9 +111,6 @@ hook.Add("InitPostEntity", "Horde_Init", function()
 
     HORDE.has_buy_zone = not table.IsEmpty(ents.FindByClass("trigger_horde_buyzone"))
 
-    local Map_spwn_distr_override = {
-        ["hr_underbase"] = HORDE.SPAWN_UNIFORM,
-    }
     -- Check spawn distribution
     HORDE.spawn_distribution = HORDE.SPAWN_PROXIMITY
     if not table.IsEmpty(ents.FindByClass("info_horde_spawn_distribution_uniform")) then
@@ -118,12 +119,10 @@ hook.Add("InitPostEntity", "Horde_Init", function()
         HORDE.spawn_distribution = HORDE.SPAWN_PROXIMITY_NOISY
     end
 
-    for k, v in pairs( Map_spwn_distr_override ) do
-        if game.GetMap() == k then
-        HORDE.spawn_distribution = v
+    if  HORDE.MapSpawnDistributionOverrides[game.GetMap()] ~= nil then
+        HORDE.spawn_distribution = HORDE.MapSpawnDistributionOverrides[game.GetMap()]
         end
-    end
-
+    
     -- Load economy
     for _, ent in pairs(ents.FindByClass("logic_horde_economy")) do
         ent:KeyValue("startingmoney", ent:GetInternalVariable("startingmoney"))

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -112,7 +112,11 @@ hook.Add("InitPostEntity", "Horde_Init", function()
     if not table.IsEmpty(ents.FindByClass("info_horde_spawn_distribution_uniform")) then
         HORDE.spawn_distribution = HORDE.SPAWN_UNIFORM
     elseif not table.IsEmpty(ents.FindByClass("info_horde_spawn_distribution_proximity_noisy")) then
+        if game.GetMap() == "hr_underbase" then
+            HORDE.spawn_distribution = HORDE.SPAWN_UNIFORM
+        else
         HORDE.spawn_distribution = HORDE.SPAWN_PROXIMITY_NOISY
+        end
     end
 
     -- Load economy

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -119,10 +119,7 @@ hook.Add("InitPostEntity", "Horde_Init", function()
         HORDE.spawn_distribution = HORDE.SPAWN_PROXIMITY_NOISY
     end
 
-    if  HORDE.MapSpawnDistributionOverrides[game.GetMap()] ~= nil then
-        HORDE.spawn_distribution = HORDE.MapSpawnDistributionOverrides[game.GetMap()]
-        end
-    
+    HORDE.spawn_distribution = HORDE.MapSpawnDistributionOverrides[game.GetMap()] or HORDE.spawn_distribution 
     -- Load economy
     for _, ent in pairs(ents.FindByClass("logic_horde_economy")) do
         ent:KeyValue("startingmoney", ent:GetInternalVariable("startingmoney"))

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -107,15 +107,20 @@ hook.Add("InitPostEntity", "Horde_Init", function()
 
     HORDE.has_buy_zone = not table.IsEmpty(ents.FindByClass("trigger_horde_buyzone"))
 
+    local Map_spwn_distr_override = {
+        ["hr_underbase"] = HORDE.SPAWN_UNIFORM,
+    }
     -- Check spawn distribution
     HORDE.spawn_distribution = HORDE.SPAWN_PROXIMITY
     if not table.IsEmpty(ents.FindByClass("info_horde_spawn_distribution_uniform")) then
         HORDE.spawn_distribution = HORDE.SPAWN_UNIFORM
     elseif not table.IsEmpty(ents.FindByClass("info_horde_spawn_distribution_proximity_noisy")) then
-        if game.GetMap() == "hr_underbase" then
-            HORDE.spawn_distribution = HORDE.SPAWN_UNIFORM
-        else
         HORDE.spawn_distribution = HORDE.SPAWN_PROXIMITY_NOISY
+    end
+
+    for k, v in pairs( Map_spwn_distr_override ) do
+        if game.GetMap() == k then
+        HORDE.spawn_distribution = v
         end
     end
 


### PR DESCRIPTION
specific fix for underbase so it uses a different spawn distribution without having to decompile and recompile the map (decompiling is imperfect and can cause issues and isn't great for map edits)

this makes it use the uniform spawning distribution so enemies will spawn regardless of player proximity to their spawnpoints, which has been a common issue for as long as we've had underbase

and yes i did infact test this and it does work, atleast from my tests