### PR TITLE
Nuke hotfix

### DIFF
--- a/gamemodes/horde/gamemode/gadgets/gadget_nuke.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_nuke.lua
@@ -3,7 +3,7 @@ GADGET.Description =
 [[Bombards an area with 8 large explosions after a 10 second delay.
 Finishes off with a Nuke detonation dealing massive Blast damage.
 
-Leaves behind Decay for 60 seconds.]]
+Leaves behind Decay for 45 seconds.]]
 GADGET.Icon = "items/gadgets/nuke.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 90
@@ -20,7 +20,7 @@ local function Blast(attacker, inflictor, pos, radius, damage, effect_name, soun
     dmg:SetDamage(damage)
     util.BlastDamageInfo(dmg, pos, radius)
     local effectdata = EffectData()
-	effectdata:SetOrigin(pos)
+    effectdata:SetOrigin(pos)
     if effect_name then
         ParticleEffect(effect_name, pos, Angle(0, 0, 0))
     else
@@ -82,7 +82,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
                 local x = math.cos(angle) * distance
                 local y = math.sin(angle) * distance
                 local blast_pos = pos + Vector(x, y, 0)
-                Blast(attacker, ent, blast_pos, 1000, 800, "explosion_huge", "ambient/explosions/explode_" .. math.random(1, 9) .. ".wav")
+                Blast(attacker, ent, blast_pos, 1000, 800, "vj_explosion" .. math.random( 1,3 ), "ambient/explosions/explode_" .. i .. ".wav")
             end )
         end
 
@@ -91,11 +91,11 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
             Blast(attacker, ent, pos, 1600, 1500, "explosion_huge", "ambient/explosions/explode_1.wav")
         end )
 
-        HORDE:CreateTimer("NukeDecay", 1, 60, function ()
+        HORDE:CreateTimer("NukeDecay", 1, 45, function ()
             if not ply:IsValid() or not ply:Alive() then HORDE:RemoveTimer("NukeDecay") return end
             for _, e in pairs(ents.FindInSphere(pos, 1000)) do
                 if e:IsPlayer() then
-                    e:Horde_AddDebuffBuildup(HORDE.Status_Decay, 10, ply)
+                    e:Horde_AddDebuffBuildup(HORDE.Status_Decay, 15, ply)
                 end
             end
         end )


### PR DESCRIPTION
Changed the explosion used for the barrage to be less resource intense
Removed some randomised elements
Decreased Decay duration from 60 to 45 seconds
Increased Decay buildup speed from 10 to 15 per tick