### PR TITLE
Log player revives in chat

### DIFF
--- a/gamemodes/horde/entities/weapons/weapon_horde_medkit.lua
+++ b/gamemodes/horde/entities/weapons/weapon_horde_medkit.lua
@@ -48,6 +48,7 @@ SWEP.ReviveSpeed = 20 -- Amount of progress per second
 
 if SERVER then
 	util.AddNetworkString( "horde_medkit_deadplayers" )
+	util.AddNetworkString( "horde_medkit_player_revived" )
 end
 
 function SWEP:Initialize()
@@ -333,6 +334,20 @@ if CLIENT then
 		medkit.DeadPlayers = deadPlayers
 	end )
 
+	local reviveGreen = Color( 0, 170, 14 )
+
+	net.Receive( "horde_medkit_player_revived", function()
+		local revived = net.ReadEntity()
+		local revivedName = revived:GetName()
+		local revivedCol = team.GetColor( revived:Team() )
+
+		local reviver = net.ReadEntity()
+		local reviverName = reviver:GetName()
+		local reviverCol = team.GetColor( reviver:Team() )
+
+		chat.AddText( reviveGreen, "[HORDE] ", revivedCol, revivedName, color_white, " was revived by ", reviverCol, reviverName )
+	end )
+
 	-- Draw the dead players and revive progerss bar
 	function SWEP:DrawHUD()
 
@@ -416,6 +431,11 @@ if SERVER then
 
 		owner:Horde_AddMoney( 50 )
 		owner:Horde_SyncEconomy()
+
+		net.Start( "horde_medkit_player_revived" )
+			net.WriteEntity( ply ) -- Revived
+			net.WriteEntity( owner ) -- Reviver
+		net.Broadcast()
 	end
 
 	hook.Add( "Horde_OnPlayerShouldRespawnDuringWave", "HordeMedkitRevive", function( ply )


### PR DESCRIPTION
Could see this being a issue if many players are revived at once but then again player deaths will also do that so ¯\\_(ツ)_/¯

Tests:
- [x] Revives still work
- [x] Revive text shows up
- [x] Revive 2d3d shows up

Example of text (Player color changes with rank)
![{AE87BCF9-CF20-4FAB-858F-FF93F27709B0}](https://github.com/user-attachments/assets/863b2283-9f26-427a-91d8-fe1ef9207211)
