### PR TITLE
Fixed perks being given mid wave

### DIFF
--- a/gamemodes/horde/gamemode/sv_perk.lua
+++ b/gamemodes/horde/gamemode/sv_perk.lua
@@ -30,12 +30,15 @@ function plymeta:Horde_ApplyPerksForClass()
     self.Horde_PerkChoices[class] = self.Horde_PerkChoices[class] or {}
 
     for perk_level, v in pairs(perks) do
-        if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or (HORDE.current_wave == HORDE:Horde_GetWaveForPerk(perk_level) and HORDE.current_break_time <= 0) then goto cont end
-        local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
-        local choice = v.choices[c]
-        if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
-        if not self:Horde_GetPerk(choice) then self:Horde_SetPerk(choice) end
-        ::cont::
+        local curWave = HORDE.current_wave
+        local perkWaveRequirement = HORDE:Horde_GetWaveForPerk(perk_level)
+
+        if curWave >= perkWaveRequirement or (curWave == perkWaveRequirement and HORDE.current_break_time > 0) then
+            local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
+            local choice = v.choices[c]
+            if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
+            if not self:Horde_GetPerk(choice) then self:Horde_SetPerk(choice) end
+        end
     end
 
     self:Horde_SetMaxHealth()

--- a/gamemodes/horde/gamemode/sv_perk.lua
+++ b/gamemodes/horde/gamemode/sv_perk.lua
@@ -30,12 +30,12 @@ function plymeta:Horde_ApplyPerksForClass()
     self.Horde_PerkChoices[class] = self.Horde_PerkChoices[class] or {}
 
     for perk_level, v in pairs(perks) do
-        if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time <= 0 then continue end
-        local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
-        local choice = v.choices[c]
-        if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
-        if self:Horde_GetPerk(choice) then continue end
-        self:Horde_SetPerk(choice)
+        if HORDE.current_wave >= HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time > 0 then
+            local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
+            local choice = v.choices[c]
+            if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
+            if self:Horde_GetPerk(choice) then self:Horde_SetPerk(choice) end
+        end
     end
 
     self:Horde_SetMaxHealth()

--- a/gamemodes/horde/gamemode/sv_perk.lua
+++ b/gamemodes/horde/gamemode/sv_perk.lua
@@ -30,13 +30,13 @@ function plymeta:Horde_ApplyPerksForClass()
     self.Horde_PerkChoices[class] = self.Horde_PerkChoices[class] or {}
 
     for perk_level, v in pairs(perks) do
-        if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) then goto cont end
+        print(HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level), HORDE.current_break_time <= 0, HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time <= 0, perk_level)
+        if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time <= 0 then continue end
         local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
         local choice = v.choices[c]
         if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
-        if self:Horde_GetPerk(choice) then goto cont end
+        if self:Horde_GetPerk(choice) then continue end
         self:Horde_SetPerk(choice)
-        ::cont::
     end
 
     self:Horde_SetMaxHealth()

--- a/gamemodes/horde/gamemode/sv_perk.lua
+++ b/gamemodes/horde/gamemode/sv_perk.lua
@@ -33,7 +33,7 @@ function plymeta:Horde_ApplyPerksForClass()
         local curWave = HORDE.current_wave
         local perkWaveRequirement = HORDE:Horde_GetWaveForPerk(perk_level)
 
-        if curWave >= perkWaveRequirement or (curWave == perkWaveRequirement and HORDE.current_break_time > 0) then
+        if curWave > perkWaveRequirement or (curWave == perkWaveRequirement and HORDE.current_break_time > 0) then
             local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
             local choice = v.choices[c]
             if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end

--- a/gamemodes/horde/gamemode/sv_perk.lua
+++ b/gamemodes/horde/gamemode/sv_perk.lua
@@ -30,7 +30,6 @@ function plymeta:Horde_ApplyPerksForClass()
     self.Horde_PerkChoices[class] = self.Horde_PerkChoices[class] or {}
 
     for perk_level, v in pairs(perks) do
-        print(HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level), HORDE.current_break_time <= 0, HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time <= 0, perk_level)
         if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time <= 0 then continue end
         local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
         local choice = v.choices[c]

--- a/gamemodes/horde/gamemode/sv_perk.lua
+++ b/gamemodes/horde/gamemode/sv_perk.lua
@@ -30,12 +30,12 @@ function plymeta:Horde_ApplyPerksForClass()
     self.Horde_PerkChoices[class] = self.Horde_PerkChoices[class] or {}
 
     for perk_level, v in pairs(perks) do
-        if HORDE.current_wave >= HORDE:Horde_GetWaveForPerk(perk_level) or HORDE.current_break_time > 0 then
-            local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
-            local choice = v.choices[c]
-            if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
-            if self:Horde_GetPerk(choice) then self:Horde_SetPerk(choice) end
-        end
+        if HORDE.current_wave < HORDE:Horde_GetWaveForPerk(perk_level) or (HORDE.current_wave == HORDE:Horde_GetWaveForPerk(perk_level) and HORDE.current_break_time <= 0) then goto cont end
+        local c = math.min(2, math.max(1, self.Horde_PerkChoices[class][perk_level] or 1))
+        local choice = v.choices[c]
+        if not choice then error("Invalid choice in perk level " .. perk_level .. " for " .. class .. "!") return end
+        if not self:Horde_GetPerk(choice) then self:Horde_SetPerk(choice) end
+        ::cont::
     end
 
     self:Horde_SetMaxHealth()


### PR DESCRIPTION
This fixes the revive exploit/bug (depending on how it happens) where if you were to get revived mid wave (ie wave 5) you would get your perks before you're supposed to.
~Also changed out `goto cont` with continue since goto isn't required here~

Testing checklist:
- [x] Check that it doesn't give you them early (when revived)
- [x] Check that you can switch between perks
- [x] Check that it gives them to you correctly on intermission
- [x] Check that they aren't locked on the wave

