### PR TITLE
removed m14 from assault

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_m14.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m14.lua
@@ -36,8 +36,8 @@ SWEP.Penetration = 5
 SWEP.DamageType = DMG_BULLET
 
 SWEP.ChamberSize = 0
-SWEP.Primary.ClipSize = 20
-SWEP.ExtendedClipSize = 30
+SWEP.Primary.ClipSize = 10
+SWEP.ExtendedClipSize = 10
 SWEP.ReducedClipSize = 10
 
 SWEP.Recoil = 0.5


### PR DESCRIPTION
the insanely low cost, and incredibly high 100 damage per shot (highest damage assault rifle assault could use btw, the scar does 73 damage and the ar2 does 76 damage), and considering the fact the m14 was balanced using Ghost's Winchester as a reference, it upsets the balance of most of the assault rifles assault has access to, and pretty much nullifies reasons to use lower to mid tier assault rifles simply because the M14 outdamages them and costs way less, not to mention it invalidates any reason to use any of the lower to mid tier smgs as well, especially considering the fact you can run the full auto perk on the m14 anyway, rendering the fact its semi auto only a moot point

sure in a vacuum its fine, and the glock *technically* does more damage per magazine or dps or whatever, but in practice players will always gravitate towards the highest damage per shot option in most cases and use the more effective options at their disposal, and frankly the m14 is just too effective for its price to be available on assault without upsetting the balance of the rest of the assault rifles and smgs assault has access to

also you never see assault classes exclusively run the glock outside of wave 1-3

i increased the magsize from 10 -> 20 as its less likely to upset balance for the classes that can still use it without being held back by it being accessible for assault and being in a really weird spot it shouldn't have been in to begin with