### PR TITLE
Cycle time reduction for Winchester & China Lake + USAS Drum mag buff

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_chinalake.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_chinalake.lua
@@ -231,54 +231,54 @@ SWEP.Animations = {
         Source = {
             "pump",
         },
-        Time = 69 / 50,
+        Time = 35 / 25,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Back", t = 25 / 50},
-            {s = "ArcCW_BO1.CL_Fwd", t = 37 / 50}
+            {s = "ArcCW_BO1.CL_Back", t = 25 / 25},
+            {s = "ArcCW_BO1.CL_Fwd", t = 37 / 25}
         },
     },
     ["cycle_iron"] = {
         Source = {
             "pump",
         },
-        Time = 69 / 50,
+        Time = 35 / 25,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Back", t = 26 / 50},
-            {s = "ArcCW_BO1.CL_Fwd", t = 38 / 50}
+            {s = "ArcCW_BO1.CL_Back", t = 26 / 25},
+            {s = "ArcCW_BO1.CL_Fwd", t = 38 / 25}
         },
     },
     ["sgreload_start"] = {
         Source = "reload_in",
-        Time = 30 / 48,
+        Time = 15 / 24,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
         LHIK = true,
         LHIKIn = 0.5,
         LHIKOut = 0,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Back", t = 4 / 48}
+            {s = "ArcCW_BO1.CL_Back", t = 4 / 24}
         },
     },
     ["sgreload_insert"] = {
         Source = "reload_loop",
-        Time = 52 / 48,
+        Time = 26 / 24,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
         TPAnimStartTime = 0.3,
         LHIK = true,
         LHIKIn = 0,
         LHIKOut = 0,
-        MinProgress = 17 / 48,
+        MinProgress = 17 / 24,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Shell", t = 17 / 48}
+            {s = "ArcCW_BO1.CL_Shell", t = 17 / 24}
         },
     },
     ["sgreload_finish"] = {
         Source = "reload_out",
-        Time = 36 / 48,
+        Time = 18 / 24,
         LHIK = true,
         LHIKIn = 0,
         LHIKOut = 1,
         SoundTable = {
-            {s = "ArcCW_BO1.CL_Fwd", t = 20 / 48}
+            {s = "ArcCW_BO1.CL_Fwd", t = 20 / 24}
         },
     },
     ["enter_sprint"] = {

--- a/gamemodes/horde/entities/weapons/arccw_horde_winchester.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_winchester.lua
@@ -276,14 +276,14 @@ SWEP.Animations = {
     },
     ["cycle"] = {
         Source = "cycle",
-        Time = 1,
+        Time = 0.5,
         ShellEjectAt = 0.3,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
         TPAnimStartTime = 0.6,
     },
     ["cycle_iron"] = {
         Source = "cycle_iron",
-        Time = 1,
+        Time = 0.5,
         ShellEjectAt = 0.4,
     },
     ["sgreload_start"] = {
@@ -292,13 +292,13 @@ SWEP.Animations = {
     },
     ["sgreload_insert"] = {
         Source = "reload_insert",
-        Time = 0.5,
+        Time = 0.3,
         TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
         TPAnimStartTime = 0.5,
     },
     ["sgreload_finish"] = {
         Source = "reload_finish",
-        Time = 0.5,
+        Time = 0.3,
     },
     ["sgreload_finish_empty"] = {
         Source = "reload_finish_empty",


### PR DESCRIPTION
- Winchester cycle speed reduced to 0.5 seconds (Original: 1 second. Why.)

- Shell reload speed reduced to 0.3 seconds (Original: 0.5 seconds)

Deft Hands was a virtual requirement for this weapon to be decent.

- China Lake cycle speed reduced to 0.62 seconds

- Grenade Reload speed reduced to 0.47 seconds

- Draw speed reduced to 0.83 seconds

The weapon was very awkward to use due to how slow the equip, pump, and reload animations were, thus making it fairly unviable compared to the Thumper and Milkor.

- Reduced USAS-12 Drum Mag movement penalty to 13.5% (orig: 20%)

The movement penalty feels too punishing when compared to a lot of extended mag options given how fast this thing empties the drum.