### PR TITLE
remove fucket error

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_fucket.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_fucket.lua
@@ -64,7 +64,7 @@ SWEP.Attachments = {
             wpos = Vector(13.762, 0.832, -6.102),
             wang = Angle(-10.393, 0, 180)
         },
-        InstalledEles = {"nors","mount"},
+        InstalledEles = "nors",
     },
     {
         PrintName = "Muzzle",

--- a/gamemodes/horde/entities/weapons/arccw_horde_fucket_rifle.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_fucket_rifle.lua
@@ -65,7 +65,7 @@ SWEP.Attachments = {
             wpos = Vector(13.762, 0.832, -6.102),
             wang = Angle(-10.393, 0, 180)
         },
-        InstalledEles = {"nors","mount"},
+        InstalledEles = "nors",
     },
     {
         PrintName = "Muzzle",


### PR DESCRIPTION
the mount installed element calls a model that literally doesn't exist in either arccw base, mw2 pack, or gunsmith offensive, which causes an error ingame