### PR TITLE
Revert Minion Collision

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_class_assault/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_class_assault/init.lua
@@ -37,7 +37,7 @@ ENT.SoundTbl_Death = {"player/pl_pain5.wav","player/pl_pain6.wav","player/pl_pai
 -----------------------------------------------*/
 function ENT:CustomOnInitialize()
 	self:Give("weapon_vj_horde_m16m203")
-	self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+	self:SetCollisionBounds(Vector(0,0,0), Vector(0,0,0))
 end
 function ENT:DoRelationshipCheck(ent)
     if ent:IsPlayer() or ent:GetNWEntity("HordeOwner"):IsValid() then return false end

--- a/gamemodes/horde/entities/entities/npc_vj_horde_class_survivor/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_class_survivor/init.lua
@@ -37,7 +37,7 @@ ENT.SoundTbl_Death = {"player/pl_pain5.wav","player/pl_pain6.wav","player/pl_pai
 -----------------------------------------------*/
 function ENT:CustomOnInitialize()
 	self:Give("weapon_vj_horde_ar15")
-	self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+	self:SetCollisionBounds(Vector(0,0,0), Vector(0,0,0))
 end
 function ENT:DoRelationshipCheck(ent)
     if ent:IsPlayer() or ent:GetNWEntity("HordeOwner"):IsValid() then return false end

--- a/gamemodes/horde/entities/entities/npc_vj_horde_combat_bot/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_combat_bot/init.lua
@@ -133,6 +133,7 @@ local extraSounds = {"physics/concrete/concrete_block_impact_hard1.wav", "physic
 
 function ENT:CustomOnInitialize()
 	self:SetColor(Color(0,150,255))
+	self:SetCollisionBounds(Vector(0,0,0), Vector(0,0,0))
 end
 
 function ENT:CustomOnMeleeAttack_AfterChecks(hitEnt, isProp)

--- a/gamemodes/horde/entities/entities/npc_vj_horde_combat_bot/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_combat_bot/init.lua
@@ -133,7 +133,6 @@ local extraSounds = {"physics/concrete/concrete_block_impact_hard1.wav", "physic
 
 function ENT:CustomOnInitialize()
 	self:SetColor(Color(0,150,255))
-	self:SetCollisionBounds(Vector(0,0,0), Vector(0,0,0))
 end
 
 function ENT:CustomOnMeleeAttack_AfterChecks(hitEnt, isProp)

--- a/gamemodes/horde/entities/entities/npc_vj_horde_vortigaunt/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_vortigaunt/init.lua
@@ -99,7 +99,7 @@ ENT.DisableDefaultRangeAttackCode = true
 ENT.DisableMakingSelfEnemyToNPCs = true
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:CustomOnInitialize()
-    self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+    self:SetCollisionBounds(Vector(0,0,0), Vector(0,0,0))
 end
 
 function ENT:OnRemove()


### PR DESCRIPTION
Doing this because collision group debris doesn't stop the NPCs from getting stuck inside each other, this will have to suffice for now until i can figure out a solution to replace it that's better.

Also thing is the problem is only prominent in VJ Base 2.16.0. The 3.0.0 update improved AI behavior and stopped NPCs from getting stuck in each other in pretty much all cases. So if Redox wanted to add support for 3.0.0, it'd be a good thing for all of the ai around the board, and improve performance.