### PR TITLE
Berserker & Flash Gadget tweaks

### DIFF
--- a/gamemodes/horde/gamemode/gadgets/gadget_flash.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_flash.lua
@@ -19,7 +19,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function( ply )
     sound.Play( "weapons/physcannon/energy_sing_explosion2.wav", ply:GetPos() )
 
     local dir = ply:GetAimVector()
-    local vel = dir * 8000
+    local vel = dir * 1000
     ply.Horde_NextAttack_Flash = true
     ply.Horde_Invincible = true
     ply.Flash_Fall_Damage_Prevention = true
@@ -68,14 +68,7 @@ end
 
 GADGET.Hooks.Horde_GetFallDamage = function(ply, speed, bonus)
     if ply:Horde_GetGadget() ~= "gadget_flash" then return end
-    if not ply.Flash_Fall_Damage_Prevention then return end
     bonus.less = bonus.less * 0.1
-    ply.Flash_Fall_Damage_Prevention = nil
 end
 
-GADGET.Hooks.PlayerTick = function (ply, mv)
-    if not ply.Flash_Fall_Damage_Prevention or not ply:Alive() then return end
-    if ply:IsOnGround() and not ply.Horde_In_Flash then
-        ply.Flash_Fall_Damage_Prevention = nil
-    end
-end
+

--- a/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
+++ b/gamemodes/horde/gamemode/perks/berserker/berserker_base.lua
@@ -8,7 +8,7 @@ Complexity: HIGH
 {4} increased Movement Speed and Jump height
 +{5} damage block.
 
-Aerial Parry: Jump to reduce Physical damage taken by {6}.]]
+Aerial Parry: Jump to reduce damage taken by {6}.]]
 PERK.Params = {
     [1] = { percent = true, level = 0.008, max = 0.20, classname = HORDE.Class_Berserker },
     [2] = { value = 0.008, percent = true },

--- a/gamemodes/horde/gamemode/status/buff/sv_aerial_guard.lua
+++ b/gamemodes/horde/gamemode/status/buff/sv_aerial_guard.lua
@@ -44,7 +44,7 @@ hook.Add("Horde_OnPlayerDamageTaken", "Horde_AerialGuardDamageTaken", function (
     if ply.HasUnwaveringGuardBuff then
         bonus.less = bonus.less * 0.75
     end
-    if ply:Horde_GetAerialGuard() == 1 and HORDE:IsPhysicalDamage(dmginfo) then
+    if ply:Horde_GetAerialGuard() == 1 then
         bonus.less = bonus.less * 0.35
         local e = EffectData()
         if dmginfo:GetDamagePosition() ~= Vector(0,0,0) then


### PR DESCRIPTION
Made the berserker parry apply to all damage types

Massively reduced the velocity of Flash from 8000 to 1000
Made the 90% fall damage reduction of Flash permanent