### PR TITLE
melee hitreg and gadget cooldown fix

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_base_melee.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_base_melee.lua
@@ -1,8 +1,11 @@
 SWEP.Base = "arccw_base_melee"
 
 function SWEP:MeleeAttack(melee2)
-    local reach = 32 + self:GetBuff_Add("Add_MeleeRange") + (melee2 and self.Melee2Range or self.MeleeRange)
-    local dmg = self:GetBuff_Override("Override_MeleeDamage", melee2 and self.Melee2Damage or self.MeleeDamage) or 20
+    local reach = melee2 and self.Melee2Range or self.MeleeRange
+    local dmg = melee2 and self.Melee2Damage or self.MeleeDamage
+
+    reach = 32 + self:GetBuff_Add("Add_MeleeRange") + reach
+    dmg = self:GetBuff_Override("Override_MeleeDamage", dmg) or 20
 
     dmg = dmg * self:GetBuff_Mult("Mult_MeleeDamage")
 

--- a/gamemodes/horde/entities/weapons/arccw_horde_base_melee.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_base_melee.lua
@@ -86,9 +86,8 @@ function SWEP:MeleeAttack(melee2)
         dmginfo:SetDamageType(self:GetBuff_Override("Override_MeleeDamageType") or self.MeleeDamageType or DMG_CLUB)
         dmginfo:SetDamagePosition(tr.HitPos)
 	dmginfo:SetDamageForce(self:GetOwner():GetRight() * -4912 + self:GetOwner():GetForward() * 9989)
-        if hitent:IsPlayer() and tr.HitGroup == HITGROUP_HEAD then hitent:SetLastHitGroup(HITGROUP_HEAD) end
 
-        hitent:DispatchTraceAttack( dmginfo, tr, tr.Normal )
+        hitent:DispatchTraceAttack(dmginfo, tr, tr.Normal)
 
         if hitent:GetClass() == "func_breakable_surf" then
             hitent:Fire("Shatter", "0.5 0.5 256")

--- a/gamemodes/horde/entities/weapons/arccw_horde_base_melee.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_base_melee.lua
@@ -1,13 +1,8 @@
 SWEP.Base = "arccw_base_melee"
 
 function SWEP:MeleeAttack(melee2)
-    local reach = 32 + self:GetBuff_Add("Add_MeleeRange") + self.MeleeRange
-    local dmg = self:GetBuff_Override("Override_MeleeDamage", self.MeleeDamage) or 20
-
-    if melee2 then
-        reach = 32 + self:GetBuff_Add("Add_MeleeRange") + self.Melee2Range
-        dmg = self:GetBuff_Override("Override_MeleeDamage", self.Melee2Damage) or 20
-    end
+    local reach = 32 + self:GetBuff_Add("Add_MeleeRange") + (melee2 and self.Melee2Range or self.MeleeRange)
+    local dmg = self:GetBuff_Override("Override_MeleeDamage", melee2 and self.Melee2Damage or self.MeleeDamage) or 20
 
     dmg = dmg * self:GetBuff_Mult("Mult_MeleeDamage")
 
@@ -35,8 +30,10 @@ function SWEP:MeleeAttack(melee2)
         })
     end
 
+    local hitent = tr.Entity
+
     -- Backstab damage if applicable
-    local backstab = tr.Hit and self:CanBackstab(melee2, tr.Entity)
+    local backstab = tr.Hit and self:CanBackstab(melee2, hitent)
     if backstab then
         if melee2 then
             local bs_dmg = self:GetBuff_Override("Override_Melee2DamageBackstab", self.Melee2DamageBackstab)
@@ -58,7 +55,7 @@ function SWEP:MeleeAttack(melee2)
     -- We need the second part for single player because SWEP:Think is ran shared in SP
     if !(game.SinglePlayer() and CLIENT) then
         if tr.Hit then
-            if tr.Entity:IsNPC() or tr.Entity:IsNextBot() or tr.Entity:IsPlayer() then
+            if hitent:IsNPC() or hitent:IsNextBot() or hitent:IsPlayer() then
                 self:MyEmitSound(self.MeleeHitNPCSound, 75, 100, 1, CHAN_USER_BASE + 2)
             else
                 self:MyEmitSound(self.MeleeHitSound, 75, 100, 1, CHAN_USER_BASE + 2)
@@ -75,37 +72,29 @@ function SWEP:MeleeAttack(melee2)
         end
     end
 
-    if SERVER and IsValid(tr.Entity) and (tr.Entity:IsNPC() or tr.Entity:IsPlayer() or tr.Entity:Health() > 0) then
+    if SERVER and IsValid(hitent) and (hitent:IsNPC() or hitent:IsPlayer() or hitent:Health() > 0) then
         local attacker = self:GetOwner()
         if !IsValid(attacker) then attacker = self end
 
-        self:FireBullets({
-            Attacker = attacker,
-            Inflictor = self,
-            Damage = dmg,
-            Tracer = -1,
-            Distance = reach,
-            Dir = tr.HitPos - self:GetOwner():GetShootPos(),
-            Src = self:GetOwner():GetShootPos(),
-            Callback = function(att, trb, dmginfo)
-                dmginfo:SetDamage(dmg)
-                dmginfo:SetDamageForce(self:GetOwner():GetRight() * -4912 + self:GetOwner():GetForward() * 9989)
-                dmginfo:SetDamageType(self:GetBuff_Override("Override_MeleeDamageType") or self.MeleeDamageType or DMG_CLUB)
+        local dmginfo = DamageInfo()
+        dmginfo:SetDamage(dmg)
+        dmginfo:SetAttacker(attacker)
+        dmginfo:SetInflictor(self)
+        dmginfo:SetDamageType(self:GetBuff_Override("Override_MeleeDamageType") or self.MeleeDamageType or DMG_CLUB)
+        dmginfo:SetDamagePosition(tr.HitPos)
+	dmginfo:SetDamageForce(self:GetOwner():GetRight() * -4912 + self:GetOwner():GetForward() * 9989)
+        if hitent:IsPlayer() and tr.HitGroup == HITGROUP_HEAD then hitent:SetLastHitGroup(HITGROUP_HEAD) end
 
-                if (not trb.Entity:IsValid()) or (not trb.Entity:IsNPC()) then
-                    tr.Entity:TakeDamageInfo(dmginfo)
-                end
-            end
-        })
+        hitent:DispatchTraceAttack( dmginfo, tr, tr.Normal )
 
-        if tr.Entity:GetClass() == "func_breakable_surf" then
-            tr.Entity:Fire("Shatter", "0.5 0.5 256")
+        if hitent:GetClass() == "func_breakable_surf" then
+            hitent:Fire("Shatter", "0.5 0.5 256")
         end
 
     end
 
-    if SERVER and IsValid(tr.Entity) and IsValid(self:GetOwner()) then
-        local phys = tr.Entity:GetPhysicsObject()
+    if SERVER and IsValid(hitent) and IsValid(self:GetOwner()) then
+        local phys = hitent:GetPhysicsObject()
         if IsValid(phys) then
             phys:ApplyForceOffset(self:GetOwner():GetAimVector() * 80 * phys:GetMass(), tr.HitPos)
         end

--- a/gamemodes/horde/entities/weapons/horde_carcass.lua
+++ b/gamemodes/horde/entities/weapons/horde_carcass.lua
@@ -171,7 +171,6 @@ function SWEP:DealDamage()
 		dmginfo:SetInflictor(self)
 		dmginfo:SetDamageType(DMG_CLUB)
 		dmginfo:SetDamagePosition(tr.HitPos)
-		if hitent:IsPlayer() and tr.HitGroup == HITGROUP_HEAD then hitent:SetLastHitGroup(HITGROUP_HEAD) end
 
 		local bonus = {increase = 0, more = 1}
 		if self.Charged == 1 then

--- a/gamemodes/horde/entities/weapons/horde_carcass.lua
+++ b/gamemodes/horde/entities/weapons/horde_carcass.lua
@@ -201,7 +201,7 @@ function SWEP:DealDamage()
 			uppercut = true
 		end
 
-		hitent:DispatchTraceAttack( dmginfo, tr, tr.Normal )
+		hitent:DispatchTraceAttack(dmginfo, tr, tr.Normal)
 
 		if uppercut then
 			local pos, damage = dmginfo:GetDamagePosition(), dmginfo:GetDamage() / 2

--- a/gamemodes/horde/gamemode/gui/cl_status.lua
+++ b/gamemodes/horde/gamemode/gui/cl_status.lua
@@ -535,7 +535,7 @@ hook.Add("HUDPaint", "Horde_DrawHud", function ()
         if MySelf:Horde_GetGadget() ~= nil then
             local gadget = MySelf:Horde_GetGadget()
             local charge = MySelf:Horde_GetGadgetCharges()
-            local cd = MySelf:Horde_GetGadgetInternalCooldown()
+            local cd = math.ceil(MySelf:Horde_GetGadgetInternalCooldown() - CurTime())
             local x = ScrW() - airgap - ScreenScale(78) - ScreenScale(33)
             local y = ScrH() - ScreenScale(33) - airgap
             local s = ScreenScale(26) + airgap
@@ -556,8 +556,10 @@ hook.Add("HUDPaint", "Horde_DrawHud", function ()
 
             if cd > 0 then
                 draw.RoundedBox(10, x, y, s, s, Color(40,40,40,225))
-                surface.SetDrawColor(color_white)
-                draw.SimpleText(cd, font, x + s/2, y + s/2, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+                if MySelf:Horde_GetGadgetCooldown() >= 1 then
+                    surface.SetDrawColor(color_white)
+                    draw.SimpleText(cd, font, x + s/2, y + s/2, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+                end
             end
 
             if charge >= 0 then
@@ -640,12 +642,7 @@ if CLIENT then
         end)
     end
     net.Receive("Horde_GadgetStartCooldown", function()
-        MySelf:Horde_SetGadgetInternalCooldown(net.ReadUInt(8))
-        if MySelf:Horde_GetGadgetInternalCooldown() <= 0 then return end
-        timer.Create("Horde_LocalGadgetCooldown", 1, 0, function()
-            if MySelf:Horde_GetGadgetInternalCooldown() <= 0 then timer.Remove("Horde_LocalGadgetCooldown") return end
-            MySelf:Horde_SetGadgetInternalCooldown(MySelf:Horde_GetGadgetInternalCooldown() - 1)
-        end)
+        MySelf:Horde_SetGadgetInternalCooldown(net.ReadFloat())
     end)
 
     net.Receive("Horde_PerkStartCooldown", function ()


### PR DESCRIPTION
* Changed melee hitreg code to use trace attacks instead of firing a bullet. (fixes melee being able to snipe zombies)
* Made cooldown code more stable by changing it to use CurTime() instead of manually counting down a timer in a think hook. (fixes hemocannon being able to fire twice instantly)