### PR TITLE
Elemental Grenade update 

### DIFF
--- a/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_emp/shared.lua
@@ -56,7 +56,7 @@ function ENT:Think()
 end
 
 function ENT:Explode()
-    if !self:IsValid() then return end
+    if not self:IsValid() then return end
     self:EmitSound("ambient/levels/labs/electric_explosion1.wav", 100, 100, 1, CHAN_ITEM)
 
     local attacker = self
@@ -68,17 +68,17 @@ function ENT:Explode()
     for _, e in pairs(ents.FindInSphere(self:GetPos(), 200)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
             for i = 1, 15 do
-                local dmginfo = DamageInfo()
-                dmginfo:SetDamage(8)
-                dmginfo:SetDamageType(DMG_SHOCK)
-                dmginfo:SetAttacker(attacker)
-                dmginfo:SetInflictor(self)
-                dmginfo:SetDamagePosition(e:GetPos())
-                e:TakeDamageInfo(dmginfo)
+                local dmg = DamageInfo()
+                dmg:SetDamage(10)
+                dmg:SetDamageType(DMG_SHOCK)
+                dmg:SetAttacker(attacker)
+                dmg:SetInflictor(self)
+                dmg:SetDamagePosition(e:GetPos())
+                e:TakeDamageInfo(dmg)
+                e:Horde_AddDebuffBuildup(HORDE.Status_Shock, dmg:GetDamage(), attacker, self:GetPos())
             end
         end
     end
-
 
     local ed = EffectData()
     ed:SetOrigin(self:GetPos())
@@ -86,9 +86,7 @@ function ENT:Explode()
 end
 
 function ENT:Detonate()
-    if !self:IsValid() then return end
-    if self.Detonated then return end
-    if !self.Armed then return end
+    if not self:IsValid() or self.Detonated or not self.Armed then return end
 
     self.Armed = false
     self.Detonated = true

--- a/gamemodes/horde/entities/entities/arccw_thr_hemo/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_hemo/shared.lua
@@ -66,16 +66,17 @@ function ENT:Explode()
     if self:GetOwner():IsValid() then
         attacker = self:GetOwner()
     end
+    local dmg = DamageInfo()
+    dmg:SetDamage(170)
+    dmg:SetDamageType(DMG_SLASH)
+    dmg:SetAttacker(attacker)
+    dmg:SetInflictor(self)
+    dmg:SetDamagePosition(self:GetPos())
+    util.BlastDamageInfo(dmg, self:GetPos(), 240)
     for _, e in pairs(ents.FindInSphere(self:GetPos(), 240)) do
         if IsValid(e) and HORDE:IsEnemy(e) then
-            local dmg = DamageInfo()
-            dmg:SetDamage(170)
-            dmg:SetDamageType(DMG_SLASH)
-            dmg:SetAttacker(attacker)
-            dmg:SetInflictor(self)
-            dmg:SetDamagePosition(self:GetPos())
-            e:TakeDamageInfo(dmg)
-            e:Horde_AddDebuffBuildup(HORDE.Status_Bleeding, dmg:GetDamage(), attacker, self:GetPos())
+            local damageDealt = dmg:GetDamage() * 0.75
+            e:Horde_AddDebuffBuildup(HORDE.Status_Bleeding, damageDealt, attacker, self:GetPos())
         end
     end
 

--- a/gamemodes/horde/entities/entities/arccw_thr_medicgrenade/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_thr_medicgrenade/shared.lua
@@ -40,12 +40,13 @@ function entmeta:Horde_AddEffect_MedicGrenade(ent)
             HORDE:OnAntlionHeal(ent, healinfo)
         elseif ent:IsValid() and ent.Owner:IsValid() and ent.Inflictor:IsValid() and self:IsNPC() and (not self:GetNWEntity("HordeOwner"):IsValid()) then
             local d = DamageInfo()
-            d:SetDamage(25)
+            d:SetDamage(12)
             d:SetAttacker(ent.Owner)
             d:SetInflictor(ent.Inflictor)
             d:SetDamageType(DMG_NERVEGAS)
             d:SetDamagePosition(self:GetPos())
             self:TakeDamageInfo(d)
+            self:Horde_AddDebuffBuildup(HORDE.Status_Break, d:GetDamage(), ent:GetOwner(), self:GetPos())
         end
     end)
 end
@@ -85,7 +86,7 @@ function ENT:Initialize()
         self.SpawnTime = CurTime()
 
         timer.Simple(0, function()
-            if !IsValid(self) then return end
+            if not IsValid(self) then return end
             self:SetCollisionGroup(COLLISION_GROUP_PLAYER_MOVEMENT)
         end)
     end
@@ -124,9 +125,9 @@ function ENT:EndTouch(ent)
 end
 
 function ENT:Think()
-    if !self.SpawnTime then self.SpawnTime = CurTime() end
+    if not self.SpawnTime then self.SpawnTime = CurTime() end
 
-    if SERVER and CurTime() - self.SpawnTime >= self.FuseTime and !self.Armed then
+    if SERVER and CurTime() - self.SpawnTime >= self.FuseTime and not self.Armed then
         self:Detonate()
         self:SetArmed(true)
     end
@@ -156,7 +157,7 @@ function ENT:Think()
                 smoke:SetBounce(0)
                 smoke:SetNextThink(CurTime() + FrameTime())
                 smoke:SetThinkFunction( function(pa)
-                    if !pa then return end
+                    if not pa then return end
                     local col1 = Color(105, 255, 50)
                     local col2 = Color(50, 200, 50)
 
@@ -171,8 +172,8 @@ function ENT:Think()
                 end)
             end
 
-            if !self:IsValid() or self:WaterLevel() > 2 then return end
-            if !IsValid(emitter) then return end
+            if not self:IsValid() or self:WaterLevel() > 2 then return end
+            if not IsValid(emitter) then return end
 
             self.Ticks = self.Ticks + 1
         end
@@ -189,7 +190,7 @@ function ENT:OnRemove()
 end
 
 function ENT:Detonate()
-    if !self:IsValid() then return end
+    if not self:IsValid() then return end
 
     self.Armed = true
     self:EmitSound("arccw_go/smokegrenade/smoke_emit.wav", 90, 100, 1, CHAN_AUTO)
@@ -209,6 +210,6 @@ function ENT:Draw()
     if CLIENT then
         self:DrawModel()
 
-        if !self:GetArmed() then return end
+        if not self:GetArmed() then return end
     end
 end

--- a/gamemodes/horde/entities/entities/arccw_ubgl_medicgrenade/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_ubgl_medicgrenade/shared.lua
@@ -2,7 +2,7 @@ if not ArcCWInstalled then return end
 -- Referenced From GSO
 ENT.Type = "anim"
 ENT.Base = "base_entity"
-ENT.PrintName = "Medic Grenade"
+ENT.PrintName = "UBGL Medic Grenade"
 ENT.Author = ""
 ENT.Information = ""
 ENT.Spawnable = false
@@ -26,35 +26,36 @@ AddCSLuaFile()
 
 local entmeta = FindMetaTable("Entity")
 
-function entmeta:Horde_AddEffect_MedicGrenade(ent)
+function entmeta:Horde_AddEffect_UBGLMedicGrenade(ent)
     local owner = self:GetOwner()
-    if self.horde_effect_medicgrenade then return end
-    self.horde_effect_medicgrenade = true
+    if self.horde_effect_ubglmedicgrenade then return end
+    self.horde_effect_ubglmedicgrenade = true
     local id = self:GetCreationID()
-    timer.Create("Horde_MedicGrenadeEffect" .. id, 0.5, 0, function ()
-        if not self:IsValid() then timer.Remove("Horde_MedicGrenadeEffect" .. id) return end
+    timer.Create("Horde_UBGLMedicGrenadeEffect" .. id, 0.5, 0, function ()
+        if not self:IsValid() then timer.Remove("Horde_UBGLMedicGrenadeEffect" .. id) return end
         if self:IsPlayer() then
-            local healinfo = HealInfo:New({amount = 4, healer = ent.Owner})
+            local healinfo = HealInfo:New({amount = 15, healer = ent.Owner})
             HORDE:OnPlayerHeal(self, healinfo)
         elseif ent:GetClass() == "npc_vj_horde_antlion" then
-            local healinfo = HealInfo:New({amount = 4, healer = owner})
+            local healinfo = HealInfo:New({amount = 10, healer = owner})
             HORDE:OnAntlionHeal(ent, healinfo)
         elseif ent:IsValid() and ent.Owner:IsValid() and ent.Inflictor:IsValid() and self:IsNPC() and (not self:GetNWEntity("HordeOwner"):IsValid()) then
             local d = DamageInfo()
-            d:SetDamage(25)
+            d:SetDamage(20)
             d:SetAttacker(ent.Owner)
             d:SetInflictor(ent.Inflictor)
             d:SetDamageType(DMG_NERVEGAS)
             d:SetDamagePosition(self:GetPos())
             self:TakeDamageInfo(d)
+            self:Horde_AddDebuffBuildup(HORDE.Status_Break, d:GetDamage() * 0.8, ent:GetOwner(), self:GetPos())
         end
     end)
 end
 
-function entmeta:Horde_RemoveEffect_MedicGrenade()
-    if self.horde_effect_medicgrenade then
-        timer.Remove("Horde_MedicGrenadeEffect" .. self:GetCreationID())
-        self.horde_effect_medicgrenade = nil
+function entmeta:Horde_RemoveEffect_UBGLMedicGrenade()
+    if self.horde_effect_ubglmedicgrenade then
+        timer.Remove("Horde_UBGLMedicGrenadeEffect" .. self:GetCreationID())
+        self.horde_effect_ubglmedicgrenade = nil
     end
 end
 
@@ -109,10 +110,10 @@ end
 
 function ENT:Touch(ent)
     if SERVER then
-        if self.TouchedEntities[ent:GetCreationID()] and ent.horde_effect_medicgrenade then return end
+        if self.TouchedEntities[ent:GetCreationID()] and ent.horde_effect_ubglmedicgrenade then return end
         if self:GetArmed() and (ent:IsPlayer() or ent:IsNPC()) then
             self.TouchedEntities[ent:GetCreationID()] = ent
-            ent:Horde_AddEffect_MedicGrenade(self)
+            ent:Horde_AddEffect_UBGLMedicGrenade(self)
         end
     end
 end
@@ -121,7 +122,7 @@ function ENT:EndTouch(ent)
     if SERVER then
         if not (ent:IsNPC() or ent:IsPlayer()) then return end
         self.TouchedEntities[ent:GetCreationID()] = nil
-        ent:Horde_RemoveEffect_MedicGrenade()
+        ent:Horde_RemoveEffect_UBGLMedicGrenade()
     end
 end
 
@@ -179,7 +180,7 @@ end
 function ENT:OnRemove()
     if SERVER then
         for _, ent in pairs(self.TouchedEntities) do
-            if ent:IsValid() then ent:Horde_RemoveEffect_MedicGrenade() end
+            if ent:IsValid() then ent:Horde_RemoveEffect_UBGLMedicGrenade() end
         end
     end
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_aegis.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_aegis.lua
@@ -37,3 +37,17 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
         end
     end
 end
+
+GADGET.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmg, bonus)
+    if ply.Horde_Aegis then
+        dmg:SetDamage(0)
+        return true
+    end
+end
+
+GADGET.Hooks.Horde_OnPlayerDebuffApply = function (ply, debuff, bonus)
+    if ply.Horde_Aegis then
+        bonus.apply = 0
+        return true
+    end
+end


### PR DESCRIPTION
### Elemental Grenade Update
**Warden:**
- **EMP Grenade** damage increased from 8 to 10
- **EMP Grenade** now inflicts 100% of damage as Shock buildup

**Medic:**
- **Medic Grenade** damage reduced from 25 to 12
- **Medic Grenade** now inflicts 100% of damage as Break buildup
- **UBGL Grenade** damage reduced from 25 to 20
- **UBGL Grenade** now inflicts 80% of damage as Break buildup
- **UBGL Grenade** healing increased from 4 to 15
- **UBGL Grenade** antlion healing increased from 4 to 10
- **Medic RPG** damage remains unchanged at 50
- **Medic RPG** now inflicts 50% of damage as Break buildup
- **Medic RPG** healing decreased from 30 to 20
- **Medic RPG** antlion healing reduced from 30 to 15

**Berserker:**
- **Hemo Grenade** now inflicts 75% of damage dealt as Bleed buildup