### PR TITLE
Elemental grenade fixes, Cremator improvements

### DIFF
--- a/gamemodes/horde/entities/entities/horde_edible_gib/init.lua
+++ b/gamemodes/horde/entities/entities/horde_edible_gib/init.lua
@@ -13,7 +13,7 @@ function ENT:Initialize()
     self:PhysWake()
     self:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 
-    timer.Simple(5, function ()
+    timer.Simple(15, function ()
         if self:IsValid() then
             self:Remove()
         end
@@ -22,6 +22,7 @@ end
 
 function ENT:StartTouch(ent)
     if ent:IsPlayer() then
+        if ent:Health() >= ent:GetMaxHealth() then return end
         local healinfo = HealInfo:New({amount=ent:GetMaxHealth() * 0.1, healer=self.Owner})
         HORDE:OnPlayerHeal(ent, healinfo)
         sound.Play("horde/gadgets/yummy.ogg", self:GetPos())

--- a/gamemodes/horde/entities/entities/horde_projectile_cryo_round/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_projectile_cryo_round/shared.lua
@@ -59,3 +59,79 @@ function ENT:CustomOnExplode()
         self:EmitSound("horde/sound/horde/status/cold_explosion.ogg", 125, 100, 1, CHAN_AUTO)
     end
 end
+
+function ENT:Detonate(data)
+    if !self:IsValid() or self.Removing then return end
+    local attacker = self
+
+    if self.Owner:IsValid() then
+        attacker = self.Owner
+    end
+
+    local nodetonate = self:CustomOnPreDetonate(data)
+    local hitEnt = data.HitEntity
+    if nodetonate then self:Remove() return end
+
+    if (self.StartPos:DistToSqr(self:GetPos()) <= self.ArmDistanceSqr) or self.ProjectileSabotRound then
+        if self.ProjectileSabotRound then
+            self.ProjectileDamage = self.ProjectileDamage * 1.25
+        end
+        self:FireBullets({
+            Attacker = self.Owner,
+            Damage = self.ProjectileDamage * 0.85,
+            Tracer = 0,
+            Distance = 400,
+            Dir = (data.HitPos - self:GetPos()),
+            Src = self:GetPos(),
+            Callback = function(att, tr, dmg)
+                dmg:SetDamageType(self.ProjectileUnarmedDamageType)
+                dmg:SetAttacker(self.Owner)
+                dmg:SetInflictor(self)
+
+                hook.Run("Horde_OnExplosiveProjectileHeadshot", self.Owner, dmg)
+            end
+        })
+        self.Removing = true
+        self:Remove()
+        return
+    end
+
+    self:CustomOnExplode()
+
+    if self.Horde_Armor_Piercing then
+        self.ProjectileDamage = self.ProjectileDamage * 1.15
+        self.ProjectileDamageRadius = self.ProjectileDamageRadius * 0.7
+    end
+
+    self:FireBullets({
+		Attacker = self.Owner,
+		Damage = 0,
+		Tracer = 0,
+		Distance = 400,
+		Dir = (data.HitPos - self:GetPos()),
+		Src = self:GetPos(),
+		Callback = function(att, tr, dmg)
+			if tr.HitGroup == HITGROUP_HEAD then
+				dmg:SetDamageType(self.ProjectileExplosionDamageType)
+				dmg:SetAttacker(self.Owner)
+				dmg:SetInflictor(self)
+				dmg:SetDamage(self.ProjectileDamage / 2)
+                hook.Run("Horde_OnExplosiveProjectileHeadshot", self.Owner, dmg)
+			end
+
+            if self.Decal then
+                util.Decal(self.Decal, tr.StartPos, tr.HitPos - (tr.HitNormal * 16), self)
+            end
+		end
+	})
+    local dmg2 = DamageInfo()
+    dmg2:SetDamageType(self.ProjectileExplosionDamageType)
+    dmg2:SetAttacker(attacker)
+    dmg2:SetInflictor(self)
+    dmg2:SetDamage(self.ProjectileDamage)
+    util.BlastDamageInfo(dmg2, self:GetPos(), self.ProjectileDamageRadius)
+    hook.Run("Horde_PostExplosiveProjectileExplosion", self.Owner, self, dmg2, self.ProjectileDamageRadius)
+	hitEnt:Horde_AddDebuffBuildup(HORDE.Status_Frostbite, dmg2:GetDamage() * 0.75, attacker, dmg2:GetDamagePosition())
+    self.Removing = true
+    self:Remove()
+end

--- a/gamemodes/horde/entities/entities/horde_projectile_cryo_round/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_projectile_cryo_round/shared.lua
@@ -131,7 +131,7 @@ function ENT:Detonate(data)
     dmg2:SetDamage(self.ProjectileDamage)
     util.BlastDamageInfo(dmg2, self:GetPos(), self.ProjectileDamageRadius)
     hook.Run("Horde_PostExplosiveProjectileExplosion", self.Owner, self, dmg2, self.ProjectileDamageRadius)
-	hitEnt:Horde_AddDebuffBuildup(HORDE.Status_Frostbite, dmg2:GetDamage() * 0.75, attacker, dmg2:GetDamagePosition())
+    hitEnt:Horde_AddDebuffBuildup(HORDE.Status_Frostbite, dmg2:GetDamage() * 0.75, attacker, dmg2:GetDamagePosition())
     self.Removing = true
     self:Remove()
 end

--- a/gamemodes/horde/entities/entities/horde_projectile_shock_round/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_projectile_shock_round/shared.lua
@@ -59,3 +59,79 @@ function ENT:CustomOnExplode()
         self:EmitSound("ambient/levels/labs/electric_explosion1.wav", 125, 100, 1, CHAN_AUTO)
     end
 end
+
+function ENT:Detonate(data)
+    if !self:IsValid() or self.Removing then return end
+    local attacker = self
+
+    if self.Owner:IsValid() then
+        attacker = self.Owner
+    end
+
+    local nodetonate = self:CustomOnPreDetonate(data)
+    local hitEnt = data.HitEntity
+    if nodetonate then self:Remove() return end
+
+    if (self.StartPos:DistToSqr(self:GetPos()) <= self.ArmDistanceSqr) or self.ProjectileSabotRound then
+        if self.ProjectileSabotRound then
+            self.ProjectileDamage = self.ProjectileDamage * 1.25
+        end
+        self:FireBullets({
+            Attacker = self.Owner,
+            Damage = self.ProjectileDamage * 0.85,
+            Tracer = 0,
+            Distance = 400,
+            Dir = (data.HitPos - self:GetPos()),
+            Src = self:GetPos(),
+            Callback = function(att, tr, dmg)
+                dmg:SetDamageType(self.ProjectileUnarmedDamageType)
+                dmg:SetAttacker(self.Owner)
+                dmg:SetInflictor(self)
+
+                hook.Run("Horde_OnExplosiveProjectileHeadshot", self.Owner, dmg)
+            end
+        })
+        self.Removing = true
+        self:Remove()
+        return
+    end
+
+    self:CustomOnExplode()
+
+    if self.Horde_Armor_Piercing then
+        self.ProjectileDamage = self.ProjectileDamage * 1.15
+        self.ProjectileDamageRadius = self.ProjectileDamageRadius * 0.7
+    end
+
+    self:FireBullets({
+		Attacker = self.Owner,
+		Damage = 0,
+		Tracer = 0,
+		Distance = 400,
+		Dir = (data.HitPos - self:GetPos()),
+		Src = self:GetPos(),
+		Callback = function(att, tr, dmg)
+			if tr.HitGroup == HITGROUP_HEAD then
+				dmg:SetDamageType(self.ProjectileExplosionDamageType)
+				dmg:SetAttacker(self.Owner)
+				dmg:SetInflictor(self)
+				dmg:SetDamage(self.ProjectileDamage / 2)
+                hook.Run("Horde_OnExplosiveProjectileHeadshot", self.Owner, dmg)
+			end
+
+            if self.Decal then
+                util.Decal(self.Decal, tr.StartPos, tr.HitPos - (tr.HitNormal * 16), self)
+            end
+		end
+	})
+    local dmg2 = DamageInfo()
+    dmg2:SetDamageType(self.ProjectileExplosionDamageType)
+    dmg2:SetAttacker(attacker)
+    dmg2:SetInflictor(self)
+    dmg2:SetDamage(self.ProjectileDamage)
+    util.BlastDamageInfo(dmg2, self:GetPos(), self.ProjectileDamageRadius)
+    hook.Run("Horde_PostExplosiveProjectileExplosion", self.Owner, self, dmg2, self.ProjectileDamageRadius)
+	hitEnt:Horde_AddDebuffBuildup(HORDE.Status_Shock, dmg2:GetDamage() * 0.75, attacker, dmg2:GetDamagePosition())
+    self.Removing = true
+    self:Remove()
+end

--- a/gamemodes/horde/entities/entities/horde_projectile_shock_round/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_projectile_shock_round/shared.lua
@@ -131,7 +131,7 @@ function ENT:Detonate(data)
     dmg2:SetDamage(self.ProjectileDamage)
     util.BlastDamageInfo(dmg2, self:GetPos(), self.ProjectileDamageRadius)
     hook.Run("Horde_PostExplosiveProjectileExplosion", self.Owner, self, dmg2, self.ProjectileDamageRadius)
-	hitEnt:Horde_AddDebuffBuildup(HORDE.Status_Shock, dmg2:GetDamage() * 0.75, attacker, dmg2:GetDamagePosition())
+    hitEnt:Horde_AddDebuffBuildup(HORDE.Status_Shock, dmg2:GetDamage() * 0.75, attacker, dmg2:GetDamagePosition())
     self.Removing = true
     self:Remove()
 end

--- a/gamemodes/horde/entities/weapons/arccw_horde_heat_crossbow.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_heat_crossbow.lua
@@ -51,12 +51,13 @@ SWEP.Primary.ClipSize = 1 -- DefaultClip is automatically set.
 SWEP.ExtendedClipSize = 1
 SWEP.ReducedClipSize = 1
 
-SWEP.Recoil = 1
-SWEP.RecoilSide = 1
-SWEP.VisualRecoilMult = 1
-SWEP.RecoilRise = 2
+SWEP.Recoil = 0
+SWEP.RecoilSide = 0
+SWEP.VisualRecoilMult = 0
+SWEP.RecoilRise = 0
+SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 600 -- 60 / RPM.
+SWEP.Delay = 0.75 -- 60 / RPM.
 SWEP.Num = 1 -- number of shots per trigger pull.
 SWEP.Firemodes = {
     {
@@ -65,16 +66,16 @@ SWEP.Firemodes = {
     },
     {
         Mode = 3,
-        PrintName = "Impact Mode"
+        PrintName = "Heat Mode"
     },
 }
 
 SWEP.NPCWeaponType = "weapon_crossbow"
 SWEP.NPCWeight = 75
 
-SWEP.AccuracyMOA = 10 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 150 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 250
+SWEP.AccuracyMOA = 0 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
+SWEP.HipDispersion = 0 -- inaccuracy added by hip firing.
+SWEP.MoveDispersion = 0
 
 SWEP.Primary.Ammo = "XBowBolt" -- what ammo type the gun uses
 
@@ -196,4 +197,11 @@ function SWEP:DrawWeaponSelection(x, y, w, h, a)
     surface.SetMaterial(self.WepSelectIconMat)
 
     surface.DrawTexturedRect(x, y, w, w / 2)
+end
+
+function SWEP:Hook_PostFireRocket(rocket)
+    if self.Owner:IsValid() and self.Owner:GetAmmoCount("XBowBolt") > 0 then
+    self:SetClip1(2)
+    self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("XBowBolt") - 1, "XBowBolt")
+    end
 end

--- a/gamemodes/horde/entities/weapons/horde_gluon.lua
+++ b/gamemodes/horde/entities/weapons/horde_gluon.lua
@@ -68,8 +68,8 @@ SWEP.Idle = 0
 SWEP.IdleTimer = CurTime()
 
 SWEP.Primary.Sound = Sound( "Weapon_HL_Gluon_Gun.Single" )
-SWEP.Primary.ClipSize = 50
-SWEP.Primary.DefaultClip = 50
+SWEP.Primary.ClipSize = 100
+SWEP.Primary.DefaultClip = 100
 SWEP.Primary.MaxAmmo = 9999
 SWEP.Primary.Automatic = true
 SWEP.Primary.Ammo = "GaussEnergy"
@@ -178,6 +178,10 @@ function SWEP:PrimaryAttack()
         self.Owner:SetAnimation( PLAYER_ATTACK1 )
         self.Sound = 1
         self.SoundTimer = CurTime() + 2
+    end
+    if self.Owner:IsValid() and self.Owner:GetAmmoCount("GaussEnergy") > 0 then
+    self:SetClip1(101)
+    self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("GaussEnergy") - 1, "GaussEnergy")
     end
     self:TakePrimaryAmmo( self.Primary.TakeAmmo )
     self:SetNextPrimaryFire( CurTime() + self.Primary.Delay )

--- a/gamemodes/horde/entities/weapons/horde_healingthrower.lua
+++ b/gamemodes/horde/entities/weapons/horde_healingthrower.lua
@@ -64,6 +64,10 @@ end
 function SWEP:PrimaryAttack()
     local owner = self:GetOwner()
     if (not self:CanPrimaryAttack()) then return end
+    if self.Owner:IsValid() and self.Owner:GetAmmoCount("horde_m2_flamethrower") > 0 then
+    self:SetClip1(101)
+    self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("horde_m2_flamethrower") - 1, "horde_m2_flamethrower")
+    end
     self:TakePrimaryAmmo(1)
     owner:MuzzleFlash()
     self:SetNextPrimaryFire( CurTime() + self.Delay )

--- a/gamemodes/horde/entities/weapons/horde_m2.lua
+++ b/gamemodes/horde/entities/weapons/horde_m2.lua
@@ -63,6 +63,11 @@ end
 function SWEP:PrimaryAttack()
     local owner = self:GetOwner()
     if (not self:CanPrimaryAttack()) then return end
+	
+    if self.Owner:IsValid() and self.Owner:GetAmmoCount("horde_m2_flamethrower") > 0 then
+    self:SetClip1(101)
+    self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("horde_m2_flamethrower") - 1, "horde_m2_flamethrower")
+    end
 
     self:TakePrimaryAmmo(1)
     owner:MuzzleFlash()

--- a/gamemodes/horde/entities/weapons/horde_tau.lua
+++ b/gamemodes/horde/entities/weapons/horde_tau.lua
@@ -189,6 +189,10 @@ function SWEP:PrimaryAttack()
     bullet.Callback = function (attacker, ttt, dmginfo)
         dmginfo:SetDamageType(DMG_BURN)
     end
+    if self.Owner:IsValid() and self.Owner:GetAmmoCount("GaussEnergy") > 0 then
+    self:SetClip1(31)
+    self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("GaussEnergy") - 1, "GaussEnergy")
+    end
     bullet.Num = self.Primary.NumberofShots
     bullet.Src = self.Owner:GetShootPos()
     bullet.Dir = self.Owner:GetAimVector()
@@ -296,12 +300,24 @@ function SWEP:Think()
         self.Owner:SetAnimation( PLAYER_ATTACK1 )
         self.Owner:MuzzleFlash()
         if self.SpinTimer > CurTime() + 6.5 and self.SpinTimer <= CurTime() + 7 then
+            if self.Owner:IsValid() and self.Owner:GetAmmoCount("GaussEnergy") > 0 then
+            self:SetClip1(35)
+            self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("GaussEnergy") - 5, "GaussEnergy")
+            end
             self:TakePrimaryAmmo(math.min(self.Weapon:Clip1(), self.Secondary.TakeAmmo ))
         end
         if self.SpinTimer > CurTime() + 6 and self.SpinTimer <= CurTime() + 6.5 then
+            if self.Owner:IsValid() and self.Owner:GetAmmoCount("GaussEnergy") > 0 then
+            self:SetClip1(35)
+            self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("GaussEnergy") - 5, "GaussEnergy")
+            end
             self:TakePrimaryAmmo( math.min(self.Weapon:Clip1(), 5 ) )
         end
         if self.SpinTimer <= CurTime() + 6 then
+            if self.Owner:IsValid() and self.Owner:GetAmmoCount("GaussEnergy") > 0 then
+            self:SetClip1(40)
+            self:GetOwner():SetAmmo(self.Owner:GetAmmoCount("GaussEnergy") - 10, "GaussEnergy")
+            end
             self:TakePrimaryAmmo( math.min(self.Weapon:Clip1(), 10 ) )
         end
         self:SetNextPrimaryFire( CurTime() + self.Primary.Delay )

--- a/gamemodes/horde/gamemode/gadgets/gadget_barbeque.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_barbeque.lua
@@ -1,15 +1,25 @@
 GADGET.PrintName = "Barbeque"
 GADGET.Description =
-[[Ignited enemies killed by you drop edible gibs.
-Each gib restores {1} health.]]
+[[Dealing Fire damage heals you for {1} of your max health.
+Ignited enemies killed by you drop edible gibs.
+Each gib restores {2} of your max health.]]
 GADGET.Icon = "items/gadgets/barbeque.png"
 GADGET.Duration = 0
 GADGET.Cooldown = 0
 GADGET.Active = false
 GADGET.Params = {
-    [1] = { value = 5 },
+    [1] = { value = 0.01, percent=true },
+    [2] = { value = 0.1, percent=true },
 }
 GADGET.Hooks = {}
+
+GADGET.Hooks.Horde_OnPlayerDamagePost = function (ply, npc, bonus, hitgroup, dmginfo)
+    if ply:Horde_GetGadget() ~= "gadget_barbeque"  then return end
+    if ply:Health() >= ply:GetMaxHealth() then return end
+    if HORDE:IsFireDamage(dmginfo) and not npc:IsPlayer() and ply:Alive() then
+    HORDE:SelfHeal(ply, ply:GetMaxHealth() * 0.01)
+    end
+end
 
 GADGET.Hooks.Horde_OnEnemyKilled = function(victim, killer, wpn)
     if killer:Horde_GetGadget() ~= "gadget_barbeque" then return end

--- a/gamemodes/horde/gamemode/languages/english.lua
+++ b/gamemodes/horde/gamemode/languages/english.lua
@@ -349,8 +349,9 @@ LANGUAGE["Perk_cremator_base"] = [[
 The Cremator builds its offense and defense around Fire damage.
 Complexity: EASY
 
-{8} increased Fire damage resistance.
+{8} increased Fire damage resistance and immune to Ignite.
 Attacks have {5} chance to Ignite enemies.
+Regenerate a Molotov every 45 seconds.
 {1} increased Ignite damage. ({3} per level, up to {4}).
 
 Ignite base duration is {6} and deals damage over time based on hit damage.
@@ -1170,7 +1171,7 @@ Shoots incendiary grenades the erupt into flames on impact.
 LANGUAGE["Item_Heat Crossbow"] = [[Heat Crossbow]]
 LANGUAGE["Item_Desc_Heat Crossbow"] = [[
 Improvised sniper weapon.
-Has two firemodes (Ballistic/Impact).
+Has two firemodes that can be swapped between to deal either Ballistic or Fire damage.
 
 Deals 300% headshot damage.
 ]]
@@ -1673,6 +1674,6 @@ Deals 20 base Ignite damage.
 
 LANGUAGE["Gadget_barbeque"] = [[Barbeque]]
 LANGUAGE["Gadget_Desc_gadget_barbeque"] = [[
+Dealing Fire damage heals you for {1} of your max health.
 Ignited enemies killed by you drop edible gibs.
-Each gib restores 5 health.
-]]
+Each gib restores {2} of your max health.]]

--- a/gamemodes/horde/gamemode/perks/cremator/cremator_base.lua
+++ b/gamemodes/horde/gamemode/perks/cremator/cremator_base.lua
@@ -3,7 +3,8 @@ PERK.Description = [[
 The Cremator builds its offense and defense around Fire damage.
 Complexity: EASY
 
-{8} increased Fire damage resistance.
+{8} increased Fire damage resistance and immune to Ignite.
+Regenerate a Molotov every 45 seconds.
 Attacks have {5} chance to Ignite enemies.
 {1} increased Ignite damage. ({3} per level, up to {4}).
 

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -508,8 +508,8 @@ function HORDE:GetDefaultItemsData()
     {Assault=true, Warden=true}, 10, 10, nil, nil, {Assault=2, Warden=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING})
     HORDE:CreateItem("Rifle",      "SCAR-L",         "arccw_horde_scarl", 3500, 8, "FN SCAR-L.\nAn assault rifle developed by Belgian manufacturer FN Herstal.\nLight version, chambered in 5.56x45mm NATO. \nEquipped with an M203 underbarrel cryo grenade launcher.\nPress USE+RELOAD to equip M203.",
     {Assault=true, Ghost=true}, 15, 10, nil, nil, {Assault=2, Ghost=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_COLD})
-    HORDE:CreateItem("Rifle",      "OSIPR",          "arccw_horde_ar2",   3500, 9, "Overwatch Standard Issue Pulse Rifle.\n\nPress ZOOM or B to change firemode.\nFires regular ballistic ammo or energy balls.",
-    {Assault=true}, 15, -1, nil, "items/hl2/weapon_ar2.png", {Assault=5}, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem("Rifle",      "OSIPR",          "arccw_horde_ar2",   3500, 9, "Overwatch Standard Issue Pulse Rifle.\n\nPress ZOOM or B to change firemode.\nFires regular ballistic ammo or energy balls that deal Lightning damage and builds up Shock.",
+    {Assault=true}, 15, -1, nil, "items/hl2/weapon_ar2.png", {Assault=5}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING})
 
     HORDE:CreateItem("Rifle",      "Winchester LAR",     "arccw_horde_winchester",1000, 4, "Winchester Lever Action Rifle.\nAn all-time classic.",
     {Survivor=true, Ghost=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
@@ -663,8 +663,8 @@ function HORDE:GetDefaultItemsData()
     HORDE:CreateItem("Special",    "Watchtower Type-Beacon",  "horde_watchtower_beacon", 2000,  4, "A watchtower that acts as a shop during waves.\nProvides additional lighting.\n(Entity Class: horde_watchtower_beacon)",
     {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=1}, "items/horde_watchtower.png", nil, nil, nil)
 
-    HORDE:CreateItem("Special",    "Heat Crossbow",  "arccw_horde_heat_crossbow", 1750,  4, "Improvised sniper weapon.\nHas two firemodes (Ballistic/Impact).\n\nDeals 300% headshot damage.",
-    {Survivor=true, Ghost=true}, 2, -1, nil, "items/hl2/weapon_crossbow.png", nil, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem("Special",    "Heat Crossbow",  "arccw_horde_heat_crossbow", 2000,  5, "Improvised sniper weapon.\nHas two firemodes that can be swapped between to deal either Ballistic or Fire damage.\n\nDeals 300% headshot damage.",
+    {Survivor=true, Ghost=true, Cremator=true}, 1, -1, nil, "items/hl2/weapon_crossbow.png", nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_FIRE})
     HORDE:CreateItem("Special",    "M2 Flamethrower", "horde_m2",            2500,  7, "M2-2 Flamethrower.\nAn American man-portable backpack flamethrower.",
     {Cremator=true}, 50, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE})
     HORDE:CreateItem("Special",    "Tau Cannon",      "horde_tau",         3000,  7, "A device that uses electromagnetism to ionize particles.\nHold RMB to charge and release a powerful shot.\nDeals more damage as you charge.\nDevice explodes if you overcharge.",


### PR DESCRIPTION
Tavor and Scar-L's elemental grenades now build up status effects of their respective element type

Gluon Gun, M2 Flamethrower, M2 Health Thrower, Heat Blaster and Tau Cannon now all take ammo from reserve when shooting

Gluon Gun clip sized increased to 100

Heat Blaster's velocity increased to be the same as the M79

Fixed Barbeque's description not mentioning the new healing changes, added a check to make the gibs ignore full health players, increased gib lifetime from 5 seconds to 15 seconds, now makes Fire damage you deal heal you for 1% of your max health

Fixed AR2 not mentioning Lightning damage and shock buildup in its shop description

Fixed Cremator's description not mentioning Ignite immunity and Molotov regen

Reworked Heat Crossbow to have the same damage type as its original implementation (Ballistic / Fire) instead of the edit (Ballistic / Direct), now draws ammo directly from reserve, removed recoil and is now perfectly accurate, fixed player collision, reduced damage from 300 to 200, added to Cremator's shop, added some nice effects to make it prettier depending on the firing mode, cleaned up the code, increased weight to 5 and price to 2000, increased firerate from 0.1 to 0.75, reduced ammo cost to 1