### PR TITLE
healththrower particle changes

### DIFF
--- a/gamemodes/horde/entities/effects/medic_flame.lua
+++ b/gamemodes/horde/entities/effects/medic_flame.lua
@@ -2,51 +2,41 @@ function EFFECT:Init(data)
 	local Startpos = self:GetTracerShootPos(self.Position, data:GetEntity(), data:GetAttachment())
 	local Hitpos = data:GetOrigin()
 	local ent = data:GetEntity()
-    if not IsValid(ent) then return end
+	if not IsValid(ent) then return end
 
-    local owner = ent.Owner
-	local has_burner = nil
-	if IsValid( owner ) and owner:Horde_GetGadget() == "gadget_hydrogen_burner" then
-		has_burner = true
-	end
-
-	if data:GetEntity():IsValid() && Startpos && Hitpos then
+	if data:GetEntity():IsValid() and Startpos and Hitpos then
 		self.Emitter = ParticleEmitter(Startpos)
 
 
 		for i = 1, 20 do
-			local p = self.Emitter:Add("particles/flamelet1", Startpos)
-			if not has_burner then
-				p:SetColor(105, 255, 50)
-			else
-				p:SetColor(0,100,255)
-			end
-			p:SetDieTime(1)
-			p:SetStartAlpha(100)
-			p:SetEndAlpha(0)
-			p:SetStartSize(math.Rand(0.8, 1.5))
-			p:SetEndSize(math.random(50, 75))
-			p:SetRoll(math.random(-10, 10))
-			p:SetRollDelta(math.random(-10, 10))
-			p:SetVelocity(((Hitpos - Startpos):GetNormal() * math.random(500, 800)) + VectorRand() * math.random(1, 20))
-			p:SetCollide(true)
-			p:SetCollideCallback(function()
-			p:SetDieTime(0)
+			local gflame = self.Emitter:Add("particles/flamelet1", Startpos)
+			gflame:SetColor(0,100,255)
+			gflame:SetDieTime(1)
+			gflame:SetStartAlpha(100)
+			gflame:SetEndAlpha(0)
+			gflame:SetStartSize(math.Rand(0.8, 1.5))
+			gflame:SetEndSize(math.random(50, 75))
+			gflame:SetRoll(math.random(-10, 10))
+			gflame:SetRollDelta(math.random(-10, 10))
+			gflame:SetVelocity(((Hitpos - Startpos):GetNormal() * math.random(500, 800)) + VectorRand() * math.random(1, 20))
+			gflame:SetCollide(true)
+			gflame:SetCollideCallback(function()
+			gflame:SetDieTime(0)
 			end)
 		end
 
 		for i = 1, 2 do
-			local p = self.Emitter:Add("particles/smokey", Startpos)
-			p:SetDieTime(1.5)
-			p:SetStartAlpha(50)
-			p:SetEndAlpha(0)
-			p:SetStartSize(math.Rand(2, 4))
-			p:SetEndSize(math.random(70, 90))
-			p:SetRoll(math.random(-10, 10))
-			p:SetRollDelta(math.random(-10, 10))
-			p:SetVelocity(((Hitpos - Startpos):GetNormal() * math.random(500, 800)) + VectorRand() * math.random(1, 60) + Vector(0,0,20))
-			p:SetCollide(true)
-			p:SetColor(40, 40, 40)
+			local smoke = self.Emitter:Add("particles/smokey", Startpos)
+			smoke:SetDieTime(1.5)
+			smoke:SetStartAlpha(50)
+			smoke:SetEndAlpha(0)
+			smoke:SetStartSize(math.Rand(2, 4))
+			smoke:SetEndSize(math.random(70, 90))
+			smoke:SetRoll(math.random(-10, 10))
+			smoke:SetRollDelta(math.random(-10, 10))
+			smoke:SetVelocity(((Hitpos - Startpos):GetNormal() * math.random(500, 800)) + VectorRand() * math.random(1, 60) + Vector(0,0,20))
+			smoke:SetCollide(true)
+			smoke:SetColor(40, 40, 40)
 		end
 
 		self.Emitter:Finish()

--- a/gamemodes/horde/entities/effects/medic_flame.lua
+++ b/gamemodes/horde/entities/effects/medic_flame.lua
@@ -25,20 +25,6 @@ function EFFECT:Init(data)
 			end)
 		end
 
-		for i = 1, 2 do
-			local smoke = self.Emitter:Add("particles/smokey", Startpos)
-			smoke:SetDieTime(1.5)
-			smoke:SetStartAlpha(50)
-			smoke:SetEndAlpha(0)
-			smoke:SetStartSize(math.Rand(2, 4))
-			smoke:SetEndSize(math.random(70, 90))
-			smoke:SetRoll(math.random(-10, 10))
-			smoke:SetRollDelta(math.random(-10, 10))
-			smoke:SetVelocity(((Hitpos - Startpos):GetNormal() * math.random(500, 800)) + VectorRand() * math.random(1, 60) + Vector(0,0,20))
-			smoke:SetCollide(true)
-			smoke:SetColor(40, 40, 40)
-		end
-
 		self.Emitter:Finish()
 	end
 end

--- a/gamemodes/horde/entities/effects/medic_flame_explosion.lua
+++ b/gamemodes/horde/entities/effects/medic_flame_explosion.lua
@@ -1,25 +1,14 @@
 function EFFECT:Init(data)
-    local owner = data:GetEntity()
-	local has_burner = nil
-	if owner and owner:IsPlayer() and owner:Horde_GetGadget() == "gadget_hydrogen_burner" then
-		has_burner = true
-	end
     local light = DynamicLight( math.random( 0, 9999999 ) )
-    if(light) then
-        if has_burner then
-            light.R = 0;
-            light.G = 132;
-            light.B = 255;
-        else
-            light.R = 105;
-            light.G = 255;
-            light.B = 50;
-        end
+    if light then
+        light.R = 105;
+        light.G = 255;
+        light.B = 50;
         light.Pos = data:GetOrigin();
         light.Size = 128;
         light.Decay = 64;
         light.Brightness = 3;
-        light.DieTime = CurTime()+1;
+        light.DieTime = CurTime() + 1;
     end
 
     local DrawFlame = 1
@@ -28,33 +17,23 @@ function EFFECT:Init(data)
 
         local FlameEmitter = ParticleEmitter(data:GetOrigin())
 
-        for i=0, 16 do
+        for i = 0, 16 do
             if !FlameEmitter then return end
             local FlameParticle = FlameEmitter:Add("particles/flamelet1", data:GetOrigin() )
 
             if (FlameParticle) then
-                if has_burner then
-                    FlameParticle:SetColor(0,100,255)
-                else
-                    FlameParticle:SetColor(105, 255, 50)
-                end
 
+                FlameParticle:SetColor(105, 255, 50)
                 FlameParticle:SetVelocity( VectorRand() * 172 )
-
                 FlameParticle:SetLifeTime(0)
                 FlameParticle:SetDieTime(0.72)
-
-                FlameParticle:SetStartAlpha(210)
+                FlameParticle:SetStartAlpha(135)
                 FlameParticle:SetEndAlpha(0)
-
                 FlameParticle:SetStartSize(0)
                 FlameParticle:SetEndSize(64 * (data:GetScale() or 1))
-
                 FlameParticle:SetRoll(math.Rand(-210, 210))
                 FlameParticle:SetRollDelta(math.Rand(-3.2, 3.2))
-
                 FlameParticle:SetAirResistance(350)
-
                 FlameParticle:SetGravity(Vector(0, 0, 64))
 
             end


### PR DESCRIPTION
• cleaned up code and made it more readable
• removed unused check for hydrogen burner gadget as cremator is likely never going to use the healththrower
• made flame particles much more transparent so players can actually *see* through the cloud of particles