### PR TITLE
Minion Damage Fix

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_class_assault/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_class_assault/init.lua
@@ -28,6 +28,7 @@ ENT.DropWeaponOnDeath = false
 
 ENT.HasMeleeAttack = true
 
+ENT.DisableWeaponReloadAnimation = true
 ENT.WeaponReload_FindCover = false
 
 ENT.WaitForEnemyToComeOut = false

--- a/gamemodes/horde/entities/entities/npc_vj_horde_class_assault/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_class_assault/init.lua
@@ -20,6 +20,8 @@ ENT.CanThrowBackDetectedGrenades = false
 
 ENT.BloodColor = "Red"
 
+ENT.Immune_AcidPoisonRadiation = true
+
 ENT.MoveOrHideOnDamageByEnemy_OnlyMove = true
 
 ENT.DropWeaponOnDeath = false

--- a/gamemodes/horde/entities/entities/npc_vj_horde_class_survivor/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_class_survivor/init.lua
@@ -28,6 +28,7 @@ ENT.DropWeaponOnDeath = false
 
 ENT.HasMeleeAttack = true
 
+ENT.DisableWeaponReloadAnimation = true
 ENT.WeaponReload_FindCover = false
 
 ENT.WaitForEnemyToComeOut = false

--- a/gamemodes/horde/entities/entities/npc_vj_horde_class_survivor/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_class_survivor/init.lua
@@ -20,6 +20,8 @@ ENT.CanThrowBackDetectedGrenades = false
 
 ENT.BloodColor = "Red"
 
+ENT.Immune_AcidPoisonRadiation = true
+
 ENT.MoveOrHideOnDamageByEnemy_OnlyMove = true
 
 ENT.DropWeaponOnDeath = false

--- a/gamemodes/horde/entities/entities/npc_vj_horde_vortigaunt/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_vortigaunt/init.lua
@@ -18,15 +18,14 @@ ENT.ConstantlyFaceEnemy = true
 
 ENT.BloodColor = "Yellow"
 
+ENT.Immune_AcidPoisonRadiation = true
+
 ENT.RunAwayOnUnknownDamage = false
 
 ENT.HasMeleeAttack = false
 
 ENT.HasRangeAttack = true
 ENT.RangeAttackEntityToSpawn = nil
-
-ENT.AnimTbl_RangeAttack = {"vjges_g_zapattack1"}
-ENT.RangeAttackAnimationStopMovement = false
 
 ENT.RangeDistance = 5000
 ENT.RangeToMeleeDistance = 10

--- a/gamemodes/horde/entities/entities/npc_vj_horde_vortigaunt/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_vortigaunt/init.lua
@@ -67,7 +67,7 @@ function ENT:CustomRangeAttackCode()
         local chargeSound = CreateSound(self, "npc/vort/attack_charge.wav");
         chargeSound:Play()
         local pos = ene:GetPos() + ene:OBBCenter()
-        timer.Simple(0.5 / self.AnimationPlaybackRate, function ()
+        timer.Simple(1.0 / self.AnimationPlaybackRate, function ()
             if not self:IsValid() then
                 chargeSound:Stop()
                 return


### PR DESCRIPTION
Minions should not take poison, acid, or radiation damage. Makes them stupidly vulnerable and unbalanced. So I added it back to Assault, Survivor, and Vortigaunt minions.

Also made a few small changes.