### PR TITLE
Shop & Infusion tweaks

### DIFF
--- a/gamemodes/horde/gamemode/sh_infusion.lua
+++ b/gamemodes/horde/gamemode/sh_infusion.lua
@@ -71,12 +71,12 @@ HORDE.Infusion_Colors = {
     [HORDE.Infusion_Galvanizing] = HORDE.DMG_COLOR[HORDE.DMG_LIGHTNING],
     [HORDE.Infusion_Quality] = color_white,
     [HORDE.Infusion_Impaling] = color_white,
-    [HORDE.Infusion_Rejuvenating] = Color(50,205,50),
-    [HORDE.Infusion_Quicksilver] = Color(220, 220, 220),
-    [HORDE.Infusion_Siphoning] = Color(255, 74, 95),
-    [HORDE.Infusion_Titanium] = Color(192, 192, 192),
-    [HORDE.Infusion_Chrono] = Color(0,139,139),
-    [HORDE.Infusion_Ruination] = Color(0,50,25),
+    [HORDE.Infusion_Rejuvenating] = Color( 50, 205, 50 ),
+    [HORDE.Infusion_Quicksilver] = Color( 220, 220, 220 ),
+    [HORDE.Infusion_Siphoning] = Color( 255, 74, 95 ),
+    [HORDE.Infusion_Titanium] = Color( 192, 192, 192 ),
+    [HORDE.Infusion_Chrono] = Color( 0, 139, 139 ),
+    [HORDE.Infusion_Ruination] = Color( 0, 50, 25 ),
 }
 
 HORDE.Infusion_Description = {
@@ -132,12 +132,12 @@ Amplifies weapon healing/leeching by 25%.
 20% less weapon damage.
 ]],
 [HORDE.Infusion_Quicksilver] = [[
-Increases/decreases weapon damage based on player's available weight.
-
-<= 15% weight -> 30% damage increase
-<= 30% weight -> 25% damage increase
-<= 40% weight -> 15% damage increase
->40% weight -> 25% damage decrease
+Increases/decreases weapon damage based on player's current weight.
+Example: (15% <= 2/15, 30% <= 4/15, 40% <= 6/15)
+<= 15% of max weight -> 30% damage increase
+<= 30% of max weight -> 25% damage increase
+<= 40% of max weight -> 15% damage increase
+> 40% of max weight -> 25% damage decrease
 ]],
 [HORDE.Infusion_Titanium] = [[
 Reduces player damage taken based on weapon weight.
@@ -154,16 +154,15 @@ Decrease 1% damage taken for every 1 weight on the weapon.
 [HORDE.Infusion_Chrono] = [[
 Increases weapon damage the longer the weapon is being held by the user.
 
-6% damage increase per wave held by the user.
-Increase caps at 50%.
-
-20% decreased weapon damage.
+Reduces weapon damage by 20%.
+Increases weapon damage by 8% per wave held.
+Weapon damage increase caps at +50%.
 ]],
 [HORDE.Infusion_Ruination] = [[
-Increases weapon damage based on your current Decay buildup.
-5% damage increase per 10 Decay buildup, up to 25%.
+While holding this weapon, you gain 10 Decay buildup per second.
 
-Gain 10 Decay buildup per second while holding this weapon.
+Increases weapon damage based on your current Decay buildup.
++5% damage per 10 Decay buildup, up to a maximum of +25% at 50 Decay.
 ]]
 }
 
@@ -193,7 +192,7 @@ end
 if CLIENT then
 net.Receive("Horde_SyncInfusion", function(len, ply)
     MySelf.Horde_Infusions = net.ReadTable()
-end)
+end )
 end
 
 if SERVER then
@@ -281,11 +280,11 @@ end
 
 local function quicksilver_damage(ply, npc, bonus, hitgroup, dmginfo)
     local percent = ply:Horde_GetWeight() / ply:Horde_GetMaxWeight()
-    if percent >= 0.85 then
+    if percent <= 0.15 then
         bonus.increase = bonus.increase + 0.3
-    elseif percent >= 0.7 then
+    elseif percent <= 0.3 then
         bonus.increase = bonus.increase + 0.25
-    elseif percent >= 0.6 then
+    elseif percent <= 0.4 then
         bonus.increase = bonus.increase + 0.15
     else
         bonus.increase = bonus.increase - 0.25
@@ -298,13 +297,13 @@ local function chrono_damage(ply, npc, bonus, hitgroup, dmginfo)
     local chrono_wave = ply.Horde_Infusion_Chrono_Wave[curr_weapon:GetClass()]
     if not chrono_wave then return end
 
-    bonus.increase = math.min(0.30, bonus.increase - 0.20 + (HORDE.current_wave - chrono_wave) * 0.06)
+    bonus.increase = math.min(0.50, bonus.increase - 0.20 + (HORDE.current_wave - chrono_wave) * 0.08)
 end
 
 local function ruination_damage(ply, npc, bonus, hitgroup, dmginfo)
     local curr_weapon = HORDE:GetCurrentWeapon(dmginfo:GetInflictor())
     if not IsValid(curr_weapon) then return end
-    bonus.increase = math.min(0.25, bonus.increase + ply:Horde_GetDebuffBuildup(HORDE.Status_Decay) / 200)
+    bonus.increase = bonus.increase + math.min(0.25, ply:Horde_GetDebuffBuildup(HORDE.Status_Decay) / 200)
 end
 
 local infusion_fns = {

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -266,13 +266,11 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_akimbo_m9"].infusions = ballistic_infusions_light
     HORDE.items["arccw_horde_akimbo_deagle"].infusions = ballistic_infusions_light
     HORDE.items["arccw_horde_raygun_mk2"].infusions = ballistic_infusions_light
-    HORDE.items["arccw_horde_masterkey"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_fucket"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
 
     --HORDE.items["arccw_horde_flaregun"].infusions = {HORDE.Infusion_Chrono, HORDE.Infusion_Quality}
 
-    -- SMGs
     local ballistic_infusions_smgs = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver}
+    -- SMGs
     HORDE.items["arccw_horde_smg1"].infusions = ballistic_infusions_light
     HORDE.items["arccw_horde_mac10"].infusions = ballistic_infusions_smgs
     HORDE.items["arccw_horde_mp40"].infusions = ballistic_infusions_smgs
@@ -290,22 +288,24 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_medic_acr"].infusions = infusions_medic
 
     -- Shotguns
+    local ballistic_infusions_shotguns = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming }
     HORDE.items["arccw_horde_shotgun"].infusions = ballistic_infusions_light
-    HORDE.items["arccw_horde_nova"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_870"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_mag7"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_m1014"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_doublebarrel"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
+    HORDE.items["arccw_horde_nova"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_870"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_mag7"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_m1014"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_doublebarrel"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_trenchgun"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Flaming, HORDE.Infusion_Siphoning}
-    HORDE.items["arccw_horde_spas12"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_striker"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_hsg1"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_aa12"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
+    HORDE.items["arccw_horde_spas12"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_striker"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_hsg1"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_aa12"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_medic_shotgun"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Septic, HORDE.Infusion_Siphoning}
+    HORDE.items["arccw_horde_masterkey"].infusions = ballistic_infusions_shotguns
 
     local ballistic_infusions_rifles = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning}
     -- Rifles
-    HORDE.items["arccw_horde_ar15"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
+    HORDE.items["arccw_horde_ar15"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_famas"].infusions = ballistic_infusions_rifles
     HORDE.items["arccw_horde_ace"].infusions = ballistic_infusions_rifles
     HORDE.items["arccw_horde_ak47"].infusions = ballistic_infusions_rifles
@@ -318,9 +318,9 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_ar2"].infusions = ballistic_infusions_rifles
 
     local ballistic_infusions_sniper_rifles = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning}
-    HORDE.items["arccw_horde_m14"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_winchester"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-    HORDE.items["arccw_horde_mosin_nagant"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
+    HORDE.items["arccw_horde_m14"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_winchester"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_mosin_nagant"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_winchester_fire"].infusions = ballistic_infusions_sniper_rifles
     HORDE.items["arccw_horde_m200"].infusions = ballistic_infusions_sniper_rifles
     HORDE.items["arccw_horde_ssg08"].infusions = ballistic_infusions_sniper_rifles
@@ -330,10 +330,9 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_fal"].infusions = ballistic_infusions_sniper_rifles
     HORDE.items["arccw_horde_barret"].infusions = ballistic_infusions_sniper_rifles
     HORDE.items["arccw_horde_m99"].infusions = ballistic_infusions_sniper_rifles
-    HORDE.items["arccw_horde_fucket_rifle"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Flaming}
-
+    HORDE.items["arccw_horde_fucket_rifle"].infusions = ballistic_infusions_shotguns
+    HORDE.items["arccw_horde_fucket"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_heat_crossbow"].infusions = ballistic_infusions_sniper_rifles
-
     HORDE.items["arccw_horde_medic_rifle"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Septic, HORDE.Infusion_Siphoning}
     HORDE.items["arccw_horde_m16m203"].infusions = ballistic_infusions_rifles
 
@@ -349,7 +348,7 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_m2_browning"].infusions = ballistic_infusions_mg_rifles
     HORDE.items["arccw_horde_gau"].infusions = ballistic_infusions_mg_rifles
 
-    local projectile_infusions = {}
+    --local projectile_infusions = {}
     HORDE.items["weapon_frag"].infusions = {}
     HORDE.items["weapon_rpg"].infusions = {}
     HORDE.items["arccw_horde_m79"].infusions = {HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Chrono, HORDE.Infusion_Ruination, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing}
@@ -391,7 +390,7 @@ function HORDE:GetDefaultItemsData()
     {Berserker=true}, 10, -1, nil, nil, {Berserker=5}, nil, {HORDE.DMG_SLASH})
 
     HORDE:CreateItem("Pistol",     "9mm",            "arccw_horde_9mm",   50,  1, "Combine standard sidearm.",
-    nil, 2, -1, nil, "items/hl2/weapon_pistol.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Engineer", "Demolition", "Survivor", "Psycho"})
+    nil, 2, -1, nil, "items/hl2/weapon_pistol.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Demolition", "Survivor", "Psycho"})
     HORDE:CreateItem("Pistol",     "Medic 9mm",       "arccw_horde_medic_9mm", 75,  1, "Modified 9mm that provides ranged healing.\n\nPress B or ZOOM to fire healing darts.\nHealing dart recharges every 1 second.",
     {Medic=true}, 2, -1, nil, "items/weapon_medic_9mm.png", nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON}, nil, {"Medic", "Hatcher"})
     HORDE:CreateItem("Pistol",     "357",            "arccw_horde_357",        100,  2, "Colt python magnum pistol.\nUsed by Black Mesa security guards.",
@@ -428,8 +427,6 @@ function HORDE:GetDefaultItemsData()
     {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 8, -1, nil, "arccw/weaponicons/arccw_go_tec9", {Survivor=2}, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Pistol",     "Skorpion",          "arccw_horde_skorpion",    1000,  3, "Sa vz. 61 Skorpion.\nDeveloped in 1959 by Miroslav Rybar and produced \nunder the official designation 'Samopal vzor 61'.",
     {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Masterkey",          "arccw_horde_masterkey",    1250,  3, "Usually seen mounted as an underbarrel shotgun intended for breaching doors\nthis Masterkey is fitted with a removeable grip\nfor use as an easily concealable shotgun.",
-    {Medic = true, Assault = true, Heavy = true, Demolition = true, Survivor = true, Engineer = true, Warden = true, Cremator = true, Ghost = true, Berserker = true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
 
     HORDE:CreateItem("Pistol",     "Dual M9",        "arccw_horde_akimbo_m9",       1500,  4, "Dual Beretta M9.\nSidearm used by the United States Armed Forces.",
     {Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
@@ -472,9 +469,11 @@ function HORDE:GetDefaultItemsData()
     {Medic=true, Warden=true}, 10, -1, nil, nil, {Medic=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
 
     HORDE:CreateItem("Shotgun",    "Pump-Action",    "arccw_horde_shotgun",100, 2, "A standard 12-gauge shotgun.",
-    {Warden=true, Engineer=true, Cremator=true}, 2, -1, nil, "items/hl2/weapon_shotgun.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Warden"})
+    {Warden=true, Engineer=true, Cremator=true}, 2, -1, nil, "items/hl2/weapon_shotgun.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Warden", "Engineer"})
     HORDE:CreateItem("Shotgun",    "Nova",           "arccw_horde_nova",     1000, 4, "Benelli Nova.\nItalian pump-action 12-gauge shotgun.",
     {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, "arccw/weaponicons/arccw_go_nova", nil, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem("Shotgun",     "Masterkey",          "arccw_horde_masterkey",    1250,  3, "Usually seen mounted as an underbarrel shotgun intended for breaching doors\nthis Masterkey is fitted with a removeable grip\nfor use as an easily concealable shotgun.",
+    {Medic = true, Assault = true, Heavy = true, Demolition = true, Survivor = true, Engineer = true, Warden = true, Cremator = true, Ghost = true, Berserker = true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Shotgun",    "M870",           "arccw_horde_870",      1500, 4, "Remington 870 Shotgun.\nManufactured in the United States.",
     {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, "arccw/weaponicons/arccw_go_870", {Engineer=1}, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Shotgun",    "MAG7",           "arccw_horde_mag7",     1500, 4, "Techno Arms MAG-7.\nFires a specialized 60mm 12 gauge shell.",
@@ -505,7 +504,7 @@ function HORDE:GetDefaultItemsData()
     HORDE:CreateItem("Rifle",      "M4A1",           "arccw_horde_m4",       3000, 7, "Colt M4.\nA 5.56×45mm NATO, air-cooled, gas-operated, select fire carbine.",
     {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "SG556",          "arccw_horde_sg556",    3000, 7, "SIG SG 550.\nAn assault rifle manufactured by Swiss Arms AG.",
-    {Assault=true}, 10, -1, nil, nil, {Assault=2}, nil, {HORDE.DMG_BALLISTIC})
+    {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "AUG",            "arccw_horde_aug",      3000, 7, "Steyr AUG.\nAn Austrian bullpup assault rifle.",
     {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "F2000",          "arccw_horde_f2000", 3250, 7, "FN F2000.\nAn ambidextrous bullpup rifle developed by FN. \nEquipped with an M203 underbarrel incendiary grenade launcher.\nPress USE+RELOAD to equip M203.",
@@ -534,11 +533,8 @@ function HORDE:GetDefaultItemsData()
     HORDE:CreateItem("Rifle",      "AWP",            "arccw_horde_awp",     2500, 8, "Magnum Ghost Rifle.\nA series of sniper rifles manufactured by the United Kingdom.",
     {Ghost=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "Fucket",            "arccw_horde_fucket_rifle",     2750, 7, "Break-action double-barrel musket.\ndebatable whether its unholy or not",
-    {Survivor = true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    --fucket explicitly for gunslinger
-    HORDE:CreateItem("Pistol",      "Fucket",            "arccw_horde_fucket",     2750, 7, "Break-action double-barrel musket.\ndebatable whether its unholy or not",
-    {Medic = false, Assault = false, Heavy = false, Demolition = false, Survivor = false, Engineer = false, Warden = false, Cremator = false}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-
+    {Survivor = true, Ghost = true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
+    
     HORDE:CreateItem("Rifle",      "M200",           "arccw_horde_m200",    3000, 9, "CheyTec M200 Intervention.\nAmerican bolt-action sniper rifle.",
     {Ghost=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
     HORDE:CreateItem("Rifle",      "Barrett AMR",    "arccw_horde_barret",  3500, 10, ".50 Cal Anti-Material Sniper Rifle.\nDoes huge amounts of ballistic damage.",


### PR DESCRIPTION
### Shop & Infusion Tweaks
**Engineer**
- Starting weapon changed from 9mm to Pump Shotgun

### Weapons
- Added Fucket to Ghost
- Moved Fucket to Rifle section
- Moved Masterkey to Shotgun section
- Removed Ghost requirement from **AR-15**
- Removed Assault requirement from **SG556**

### Infusions
- Updated description of Ruination and Chrono
- Fixed Ruination overwriting bonus damage to cap at 25%
- Fixed Quicksilver to deal more damage when less weight is used
- Increased Chrono damage scaling from 6% to 8% per wave
- Increased Chrono damage cap from 30% to 50% as advertised