### PR TITLE
Greater Spectre fix & Spectre coloration

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_spectre/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_spectre/init.lua
@@ -6,7 +6,7 @@ include('shared.lua')
 	without the prior written consent of the author, unless otherwise indicated for stand-alone materials.
 -----------------------------------------------*/
 ENT.Model = {"models/zombie/fast.mdl"} -- The game will pick a random model from the table when the SNPC is spawned | Add as many as you want
-ENT.StartHealth = 100
+ENT.StartHealth = 90
 ENT.HullType = HULL_HUMAN
 ---------------------------------------------------------------------------------------------------------------------------------------------
 ENT.VJ_NPC_Class = {"CLASS_PLAYER_ALLY", "CLASS_COMBINE"} -- NPCs with the same class with be allied to each other
@@ -117,14 +117,6 @@ function ENT:Roar()
 	self:Shockwave(1.0)
 end
 
-function ENT:Horde_SetGreaterSpectre()
-	self:SetModelScale(1.5)
-	self.HasLeapAttack = false
-	self.MeleeAttackDamage = self.MeleeAttackDamage * 1.65
-	self.NextAnyAttackTime_Melee = 0.75
-	self:SetHealth(1.25 * (90 + 2 * 16 * self.properties.level))
-end
-
 function ENT:CustomOnInitialize()
 	self:SetCollisionBounds(Vector(13, 13, 20), Vector(-13, -13, 0))
 	self.AnimTbl_Run = ACT_RUN
@@ -144,9 +136,11 @@ function ENT:CustomOnInitialize()
 		e:SetScale(0.25)
 	util.Effect("abyssal_roar", e, true, true)
 	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
-	self:SetColor(Color(0, 0, 100, 200))
+	self:SetColor(Color(20, 20, 150, 200))
 	self.MeleeAttackDamage = self.MeleeAttackDamage + 6 * self.properties.level
-	self:SetHealth(90 + 2 * 16 * self.properties.level)
+	self.LeapAttackDamage = self.LeapAttackDamage + 8 * self.properties.level
+	self.StartHealth = math.floor(self.StartHealth + 32 * self.properties.level)
+	self:SetHealth(self.StartHealth)
 	self:AddRelationship("npc_turret_floor D_LI 99")
 	self:AddRelationship("npc_vj_horde_combat_bot D_LI 99")
 	self:AddRelationship("npc_manhack D_LI 99")
@@ -156,6 +150,16 @@ function ENT:CustomOnInitialize()
 	self:AddRelationship("npc_vj_horde_class_assault D_LI 99")
 	self:AddRelationship("npc_vj_horde_antlion D_LI 99")
 	--self:EmitSound("horde/lesion/lesion_roar.ogg", 1500, 80, 1, CHAN_STATIC)
+end
+
+function ENT:Horde_SetGreaterSpectre()
+	self:SetModelScale(1.5)
+	self.HasLeapAttack = false
+	self.MeleeAttackDamage = self.MeleeAttackDamage * 1.65
+	self.NextAnyAttackTime_Melee = 0.75
+	self.StartHealth = math.floor(1.25 * self.StartHealth)
+	self:SetHealth(self.StartHealth)
+	self:SetMaxHealth(self.StartHealth)
 end
 
 function ENT:DoEntityRelationshipCheck()

--- a/gamemodes/horde/entities/entities/npc_vj_horde_spectre/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_spectre/init.lua
@@ -136,7 +136,7 @@ function ENT:CustomOnInitialize()
 		e:SetScale(0.25)
 	util.Effect("abyssal_roar", e, true, true)
 	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
-	self:SetColor(Color(20, 20, 150, 200))
+	self:SetColor(Color(120, 230, 230, 200))
 	self.MeleeAttackDamage = self.MeleeAttackDamage + 6 * self.properties.level
 	self.LeapAttackDamage = self.LeapAttackDamage + 8 * self.properties.level
 	self.StartHealth = math.floor(self.StartHealth + 32 * self.properties.level)

--- a/gamemodes/horde/gamemode/sh_spells.lua
+++ b/gamemodes/horde/gamemode/sh_spells.lua
@@ -234,7 +234,11 @@ net.Receive("Horde_BuySpellUpgrade", function (len, ply)
 end)
 
 function HORDE:RaiseSpectre(ply, param, p2)
-    local level = ply:Horde_GetSpellUpgrade("raise_spectre")
+        local spell_name = "raise_spectre"
+    if param and param.greater_spectre then
+        spell_name = "raise_greater_spectre"
+    end
+    local level = ply:Horde_GetSpellUpgrade(spell_name)
     local p = {level = level}
     hook.Run("Horde_OnRaiseSpectre", ply, p)
     local spectres_count = 0


### PR DESCRIPTION
**Spectre changes:**
- Changed start health to 90 as it should be
- Replaced and simplified hardcoded HP calculation
- Added damage to leap attack based on level
- Fixed Max HP of Greater Spectres not updating properly
- Greater Spectre now gains levels from the Greater Spectre spell as it should
- Changed color from Navy Blue to Aquamarine, helps visually avoid confusion with Shadow mutation enemies