### PR TITLE
Fix carcass null ent. error

### DIFF
--- a/gamemodes/horde/entities/weapons/horde_carcass.lua
+++ b/gamemodes/horde/entities/weapons/horde_carcass.lua
@@ -470,7 +470,7 @@ function SWEP:UpdateAttack()
 
 	if (!intestine_endpos) then
 		intestine_endpos = self.Tr.HitPos
-		if self.Tr.Entity:IsNPC() then
+		if IsValid(self.Tr.Entity) && self.Tr.Entity:IsNPC() then
 			intestine_endpos = intestine_endpos + self.Tr.Entity:OBBCenter()
 		end
 		if pull == true then


### PR DESCRIPTION
Caused when a player is using the intestine hook and is still hooked on to a enemy after they die

[Error on discord](https://discord.com/channels/539289943004938251/1164031922096316557/1401380191955062947)
```
1. OBBCenter - [C]:-1
 2. UpdateAttack - addons/horde/gamemodes/horde/entities/weapons/horde_carcass.lua:474
  3. <unknown> - addons/horde/gamemodes/horde/entities/weapons/horde_carcass.lua:620
```