### PR TITLE
SLAM & Tripmine failsafe

### DIFF
--- a/gamemodes/horde/gamemode/status/debuff/sv_debuff.lua
+++ b/gamemodes/horde/gamemode/status/debuff/sv_debuff.lua
@@ -68,6 +68,7 @@ function entmeta:Horde_AddDebuffBuildup(debuff, buildup, inflictor, pos)
     if self.Horde_Debuff_Cooldown[debuff] then return end
     if self.Horde_Debuff_Active[debuff] then return end
     if not self.Horde_Debuff_Buildup[debuff] then self.Horde_Debuff_Buildup[debuff] = 0 end
+    if not IsValid(self) then return end
     if self:IsPlayer() then
         if self.Horde_Debuff_Buildup[debuff] >= 100 then return end
         local bonus = {apply = 1, less = 1, add = 0}

--- a/gamemodes/horde/gamemode/sv_misc.lua
+++ b/gamemodes/horde/gamemode/sv_misc.lua
@@ -75,15 +75,27 @@ hook.Add("EntityTakeDamage", "ManhackContactDamage", function (target, dmginfo)
 end)
 
 function HORDE:IsPlayerOrMinion(ent)
-    return ent:IsPlayer() or ent:GetNWEntity("HordeOwner"):IsValid()
+    if not IsValid(ent) then
+        return false
+    end
+    local owner = ent:GetNWEntity("HordeOwner", nil)
+    return ent:IsPlayer() or (IsValid(owner) and owner:IsPlayer())
 end
 
 function HORDE:IsPlayerMinion(ent)
-    return ent:GetNWEntity("HordeOwner"):IsValid()
+    if not IsValid(ent) then
+        return false
+    end
+    local owner = ent:GetNWEntity("HordeOwner", nil)
+    return IsValid(owner) and owner:IsPlayer()
 end
 
 function HORDE:IsEnemy(ent)
-    return ent:IsNPC() and (not ent:IsPlayer()) and (not ent:GetNWEntity("HordeOwner"):IsValid())
+    if not IsValid(ent) then
+        return false
+    end
+    local owner = ent:GetNWEntity("HordeOwner", nil)
+    return ent:IsNPC() and not ent:IsPlayer() and not (IsValid(owner) and owner:IsPlayer())
 end
 
 function HORDE:SpawnManhack(ply, id)


### PR DESCRIPTION
Added a failsafe to remove the error spam when a debuff is attempted to be applied to an object.
Not 100% sure if it will solve the problem cause testing this is really difficult.