### PR TITLE
masterkey/fucket tweaks

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_fucket.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_fucket.lua
@@ -25,7 +25,7 @@ SWEP.DamageMin = 150 -- damage done at maximum range
 SWEP.Range = 150 -- in METRES
 SWEP.Penetration = 22
 SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 0.5
+SWEP.Recoil = 1
 SWEP.RecoilSide = 0
 
 SWEP.IsShotgun = false
@@ -33,7 +33,7 @@ SWEP.IsShotgun = false
 SWEP.Delay = 60 / 400 -- 60 / RPM.
 
 SWEP.AccuracyMOA = 0.06 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 800 -- inaccuracy added by hip firing.
+SWEP.HipDispersion = 250 -- inaccuracy added by hip firing.
 
 SWEP.ShootVol = 75 -- volume of shoot sound
 
@@ -128,11 +128,11 @@ SWEP.Attachments = {
 }
 function SWEP:Hook_ShouldNotFireFirst()
     if self:GetCurrentFiremode().Mode == 3 then
-        self.AccuracyMOA = 2
+        self.AccuracyMOA = 1.5
         self.AmmoPerShot = 2
         self.Num = 2 -- number of shots per trigger pull.
     else
-        self.AccuracyMOA = 1
+        self.AccuracyMOA = 0.06
         self.AmmoPerShot = 1
         self.Num = 1 -- number of shots per trigger pull.
     end

--- a/gamemodes/horde/entities/weapons/arccw_horde_fucket_rifle.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_fucket_rifle.lua
@@ -25,7 +25,7 @@ SWEP.DamageMin = 200 -- damage done at maximum range
 SWEP.Range = 150 -- in METRES
 SWEP.Penetration = 22
 SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 0.5
+SWEP.Recoil = 1
 SWEP.RecoilSide = 0
 
 SWEP.IsShotgun = false
@@ -33,8 +33,8 @@ SWEP.IsShotgun = false
 
 SWEP.Delay = 60 / 400 -- 60 / RPM.
 
-SWEP.AccuracyMOA = 0.06 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 800 -- inaccuracy added by hip firing.
+SWEP.AccuracyMOA = 0.12 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
+SWEP.HipDispersion = 400 -- inaccuracy added by hip firing.
 
 SWEP.ShootVol = 75 -- volume of shoot sound
 
@@ -129,11 +129,11 @@ SWEP.Attachments = {
 }
 function SWEP:Hook_ShouldNotFireFirst()
     if self:GetCurrentFiremode().Mode == 3 then
-        self.AccuracyMOA = 2
+        self.AccuracyMOA = 1.75
         self.AmmoPerShot = 2
         self.Num = 2 -- number of shots per trigger pull.
     else
-        self.AccuracyMOA = 1
+        self.AccuracyMOA = 0.12
         self.AmmoPerShot = 1
         self.Num = 1 -- number of shots per trigger pull.
     end

--- a/gamemodes/horde/entities/weapons/arccw_horde_masterkey.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_masterkey.lua
@@ -12,7 +12,7 @@ SWEP.Category = "ArcCW - Horde" -- edit this if you like
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "Masterkey"
-SWEP.Slot = 2
+SWEP.Slot = 1
 SWEP.ViewModel = "models/weapons/arccw/fesiugmw2/c_mifl_masterkey_1.mdl"
 SWEP.MirrorVMWM = true
 SWEP.WorldModelOffset = {
@@ -45,7 +45,7 @@ SWEP.Delay = 60 / 180 -- 60 / RPM.
 SWEP.Num = 8 -- number of shots per trigger pull.
 SWEP.AccuracyMOA = 75 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
 SWEP.HipDispersion = 85 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 75 -- inaccuracy added by moving. Applies in sights as well! Walking speed is considered as "maximum".
+SWEP.MoveDispersion = 50 -- inaccuracy added by moving. Applies in sights as well! Walking speed is considered as "maximum".
 SWEP.SightsDispersion = 0 -- dispersion that remains even in sights
 
 SWEP.SpeedMult = 1.15


### PR DESCRIPTION
> Masterkey
• shifted to the same weapon slot pistols typically use 
• lowered movedispersion from 75 -> 50

> Fucket (Gunslinger)
• increased recoil from 0.5 -> 1
• lowered hip dispersion from 800 -> 250 so its much more accurate from the hip to fit gunslinger more thematically 
• single shot accuracy now uses its appropriate value of 0.06 
• double shot accuracy has been changed from 2 -> 1.5 MOA to make the double shot much more consistent at further ranges

> Fucket (Survivor)
• increased recoil from 0.5 -> 1
• lowered hip dispersion from 800 -> 400
• reduced accuracy from 0.06 -> 0.12
• made single shot use the proper accuracy value of 0.12 • double shot accuracy changed from 2 MOA -> 1.75 MOA
