### PR TITLE
Agility Booster fix & Jump height rework

### DIFF
--- a/gamemodes/horde/gamemode/cl_achievement.lua
+++ b/gamemodes/horde/gamemode/cl_achievement.lua
@@ -152,7 +152,8 @@ function HORDE:SaveMapAchievements()
         and GetConVarNumber("horde_start_money") <= 1000
         and GetConVarNumber("horde_round_bonus") <= 500
         and GetConVarNumber("horde_base_walkspeed") <= 180
-        and GetConVarNumber("horde_base_runspeed") <= 220 then
+        and GetConVarNumber("horde_base_runspeed") <= 220
+        and GetConVarNumber("horde_base_jumpheight") <= 150 then
             HORDE.achievements_map[map].config = 1
         else
             HORDE.achievements_map[map].config = math.max(0, HORDE.achievements_map[map].config)

--- a/gamemodes/horde/gamemode/gadgets/gadget_agility_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_agility_booster.lua
@@ -13,23 +13,14 @@ GADGET.Params = {
 }
 GADGET.Hooks = {}
 
-GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetGadget() ~= "gadget_agility_booster" then return end
     bonus_walk.increase = bonus_walk.increase + 0.25
     bonus_run.increase = bonus_run.increase + 0.25
+    bonus_jump.increase = bonus_jump.increase + 0.3
 end
 
 GADGET.Hooks.Horde_OnPlayerDamageTaken = function(ply, dmginfo, bonus)
     if ply:Horde_GetGadget() ~= "gadget_agility_booster" then return end
     bonus.evasion = bonus.evasion + 0.2
-end
-
-GADGET.Hooks.Horde_OnSetGadget = function(ply, gadget)
-    if gadget ~= "gadget_agility_booster" then return end
-    ply:SetJumpPower( 150 * ( 1 + 0.3 ) )
-end
-
-GADGET.Hooks.Horde_OnUnsetGadget = function(ply, gadget)
-    if gadget ~= "gadget_agility_booster" then return end
-    ply:SetJumpPower( 150 )
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_agility_shard.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_agility_shard.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Agility Shard"
-GADGET.Description = "{1} increased movement speed for 30 seconds."
+GADGET.Description = "{1} increased movement speed for 30 seconds.\n{1} increased jump height for 30 seconds."
 GADGET.Icon = "items/gadgets/agility_shard.png"
 GADGET.Droppable = true
 GADGET.Once = true
@@ -22,9 +22,10 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     end)
 end
 
-GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply.Horde_Has_Agility_Shard then
         bonus_walk.increase = bonus_walk.increase + 0.2
         bonus_run.increase = bonus_run.increase + 0.2
+        bonus_jump.increase = bonus_jump.increase + 0.2
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_berserk_armor.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Berserker Armor"
-GADGET.Description = "{1} increased damage.\n{2} increased Global damage resistance.\n{3} increased movespeed."
+GADGET.Description = "{1} increased damage.\n{2} increased Global damage resistance.\n{3} increased movespeed.\n{4} increased jump height."
 GADGET.Icon = "items/gadgets/berserk_armor.png"
 GADGET.Duration = 10
 GADGET.Cooldown = 20
@@ -8,6 +8,7 @@ GADGET.Params = {
     [1] = { value = 0.25, percent = true },
     [2] = { value = 0.25, percent = true },
     [3] = { value = 0.25, percent = true },
+    [4] = { value = 0.25, percent = true },
 }
 GADGET.Hooks = {}
 
@@ -33,8 +34,9 @@ GADGET.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup)
     bonus.increase = bonus.increase + 0.25
 end
 
-GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetGadget() ~= "gadget_berserk_armor" or not ply.Horde_HasGuts then return end
     bonus_walk.increase = bonus_walk.increase + 0.25
     bonus_run.increase = bonus_run.increase + 0.25
+    bonus_jump.increase = bonus_jump.increase + 0.25
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_exoskeleton.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_exoskeleton.lua
@@ -23,7 +23,7 @@ GADGET.Hooks.Horde_OnPlayerDamageTaken = function ( ply, dmginfo, bonus )
     bonus.resistance = bonus.resistance + 0.2
 end
 
-GADGET.Hooks.Horde_PlayerMoveBonus = function ( ply, bonus_walk, bonus_run )
+GADGET.Hooks.Horde_PlayerMoveBonus = function ( ply, bonus_walk, bonus_run, bonus_jump )
     if ply:Horde_GetGadget() ~= "gadget_exoskeleton"  then return end
     bonus_run.more = bonus_run.more * 0.8
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_hardening_injection.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_hardening_injection.lua
@@ -32,7 +32,7 @@ GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     end
 end
 
-GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetGadget() ~= "gadget_hardening_injection" then return end
     if not ply.Horde_In_Hardening_Injection then return end
     bonus_walk.more = bonus_walk.more * 0.5

--- a/gamemodes/horde/gamemode/gadgets/gadget_ultimate_booster.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_ultimate_booster.lua
@@ -1,5 +1,5 @@
 GADGET.PrintName = "Ultimate Booster"
-GADGET.Description = [[{1} increased movement speed.
+GADGET.Description = [[{1} increased movement speed and jump height.
 {2} increased maximum health. {1} increased Global damage.
 {1} increased Global damage resistance.
 {2} less debuff buildup.]]
@@ -12,10 +12,11 @@ GADGET.Params = {
 }
 GADGET.Hooks = {}
 
-GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+GADGET.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetGadget() ~= "gadget_ultimate_booster" then return end
     bonus_walk.increase = bonus_walk.increase + 0.15
     bonus_run.increase = bonus_run.increase + 0.15
+    bonus_jump.increase = bonus_jump.increase + 0.15
 end
 
 GADGET.Hooks.Horde_OnSetMaxHealth = function (ply, bonus)

--- a/gamemodes/horde/gamemode/languages/english.lua
+++ b/gamemodes/horde/gamemode/languages/english.lua
@@ -277,7 +277,7 @@ LANGUAGE["Perk_assault_base"] = [[
 The Assault class is an all-purpose fighter with high mobility and a focus on Adrenaline stacks.
 Complexity: EASY
 
-{1} more movement speed. ({2} per level, up to {3}).
+{1} more movement speed and jump height ({2} per level, up to {3}).
 {5} increased Ballistic damage. ({6} per level, up to {7}).
 
 Gain Adrenaline when you kill an enemy.

--- a/gamemodes/horde/gamemode/perks/assault/assault_base.lua
+++ b/gamemodes/horde/gamemode/perks/assault/assault_base.lua
@@ -42,7 +42,7 @@ PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_ju
     if not ply:Horde_GetPerk("assault_base") then return end
     bonus_walk.more = bonus_walk.more * ply:Horde_GetPerkLevelBonus("assault_base")
     bonus_run.more = bonus_run.more * ply:Horde_GetPerkLevelBonus("assault_base")
-    bonus_jump.increase = bonus_jump.increase + ply:Horde_GetPerkLevelBonus("assault_base")
+    bonus_jump.more = bonus_jump.more * ply:Horde_GetPerkLevelBonus("assault_base")
 end
 
 PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)

--- a/gamemodes/horde/gamemode/perks/assault/assault_base.lua
+++ b/gamemodes/horde/gamemode/perks/assault/assault_base.lua
@@ -3,7 +3,7 @@ PERK.Description = [[
 The Assault class is an all-purpose fighter with high mobility and a focus on Adrenaline stacks.
 Complexity: EASY
 
-{1} more movement speed. Half as much jump height ({2} per level, up to {3}).
+{1} more movement speed and jump height ({2} per level, up to {3}).
 {5} increased Ballistic damage. ({6} per level, up to {7}).
 
 Gain Adrenaline when you kill an enemy.

--- a/gamemodes/horde/gamemode/perks/assault/assault_base.lua
+++ b/gamemodes/horde/gamemode/perks/assault/assault_base.lua
@@ -3,7 +3,7 @@ PERK.Description = [[
 The Assault class is an all-purpose fighter with high mobility and a focus on Adrenaline stacks.
 Complexity: EASY
 
-{1} more movement speed. ({2} per level, up to {3}).
+{1} more movement speed. Half as much jump height ({2} per level, up to {3}).
 {5} increased Ballistic damage. ({6} per level, up to {7}).
 
 Gain Adrenaline when you kill an enemy.
@@ -31,17 +31,18 @@ PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
     end
 end
 
-PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
-    if not ply:Horde_GetPerk("assault_base") then return end
-    bonus_walk.more = bonus_walk.more * ply:Horde_GetPerkLevelBonus("assault_base")
-    bonus_run.more = bonus_run.more * ply:Horde_GetPerkLevelBonus("assault_base")
-end
-
 PERK.Hooks.Horde_PrecomputePerkLevelBonus = function (ply)
     if SERVER then
         ply:Horde_SetPerkLevelBonus("assault_base", 1 + math.min(0.20, 0.008 * ply:Horde_GetLevel(HORDE.Class_Assault)))
         ply:Horde_SetPerkLevelBonus("assault_base2", math.min(0.10, 0.004 * ply:Horde_GetLevel(HORDE.Class_Assault)))
     end
+end
+
+PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
+    if not ply:Horde_GetPerk("assault_base") then return end
+    bonus_walk.more = bonus_walk.more * ply:Horde_GetPerkLevelBonus("assault_base")
+    bonus_run.more = bonus_run.more * ply:Horde_GetPerkLevelBonus("assault_base")
+    bonus_jump.increase = bonus_jump.increase + ply:Horde_GetPerkLevelBonus("assault_base")
 end
 
 PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)

--- a/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
@@ -5,7 +5,8 @@ Complexity: HIGH
 
 {1} increased Slashing and Blunt damage. ({2} per level, up to {3}).
 {1} increased Global damage resistance. ({2} per level, up to {3}).
-{4} increased Movement Speed and +{5} damage block.
+{4} increased Movement Speed and Jump height
++{5} damage block.
 
 Aerial Parry: Jump to reduce Physical damage taken by {6}.]]
 PERK.Params = {
@@ -50,8 +51,9 @@ PERK.Hooks.Horde_PrecomputePerkLevelBonus = function ( ply )
     end
 end
 
-hook.Add("Horde_PlayerMoveBonus", "Horde_BerserkerSpeed", function (ply, bonus_walk, bonus_run)
+hook.Add("Horde_PlayerMoveBonus", "Horde_BerserkerSpeed", function (ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("berserker_base") then return end
     bonus_walk.increase = bonus_walk.increase + 0.2
     bonus_run.increase = bonus_run.increase + 0.2
+    bonus_jump.increase = bonus_jump.increase + 0.2
 end)

--- a/gamemodes/horde/gamemode/perks/berserker/berserker_bushido.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_bushido.lua
@@ -15,8 +15,9 @@ PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
     end
 end
 
-PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("berserker_bushido") then return end
     bonus_walk.increase = bonus_walk.increase + 0.2
     bonus_run.increase = bonus_run.increase + 0.2
+    bonus_jump.increase = bonus_jump.increase + 0.2
 end

--- a/gamemodes/horde/gamemode/perks/ghost/ghost_ghost_veil.lua
+++ b/gamemodes/horde/gamemode/perks/ghost/ghost_ghost_veil.lua
@@ -19,7 +19,7 @@ PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
     end
 end
 
-PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("ghost_ghost_veil") or not ply:Horde_GetCamoflagueEnabled() then return end
     if ply:Horde_GetCamoflague() == 1 then
         bonus_walk.increase = bonus_walk.increase + 0.15

--- a/gamemodes/horde/gamemode/perks/ghost/ghost_phase_walk.lua
+++ b/gamemodes/horde/gamemode/perks/ghost/ghost_phase_walk.lua
@@ -19,7 +19,7 @@ PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
     end
 end
 
-PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("ghost_phase_walk") or not ply:Horde_GetCamoflagueEnabled() then return end
     if ply:Horde_GetCamoflague() == 1 then
         bonus_walk.increase = bonus_walk.increase + 0.25

--- a/gamemodes/horde/gamemode/perks/gunslinger/gunslinger_elusive.lua
+++ b/gamemodes/horde/gamemode/perks/gunslinger/gunslinger_elusive.lua
@@ -10,7 +10,7 @@ PERK.Params = {
 }
 PERK.Hooks = {}
 
-PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("gunslinger_elusive") then return end
     local wpn = HORDE:GetCurrentWeapon(ply)
     if not wpn:IsValid() then return end

--- a/gamemodes/horde/gamemode/perks/psycho/psycho_grudge.lua
+++ b/gamemodes/horde/gamemode/perks/psycho/psycho_grudge.lua
@@ -18,7 +18,7 @@ PERK.Hooks.Horde_OnPlayerCriticalCheck = function (ply, npc, bonus, hitgroup, dm
     end
 end
 
-PERK.Hooks.Horde_PlayerMoveBonus = function (ply, bonus_walk, bonus_run)
+PERK.Hooks.Horde_PlayerMoveBonus = function (ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetPerk("psycho_grudge") then
         local increase = math.min(0.5, math.max(0, (1 - ply:Health() / ply:GetMaxHealth())))
         bonus_walk.increase = bonus_walk.increase + increase

--- a/gamemodes/horde/gamemode/perks/samurai/samurai_base.lua
+++ b/gamemodes/horde/gamemode/perks/samurai/samurai_base.lua
@@ -35,10 +35,11 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     end
 end
 
-hook.Add("Horde_PlayerMoveBonus", "Horde_SamuraiSpeed", function (ply, bonus_walk, bonus_run)
+hook.Add("Horde_PlayerMoveBonus", "Horde_SamuraiSpeed", function (ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("samurai_base") then return end
     bonus_walk.increase = bonus_walk.increase + 0.4
     bonus_run.increase = bonus_run.increase + 0.4
+    bonus_jump.increase = bonus_jump.increase + 0.2
 end)
 
 PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)

--- a/gamemodes/horde/gamemode/perks/specops/specops_base.lua
+++ b/gamemodes/horde/gamemode/perks/specops/specops_base.lua
@@ -63,7 +63,7 @@ PERK.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
     end
 end
 
-PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run)
+PERK.Hooks.Horde_PlayerMoveBonus = function(ply, bonus_walk, bonus_run, bonus_jump)
     if not ply:Horde_GetPerk("specops_base") then return end
     if ply.Horde_In_Tactical_Mode then
         local b = ply:Horde_GetPerkLevelBonus("specops_base")

--- a/gamemodes/horde/gamemode/sh_class.lua
+++ b/gamemodes/horde/gamemode/sh_class.lua
@@ -19,9 +19,9 @@ function HORDE:CreateClass(name, extra_description, max_hp, movespd, sprintspd, 
     class.name = name
     class.extra_description = extra_description
     class.max_hp = max_hp
-    class.movespd = movespd
-    class.sprintspd = sprintspd
-    class.jumppwr = jumppwr
+    class.movespd = movespd or GetConVar("horde_base_walkspeed"):GetInt()
+    class.sprintspd = sprintspd or GetConVar("horde_base_runspeed"):GetInt()
+    class.jumppwr = jumppwr or GetConVar("horde_base_jumpheight"):GetInt()
     class.base_perk = base_perk
     class.perks = perks
     class.order = order
@@ -96,9 +96,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Survivor,
         "Has access to all weapons except for exclusive and special weapons.\n\nLimited access to attachments.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "survivor_base",
         {
             [1] = {title = "Survival", choices = {"medic_antibiotics", "assault_charge"}},
@@ -114,9 +114,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Assault,
         "Has full access to assault rifles.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "assault_base",
         {
             [1] = {title = "Maneuverability", choices = {"assault_ambush", "assault_charge"}},
@@ -132,9 +132,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Heavy,
         "Has full access to machine guns and high weight weapons.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "heavy_base",
         {
             [1] = {title = "Suppression", choices = {"heavy_sticky_compound", "heavy_crude_casing"}},
@@ -150,9 +150,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Medic,
         "Has acesss to most light weapons and medical tools.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "medic_base",
         {
             [1] = {title = "Medicine", choices = {"medic_antibiotics", "medic_painkillers"}},
@@ -168,9 +168,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Demolition,
         "Has full access to explosive weapons.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "demolition_base",
         {
             [1] = {title = "Grenade", choices = {"demolition_frag_impact", "demolition_frag_cluster"}},
@@ -186,9 +186,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Ghost,
         "Has access to sniper rifles and selected light weapons.\n\nHave access to suppressors and sniper scopes.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "ghost_base",
         {
             [1] = {title = "Tactics", choices = {"ghost_headhunter", "ghost_sniper"}},
@@ -204,9 +204,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Engineer,
         "Has access to special weapons and equipment.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "engineer_base",
         {
             [1] = {title = "Craftsmanship", choices = {"engineer_tinkerer", "engineer_pioneer"}},
@@ -222,9 +222,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Berserker,
         "Only has access to melee weapons.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "berserker_base",
         {
             [1] = {title = "Fundamentals", choices = {"berserker_breathing_technique", "berserker_bloodlust"}},
@@ -240,9 +240,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Warden,
         "Has full access to shotguns and watchtowers (horde_watchtower).",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "warden_base",
         {
             [1] = {title = "Sustain", choices = {"warden_bulwark", "warden_vitality"}},
@@ -258,9 +258,9 @@ function HORDE:GetDefaultClassesData()
         HORDE.Class_Cremator,
         "Has access to heat-based weaponry.",
         100,
-        GetConVar("horde_base_walkspeed"):GetInt(),
-        GetConVar("horde_base_runspeed"):GetInt(),
-        GetConVar("horde_base_jumpheight"):GetInt(),
+        nil,
+	nil,
+	nil,
         "cremator_base",
         {
             [1] = {title = "Chemicals", choices = {"cremator_methane", "cremator_napalm"}},

--- a/gamemodes/horde/gamemode/sh_class.lua
+++ b/gamemodes/horde/gamemode/sh_class.lua
@@ -13,15 +13,15 @@ HORDE.Class_Warden = "Warden"
 HORDE.Class_Cremator = "Cremator"
 
 -- Creates a Horde class
-function HORDE:CreateClass(name, extra_description, max_hp, movespd, sprintspd, jumppwr, base_perk, perks, order, display_name, model, icon, subclasses)
+function HORDE:CreateClass(name, extra_description, base_perk, perks, order, subclasses)
     if name == nil or name == "" then return end
     local class = {}
     class.name = name
     class.extra_description = extra_description
-    class.max_hp = max_hp
-    class.movespd = movespd or GetConVar("horde_base_walkspeed"):GetInt()
-    class.sprintspd = sprintspd or GetConVar("horde_base_runspeed"):GetInt()
-    class.jumppwr = jumppwr or GetConVar("horde_base_jumpheight"):GetInt()
+    class.max_hp = 100
+    class.movespd = GetConVar("horde_base_walkspeed"):GetInt()
+    class.sprintspd = GetConVar("horde_base_runspeed"):GetInt()
+    class.jumppwr = GetConVar("horde_base_jumpheight"):GetInt()
     class.base_perk = base_perk
     class.perks = perks
     class.order = order
@@ -95,10 +95,6 @@ function HORDE:GetDefaultClassesData()
     HORDE:CreateClass(
         HORDE.Class_Survivor,
         "Has access to all weapons except for exclusive and special weapons.\n\nLimited access to attachments.",
-        100,
-        nil,
-	nil,
-	nil,
         "survivor_base",
         {
             [1] = {title = "Survival", choices = {"medic_antibiotics", "assault_charge"}},
@@ -106,17 +102,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Imprinting", choices = {"heavy_liquid_armor", "cremator_entropy_shield"}},
             [4] = {title = "Inspired Learning", choices = {"ghost_headhunter", "specops_flare"}},
         },
-        0,nil,nil,nil,
+        0,
         {HORDE.Class_Survivor}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Assault,
         "Has full access to assault rifles.",
-        100,
-        nil,
-	nil,
-	nil,
         "assault_base",
         {
             [1] = {title = "Maneuverability", choices = {"assault_ambush", "assault_charge"}},
@@ -124,17 +116,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Aggression", choices = {"assault_cardiac_resonance", "assault_cardiac_overload"}},
             [4] = {title = "Conditioning", choices = {"assault_heightened_reflex", "assault_merciless_assault"}},
         },
-        1,nil,nil,nil,
+        1,
         {HORDE.Class_Assault}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Heavy,
         "Has full access to machine guns and high weight weapons.",
-        100,
-        nil,
-	nil,
-	nil,
         "heavy_base",
         {
             [1] = {title = "Suppression", choices = {"heavy_sticky_compound", "heavy_crude_casing"}},
@@ -142,17 +130,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Armor Protection", choices = {"heavy_liquid_armor", "heavy_reactive_armor"}},
             [4] = {title = "Technology", choices = {"heavy_nanomachine", "heavy_ballistic_shock"}},
         },
-        2,nil,nil,nil,
+        2,
         {HORDE.Class_Heavy}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Medic,
         "Has acesss to most light weapons and medical tools.",
-        100,
-        nil,
-	nil,
-	nil,
         "medic_base",
         {
             [1] = {title = "Medicine", choices = {"medic_antibiotics", "medic_painkillers"}},
@@ -160,17 +144,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Enhancement", choices = {"medic_purify", "medic_haste"}},
             [4] = {title = "Natural Selection", choices = {"medic_cellular_implosion", "medic_xcele"}},
         },
-        3,nil,nil,nil,
+        3,
         {HORDE.Class_Medic}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Demolition,
         "Has full access to explosive weapons.",
-        100,
-        nil,
-	nil,
-	nil,
         "demolition_base",
         {
             [1] = {title = "Grenade", choices = {"demolition_frag_impact", "demolition_frag_cluster"}},
@@ -178,17 +158,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Approach", choices = {"demolition_fragmentation", "demolition_knockout"}},
             [4] = {title = "Destruction", choices = {"demolition_chain_reaction", "demolition_pressurized_warhead"}},
         },
-        4,nil,nil,nil,
+        4,
         {HORDE.Class_Demolition}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Ghost,
         "Has access to sniper rifles and selected light weapons.\n\nHave access to suppressors and sniper scopes.",
-        100,
-        nil,
-	nil,
-	nil,
         "ghost_base",
         {
             [1] = {title = "Tactics", choices = {"ghost_headhunter", "ghost_sniper"}},
@@ -196,17 +172,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Trajectory", choices = {"ghost_brain_snap", "ghost_kinetic_impact"}},
             [4] = {title = "Disposal", choices = {"ghost_coup", "ghost_decapitate"}},
         },
-        5,nil,nil,nil,
+        5,
         {HORDE.Class_Ghost}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Engineer,
         "Has access to special weapons and equipment.",
-        100,
-        nil,
-	nil,
-	nil,
         "engineer_base",
         {
             [1] = {title = "Craftsmanship", choices = {"engineer_tinkerer", "engineer_pioneer"}},
@@ -214,17 +186,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Manipulation", choices = {"engineer_antimatter_shield", "engineer_displacer"}},
             [4] = {title = "Experimental", choices = {"engineer_symbiosis", "engineer_kamikaze"}},
         },
-        6,nil,nil,nil,
+        6,
         {HORDE.Class_Engineer}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Berserker,
         "Only has access to melee weapons.",
-        100,
-        nil,
-	nil,
-	nil,
         "berserker_base",
         {
             [1] = {title = "Fundamentals", choices = {"berserker_breathing_technique", "berserker_bloodlust"}},
@@ -232,17 +200,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Parry", choices = {"berserker_graceful_guard", "berserker_unwavering_guard"}},
             [4] = {title = "Combat Arts", choices = {"berserker_phalanx", "berserker_rip_and_tear"}},
         },
-        7,nil,nil,nil,
+        7,
         {HORDE.Class_Berserker}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Warden,
         "Has full access to shotguns and watchtowers (horde_watchtower).",
-        100,
-        nil,
-	nil,
-	nil,
         "warden_base",
         {
             [1] = {title = "Sustain", choices = {"warden_bulwark", "warden_vitality"}},
@@ -250,17 +214,13 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Escort", choices = {"warden_rejection_pulse", "warden_energize"}},
             [4] = {title = "Coverage", choices = {"warden_ex_machina", "warden_resonance_cascade"}},
         },
-        8,nil,nil,nil,
+        8,
         {HORDE.Class_Warden}
     )
 
     HORDE:CreateClass(
         HORDE.Class_Cremator,
         "Has access to heat-based weaponry.",
-        100,
-        nil,
-	nil,
-	nil,
         "cremator_base",
         {
             [1] = {title = "Chemicals", choices = {"cremator_methane", "cremator_napalm"}},
@@ -268,7 +228,7 @@ function HORDE:GetDefaultClassesData()
             [3] = {title = "Heat Manipulation", choices = {"cremator_hyperthermia", "cremator_ionization"}},
             [4] = {title = "Energy Discharge", choices = {"cremator_firestorm", "cremator_incineration"}},
         },
-        9,nil,nil,nil,
+        9,
         {HORDE.Class_Cremator}
     )
 end

--- a/gamemodes/horde/gamemode/sh_class.lua
+++ b/gamemodes/horde/gamemode/sh_class.lua
@@ -13,7 +13,7 @@ HORDE.Class_Warden = "Warden"
 HORDE.Class_Cremator = "Cremator"
 
 -- Creates a Horde class
-function HORDE:CreateClass(name, extra_description, max_hp, movespd, sprintspd, base_perk, perks, order, display_name, model, icon, subclasses)
+function HORDE:CreateClass(name, extra_description, max_hp, movespd, sprintspd, jumppwr, base_perk, perks, order, display_name, model, icon, subclasses)
     if name == nil or name == "" then return end
     local class = {}
     class.name = name
@@ -21,6 +21,7 @@ function HORDE:CreateClass(name, extra_description, max_hp, movespd, sprintspd, 
     class.max_hp = max_hp
     class.movespd = movespd
     class.sprintspd = sprintspd
+    class.jumppwr = jumppwr
     class.base_perk = base_perk
     class.perks = perks
     class.order = order
@@ -97,6 +98,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "survivor_base",
         {
             [1] = {title = "Survival", choices = {"medic_antibiotics", "assault_charge"}},
@@ -114,6 +116,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "assault_base",
         {
             [1] = {title = "Maneuverability", choices = {"assault_ambush", "assault_charge"}},
@@ -131,6 +134,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "heavy_base",
         {
             [1] = {title = "Suppression", choices = {"heavy_sticky_compound", "heavy_crude_casing"}},
@@ -148,6 +152,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "medic_base",
         {
             [1] = {title = "Medicine", choices = {"medic_antibiotics", "medic_painkillers"}},
@@ -165,6 +170,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "demolition_base",
         {
             [1] = {title = "Grenade", choices = {"demolition_frag_impact", "demolition_frag_cluster"}},
@@ -182,6 +188,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "ghost_base",
         {
             [1] = {title = "Tactics", choices = {"ghost_headhunter", "ghost_sniper"}},
@@ -199,6 +206,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "engineer_base",
         {
             [1] = {title = "Craftsmanship", choices = {"engineer_tinkerer", "engineer_pioneer"}},
@@ -216,6 +224,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "berserker_base",
         {
             [1] = {title = "Fundamentals", choices = {"berserker_breathing_technique", "berserker_bloodlust"}},
@@ -233,6 +242,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "warden_base",
         {
             [1] = {title = "Sustain", choices = {"warden_bulwark", "warden_vitality"}},
@@ -250,6 +260,7 @@ function HORDE:GetDefaultClassesData()
         100,
         GetConVar("horde_base_walkspeed"):GetInt(),
         GetConVar("horde_base_runspeed"):GetInt(),
+        GetConVar("horde_base_jumpheight"):GetInt(),
         "cremator_base",
         {
             [1] = {title = "Chemicals", choices = {"cremator_methane", "cremator_napalm"}},

--- a/gamemodes/horde/gamemode/sh_damage.lua
+++ b/gamemodes/horde/gamemode/sh_damage.lua
@@ -176,8 +176,9 @@ net.Receive("Horde_GetStats", function (len, ply)
 
     local bonus_walk = {increase = 0, more = 1}
     local bonus_run = {increase = 0, more = 1}
-    hook.Run("Horde_PlayerMoveBonus", ply, bonus_walk, bonus_run)
-    stats["speed"] = math.max(bonus_walk.more + bonus_walk.increase, bonus_run.more + bonus_walk.increase)
+    local bonus_jump = {increase = 0, more = 1}
+    hook.Run("Horde_PlayerMoveBonus", ply, bonus_walk, bonus_run, bonus_jump)
+    stats["speed"] = math.max(bonus_walk.more + bonus_walk.increase, bonus_run.more + bonus_run.increase, bonus_jump.more + bonus_jump.increase)
 
     HORDE:CalcImmunity(ply, stats, HORDE.Status_Bleeding)
     HORDE:CalcImmunity(ply, stats, HORDE.Status_Ignite)

--- a/gamemodes/horde/gamemode/sh_horde.lua
+++ b/gamemodes/horde/gamemode/sh_horde.lua
@@ -27,6 +27,7 @@ CreateConVar("horde_corpse_cleanup", 1, nil, "Remove corpses.")
 
 CreateConVar("horde_base_walkspeed", 180, nil, "Base walkspeed.")
 CreateConVar("horde_base_runspeed", 220, nil, "Base runspeed.")
+CreateConVar("horde_base_jumpheight", 150, nil, "Base jump height.")
 
 CreateConVar("horde_difficulty", 1, nil, "Difficulty.")
 CreateConVar("horde_disable_difficulty_voting", 0, nil, "Disable difficulty voting.")

--- a/gamemodes/horde/gamemode/status/buff/sv_adrenaline.lua
+++ b/gamemodes/horde/gamemode/status/buff/sv_adrenaline.lua
@@ -76,7 +76,7 @@ hook.Add("Horde_OnPlayerDamage", "Horde_AdrenalineStackDamage", function (ply, n
     end
 end)
 
-hook.Add("Horde_PlayerMoveBonus", "Horde_AdrenalineStackMovespeed", function(ply, bonus_walk, bonus_run)
+hook.Add("Horde_PlayerMoveBonus", "Horde_AdrenalineStackMovespeed", function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetAdrenalineStack() > 0 then
         local bonus2 = ply:Horde_GetAdrenalineStack() * 0.06
         bonus_walk.increase = bonus_walk.increase + bonus2

--- a/gamemodes/horde/gamemode/status/buff/sv_haste.lua
+++ b/gamemodes/horde/gamemode/status/buff/sv_haste.lua
@@ -29,11 +29,12 @@ function plymeta:Horde_GetHaste()
     return self.Horde_Haste or 0
 end
 
-hook.Add("Horde_PlayerMoveBonus", "Horde_HasteMovespeed", function(ply, bonus_walk, bonus_run)
+hook.Add("Horde_PlayerMoveBonus", "Horde_HasteMovespeed", function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply:Horde_GetHaste() == 1 then
         local bonus2 = 0.15 * (1 + ply:Horde_GetApplyBuffMore())
         bonus_walk.increase = bonus_walk.increase + bonus2
         bonus_run.increase = bonus_run.increase + bonus2
+        bonus_jump.increase = bonus_jump.increase + bonus2
     end
 end)
 

--- a/gamemodes/horde/gamemode/status/debuff/sv_frostbite.lua
+++ b/gamemodes/horde/gamemode/status/debuff/sv_frostbite.lua
@@ -45,7 +45,7 @@ function entmeta:Horde_AddFrostbiteEffect(duration)
     end)
 end
 
-hook.Add("Horde_PlayerMoveBonus", "Horde_FrostbiteMovespeed", function(ply, bonus_walk, bonus_run)
+hook.Add("Horde_PlayerMoveBonus", "Horde_FrostbiteMovespeed", function(ply, bonus_walk, bonus_run, bonus_jump)
     if ply.Horde_Debuff_Active and ply.Horde_Debuff_Active[HORDE.Status_Frostbite] then
         bonus_walk.more = bonus_walk.more * HORDE.Difficulty[HORDE.CurrentDifficulty].frostbiteSlow
         bonus_run.more = bonus_run.more * 0.5 * HORDE.Difficulty[HORDE.CurrentDifficulty].frostbiteSlow

--- a/gamemodes/horde/gamemode/sv_playerlifecycle.lua
+++ b/gamemodes/horde/gamemode/sv_playerlifecycle.lua
@@ -688,21 +688,23 @@ end )
 
 hook.Add("Move", "Horde_PlayerMove", function (ply, mv)
     if ply:Horde_GetClass() then
-        ply:SetJumpPower(150)
         local bonus_walk = {more = 1, increase = 0}
         local bonus_run = {more = 1, increase = 0}
-        hook.Run("Horde_PlayerMoveBonus", ply, bonus_walk, bonus_run)
+        local bonus_jump = {more = 1, increase = 0}
+        hook.Run("Horde_PlayerMoveBonus", ply, bonus_walk, bonus_run, bonus_jump)
         ply:SetWalkSpeed(ply:Horde_GetClass().movespd * bonus_walk.more * (1 + bonus_walk.increase))
         ply:SetRunSpeed(ply:Horde_GetClass().sprintspd * bonus_run.more * (1 + bonus_run.increase))
+        ply:SetJumpPower(ply:Horde_GetClass().jumppwr * bonus_jump.more * (1 + bonus_jump.increase))
     end
 end)
 
-hook.Add("Horde_PlayerMoveBonus", "Horde_PlayerPayloadMove", function (ply, bonus_walk, bonus_run)
+hook.Add("Horde_PlayerMoveBonus", "Horde_PlayerPayloadMove", function ( ply, bonus_walk, bonus_run, bonus_jump )
     if ply:Horde_HasPayload() then
         local mass = ply.Horde_Payload_Spawn.Horde_Payload_Mass
         if mass and mass > 0 then
             bonus_walk.more = bonus_walk.more * (1 - math.max(0.1, mass/100))
             bonus_run.more = bonus_run.more * (1 - math.max(0.1, mass/100))
+            bonus_jump.more = bonus_jump.more * (1 - math.max(0.1, mass/100))
         end
     end
 end)

--- a/gamemodes/horde/horde.txt
+++ b/gamemodes/horde/horde.txt
@@ -83,7 +83,7 @@
 		10
 		{
 			"name"		"horde_break_time"
-			"text"		"Break time between waves (>10)"
+			"text"		"Time between waves (>10)"
 			"type"		"Numeric"
 			"default"	"90"
 			"singleplayer" ""
@@ -139,7 +139,7 @@
 		17
 		{
 			"name"		"horde_max_spawn_distance"
-			"text"		"Maximum enenmy respawn distance."
+			"text"		"Max enemy respawn distance."
 			"type"		"Numeric"
 			"default"	"2000"
 			"singleplayer" ""
@@ -147,7 +147,7 @@
 		18
 		{
 			"name"		"horde_min_spawn_distance"
-			"text"		"Minimum enenmy respawn distance."
+			"text"		"Min. enemy respawn distance."
 			"type"		"Numeric"
 			"default"	"400"
 			"singleplayer" ""
@@ -155,7 +155,7 @@
 		19
 		{
 			"name"		"horde_max_spawn_z_distance"
-			"text"		"Maximum enemy spawn height difference."
+			"text"		"Max enemy height diff."
 			"type"		"Numeric"
 			"default"	"500"
 			"singleplayer" ""
@@ -186,10 +186,10 @@
 		}
 		23
 		{
-			"name"		"horde_total_enemies_scaling"
-			"text"		"Forced enemy scaling multiplier"
+			"name"		"horde_base_jumpheight"
+			"text"		"Base Jump Height."
 			"type"		"Numeric"
-			"default"	"0"
+			"default"	"150"
 			"singleplayer" ""
 		}
 		24
@@ -214,6 +214,14 @@
 			"text"		"(ArcCW Only) Free Attachments"
 			"type"		"CheckBox"
 			"default"	"1"
+			"singleplayer" ""
+		}
+		27
+		{
+			"name"		"horde_total_enemies_scaling"
+			"text"		"Forced enemy scaling multi."
+			"type"		"Numeric"
+			"default"	"0"
 			"singleplayer" ""
 		}
 	}


### PR DESCRIPTION
### Mobility changes
**Consumable - Agility Shard**
- Increases jump height by 20% when consumed

**Gadget - Agility Booster**
- Fixed an issue with jumping causing you to linger in the air
- Removed unnecessary code

**Gadget - Berserker Armor**
- Increases jump height by 25% on use

**Gadget - Ultimate Booster**
- Increases jump height by 15% passively

### Class Changes:
**Assault:**
- Added a 0.8% jump height increase per level, up to 20%

**Berserker:**
- Added a 20% jump height increase
- **Perk: Bushido** increases jump height by another 20%

**Samurai**
- Added a 20% jump height increase

**Medic**
- **Perk: Haste** increases jump height by 15% when applied

Added proper configuration for future changes to jump height
Reordered some config settings to reflect order of processing