### PR TITLE
Hatcher changes

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_antlion/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_antlion/init.lua
@@ -178,8 +178,9 @@ function ENT:Horde_Evolve(health)
 	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_metamorphosis") then
 		max_stage = 4
 	end
+	local base_health = self.Base_Health
 	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_natural_selection") then
-		self.Base_Health = self.Base_Health * 1.2
+		self:SetMaxHealth( base_health * 2 + self.level * 25 )
 	end
 	self.Evolve_Stage = math.min(max_stage, self.Evolve_Stage + 1)
 	if self.Evolve_Stage == 2 then

--- a/gamemodes/horde/entities/entities/npc_vj_horde_antlion/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_antlion/init.lua
@@ -178,10 +178,13 @@ function ENT:Horde_Evolve(health)
 	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_metamorphosis") then
 		max_stage = 4
 	end
+	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_natural_selection") then
+		self.Base_Health = self.Base_Health * 1.2
+	end
 	self.Evolve_Stage = math.min(max_stage, self.Evolve_Stage + 1)
 	if self.Evolve_Stage == 2 then
 		self:SetSkin(1)
-		self:SetMaxHealth(self.Base_Health * 1.5 + self.level * 9)
+		self:SetMaxHealth(self.Base_Health * 1.5 + self.level * 10)
 		self:SetHealth(self:GetMaxHealth())
 		self:SetModelScale(0.75)
 		self.MeleeAttackDamage = 45 + self.level * 6

--- a/gamemodes/horde/entities/entities/npc_vj_horde_antlion/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_antlion/init.lua
@@ -119,9 +119,13 @@ end
 
 function ENT:UpgradeReset()
 	self.level = self.properties.level
+	local anthp = self.Base_Health
+	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_natural_selection") then
+		anthp = self.Base_Health * 1.2
+	end
 	if self.Evolve_Stage == 2 then
 		self:SetSkin(1)
-		self:SetMaxHealth(self.Base_Health * 1.5 + self.level * 9)
+		self:SetMaxHealth(anthp * 1.5 + self.level * 10)
 		self:SetHealth(self:GetMaxHealth())
 		self:SetModelScale(0.75)
 		self.MeleeAttackDamage = 45 + self.level * 6
@@ -129,7 +133,7 @@ function ENT:UpgradeReset()
 		self.NextRangeAttackTime = 2
 	elseif self.Evolve_Stage == 3 then
 		self:SetSkin(3)
-		self:SetMaxHealth(self.Base_Health * 2 + self.level * 25)
+		self:SetMaxHealth(anthp * 2 + self.level * 25)
 		self:SetHealth(self:GetMaxHealth())
 		self:SetModelScale(1)
 		self.MeleeAttackDamage = 60 + self.level * 10
@@ -141,7 +145,7 @@ function ENT:UpgradeReset()
 		self:SetModelScale(1)
 		self.Model = "models/antlion_guard.mdl"
 		self:SetModel(self.Model)
-		self:SetMaxHealth(self.Base_Health * 4 + self.level * 50)
+		self:SetMaxHealth(anthp * 4 + self.level * 50)
 		self:SetHealth(self:GetMaxHealth())
 		self.MeleeAttackDamage = 70 + self.level * 15
 		self.RangeAttackDamage = 45 + self.level * 8
@@ -178,14 +182,14 @@ function ENT:Horde_Evolve(health)
 	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_metamorphosis") then
 		max_stage = 4
 	end
-	local base_health = self.Base_Health
+	local anthp = self.Base_Health
 	if self.Owner:IsValid() and self.Owner:Horde_GetPerk("hatcher_natural_selection") then
-		self:SetMaxHealth( base_health * 2 + self.level * 25 )
+		anthp = self.Base_Health * 1.2
 	end
 	self.Evolve_Stage = math.min(max_stage, self.Evolve_Stage + 1)
 	if self.Evolve_Stage == 2 then
 		self:SetSkin(1)
-		self:SetMaxHealth(self.Base_Health * 1.5 + self.level * 10)
+		self:SetMaxHealth(anthp * 1.5 + self.level * 10)
 		self:SetHealth(self:GetMaxHealth())
 		self:SetModelScale(0.75)
 		self.MeleeAttackDamage = 45 + self.level * 6
@@ -193,7 +197,7 @@ function ENT:Horde_Evolve(health)
 		self.NextRangeAttackTime = 2
 	elseif self.Evolve_Stage == 3 then
 		self:SetSkin(3)
-		self:SetMaxHealth(self.Base_Health * 2 + self.level * 25)
+		self:SetMaxHealth(anthp * 2 + self.level * 25)
 		self:SetHealth(self:GetMaxHealth())
 		self:SetModelScale(1)
 		self.MeleeAttackDamage = 60 + self.level * 10
@@ -205,7 +209,7 @@ function ENT:Horde_Evolve(health)
 		self:SetModelScale(1)
 		self.Model = "models/antlion_guard.mdl"
 		self:SetModel(self.Model)
-		self:SetMaxHealth(self.Base_Health * 3 + self.level * 50)
+		self:SetMaxHealth(anthp * 4 + self.level * 50)
 		self:SetHealth(self:GetMaxHealth())
 		self.MeleeAttackDamage = 70 + self.level * 15
 		self.RangeAttackDamage = 45 + self.level * 8
@@ -359,9 +363,10 @@ function ENT:BugPulse()
 			else
 				hook.Run("Horde_OnAntlionPulse", healer, self, ent)
 			end
-			local healinfo = HealInfo:New({amount=ent:GetMaxHealth() * 0.05, healer=healer})
+			local pulseheal = ent:GetMaxHealth() * (0.04 + (self.Evolve_Stage * 0.01))
+			local healinfo = HealInfo:New({amount=pulseheal, healer=healer})
 			HORDE:OnPlayerHeal(ent, healinfo)
-			self:SetHealth(math.min(self:GetMaxHealth(), self:Health() + self:GetMaxHealth() * 0.05))
+			self:SetHealth(math.min(self:GetMaxHealth(), self:Health() + pulseheal))
 		end
 	end
 

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
@@ -1,9 +1,11 @@
 PERK.PrintName = "Growth Hormone"
 PERK.Description =
-[[{1} increases Antlion evolving & healing rate.]]
+[[{1} increased Antlion evolve rate.
+{2} increased Antlion evolving rate when they are healed.]]
 PERK.Icon = "materials/perks/hatcher/growth_hormone.png"
 PERK.Params = {
-    [1] = {value = 1, percent = true},
+    [1] = {value = 0.5, percent = true},
+    [2] = {value = 1, percent = true},
 }
 
 PERK.Hooks = {}

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
@@ -1,6 +1,6 @@
 PERK.PrintName = "Growth Hormone"
 PERK.Description =
-[[{1} increased Antlion evolving rate when they are healed.]]
+[[{1} increases Antlion evolving & healing rate.]]
 PERK.Icon = "materials/perks/hatcher/growth_hormone.png"
 PERK.Params = {
     [1] = {value = 1, percent = true},

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
@@ -14,3 +14,8 @@ PERK.Hooks.Horde_OnAntlionHeal = function(npc, healinfo)
         healinfo:SetHealAmount(healinfo:GetHealAmount() * 2)
     end
 end
+
+PERK.Hooks.Horde_OnAntlionSelfEvolve = function(ply, npc, bonus)
+    if not ply:Horde_GetPerk("hatcher_growth_hormone") then return end
+    bonus.increase = 0.5
+end

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_growth_hormone.lua
@@ -17,5 +17,5 @@ end
 
 PERK.Hooks.Horde_OnAntlionSelfEvolve = function(ply, npc, bonus)
     if not ply:Horde_GetPerk("hatcher_growth_hormone") then return end
-    bonus.increase = 0.5
+    bonus.increase = 1.5
 end

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_natural_selection.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_natural_selection.lua
@@ -35,7 +35,7 @@ end
 PERK.Hooks.OnEntityCreated = function (ent)
     if not ent:IsValid() then return end
     if CLIENT then return end
-    timer.Simple(0.1, function()
+    timer.Simple(0.2, function()
         if not ent:IsValid() then return end
         local ply = ent:GetNWEntity("HordeOwner")
         if ply:IsPlayer() and ply:Horde_GetPerk("hatcher_natural_selection") and ent:IsNPC() then

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_natural_selection.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_natural_selection.lua
@@ -11,7 +11,7 @@ PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
         if not HORDE.player_drop_entities[ply:SteamID()] then return end
         for id, ent in pairs(HORDE.player_drop_entities[ply:SteamID()]) do
             if IsValid( ent ) and ent:IsNPC() and (not ent.Horde_Has_NaturalSelection) then
-                ent:SetMaxHealth(ent:GetMaxHealth() * 1.15)
+                ent:SetMaxHealth(ent:GetMaxHealth() * 1.2)
                 ent:SetHealth(ent:GetMaxHealth())
                 ent.Horde_Has_NaturalSelection = true
             end
@@ -24,7 +24,7 @@ PERK.Hooks.Horde_OnUnSetPerk = function(ply, perk)
         if not HORDE.player_drop_entities[ply:SteamID()] then return end
         for id, ent in pairs(HORDE.player_drop_entities[ply:SteamID()]) do
             if ent:IsNPC() and ent.Horde_Has_NaturalSelection then
-                ent:SetMaxHealth(ent:GetMaxHealth() / 1.15)
+                ent:SetMaxHealth(ent:GetMaxHealth() / 1.2)
                 ent:SetHealth(ent:GetMaxHealth())
                 ent.Horde_Has_NaturalSelection = nil
             end
@@ -39,7 +39,7 @@ PERK.Hooks.OnEntityCreated = function (ent)
         if not ent:IsValid() then return end
         local ply = ent:GetNWEntity("HordeOwner")
         if ply:IsPlayer() and ply:Horde_GetPerk("hatcher_natural_selection") and ent:IsNPC() then
-            ent:SetMaxHealth(ent:GetMaxHealth() * 1.15)
+            ent:SetMaxHealth(ent:GetMaxHealth() * 1.2)
             ent:SetHealth(ent:GetMaxHealth())
             ent.Horde_Has_NaturalSelection = true
         end

--- a/gamemodes/horde/gamemode/perks/hatcher/hatcher_natural_selection.lua
+++ b/gamemodes/horde/gamemode/perks/hatcher/hatcher_natural_selection.lua
@@ -1,14 +1,47 @@
 PERK.PrintName = "Natural Selection"
-PERK.Description =
-[[{1} increased Antlion evolve rate.]]
+PERK.Description = "{1} increased minion maximum health."
 PERK.Icon = "materials/perks/hatcher/natural_selection.png"
 PERK.Params = {
-    [1] = {value = 0.5, percent = true},
+    [1] = {value = 0.2, percent = true},
 }
 
 PERK.Hooks = {}
+PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
+    if SERVER and perk == "hatcher_natural_selection" then
+        if not HORDE.player_drop_entities[ply:SteamID()] then return end
+        for id, ent in pairs(HORDE.player_drop_entities[ply:SteamID()]) do
+            if IsValid( ent ) and ent:IsNPC() and (not ent.Horde_Has_NaturalSelection) then
+                ent:SetMaxHealth(ent:GetMaxHealth() * 1.15)
+                ent:SetHealth(ent:GetMaxHealth())
+                ent.Horde_Has_NaturalSelection = true
+            end
+        end
+    end
+end
 
-PERK.Hooks.Horde_OnAntlionSelfEvolve = function(ply, npc, bonus)
-    if not ply:Horde_GetPerk("hatcher_natural_selection") then return end
-    bonus.increase = 0.5
+PERK.Hooks.Horde_OnUnSetPerk = function(ply, perk)
+    if SERVER and perk == "hatcher_natural_selection" then
+        if not HORDE.player_drop_entities[ply:SteamID()] then return end
+        for id, ent in pairs(HORDE.player_drop_entities[ply:SteamID()]) do
+            if ent:IsNPC() and ent.Horde_Has_NaturalSelection then
+                ent:SetMaxHealth(ent:GetMaxHealth() / 1.15)
+                ent:SetHealth(ent:GetMaxHealth())
+                ent.Horde_Has_NaturalSelection = nil
+            end
+        end
+    end
+end
+
+PERK.Hooks.OnEntityCreated = function (ent)
+    if not ent:IsValid() then return end
+    if CLIENT then return end
+    timer.Simple(0.1, function()
+        if not ent:IsValid() then return end
+        local ply = ent:GetNWEntity("HordeOwner")
+        if ply:IsPlayer() and ply:Horde_GetPerk("hatcher_natural_selection") and ent:IsNPC() then
+            ent:SetMaxHealth(ent:GetMaxHealth() * 1.15)
+            ent:SetHealth(ent:GetMaxHealth())
+            ent.Horde_Has_NaturalSelection = true
+        end
+    end)
 end

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -675,7 +675,7 @@ function HORDE:GetDefaultItemsData()
     Manipulates negative energy fields.]],
     {Demolition=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_PHYSICAL}, nil, {"Warlock"}, true)
 
-    HORDE:CreateItem("Special",    "Carcass Biosystem",   "horde_carcass",   0,  13,
+    HORDE:CreateItem("Special",    "Carcass Biosystem",   "horde_carcass",   0,  12,
     [[Only usable by Carcass subclass!
     Advanced combat biosystem that completely screws up the appearance of its user.
     Leaves behind an unpleasant stench.
@@ -684,7 +684,7 @@ function HORDE:GetDefaultItemsData()
     Hold for a charged punch that deals increased damage in an area.]],
     {Heavy=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_PHYSICAL}, nil, {"Carcass"}, true)
 
-    HORDE:CreateItem("Special",    "Pheropod",   "horde_pheropod",   0,  11,
+    HORDE:CreateItem("Special",    "Pheropod",   "horde_pheropod",   0,  9,
     [[Only usable by Hatcher subclass!
     Pheropods that can hatch and control alien Antlions.
 


### PR DESCRIPTION
Changed wave 1 perks of Hatcher
Merged the old Natural Selection perk into Growth Hormone.
Created a new perk with the name Natural Selection which increases Antlion HP by 20%
Changed the HP of the Stage II Antlion to be x10 of Pheropod lvl instead of x9
Changed HP multiplier of stage IV Antlion to be x4 base HP from x3
Increased pulse healing from 5% to 5%/6%/7%/8% based on Antlion evolve stage.
Decreased Pheropod weight by 2
Decreased Carcass biosystem weight by 1