### PR TITLE
Weapon Rebalances Pt.1

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_ace.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ace.lua
@@ -16,9 +16,15 @@ SWEP.ViewModel = "models/weapons/arccw_go/v_rif_ace.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_ace.mdl"
 
 SWEP.Damage = 54
-SWEP.DamageMin = 44  -- damage done at maximum range
+SWEP.DamageMin = 44
 
-SWEP.RecoilPunch = 0
+SWEP.RecoilPunch = 0.35
 
-SWEP.Delay = 60 / 700 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.Delay = 60 / 700
+
+SWEP.FirstShootSound = ")arccw_go/galilar/galil_01.wav"
+SWEP.ShootSound =  {")arccw_go/galilar/galil_02.wav",")arccw_go/galilar/galil_03.wav"}
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound =  ")arccw_go/galilar/galil_distant.wav"
+
+SWEP.RecoilSide = 0.1

--- a/gamemodes/horde/entities/weapons/arccw_horde_ak47.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ak47.lua
@@ -15,9 +15,22 @@ SWEP.WorldModel = "models/weapons/w_rif_ak47.mdl"
 SWEP.Damage = 65
 SWEP.DamageMin = 49 -- damage done at maximum range
 
-SWEP.Recoil = 0.45
-SWEP.RecoilSide = 0.35
-SWEP.RecoilPunch = 0
+SWEP.RecoilSide = 0.1
+SWEP.RecoilPunch = 1.2
 
-SWEP.Delay = 60 / 600 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.Delay = 60 / 525
+
+SWEP.FirstShootSound = ")arccw_go/ak47/ak47_01.wav"
+SWEP.ShootSound =  ")arccw_go/ak47/ak47_01.wav"
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound =  ")arccw_go/ak47/ak47_distant.wav"
+
+SWEP.Delay = 60 / 525
+SWEP.Firemodes = {
+    {
+        Mode = 2,
+    },
+    {
+        Mode = 1,
+    }
+}

--- a/gamemodes/horde/entities/weapons/arccw_horde_ar15.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ar15.lua
@@ -16,7 +16,7 @@ SWEP.Damage = 42
 SWEP.DamageMin = 32 -- damage done at maximum range
 
 
-SWEP.RecoilPunch = 0
+SWEP.RecoilPunch = 0.8
 
 
 SWEP.Firemodes = {
@@ -25,11 +25,14 @@ SWEP.Firemodes = {
     },
     {
         Mode = 1,
-    },
-    {
-        Mode = 0
     }
 }
 
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.FirstShootSound = {")arccw_go/m4a1/m4a1_us_04.wav"}
+SWEP.ShootSound =  {")arccw_go/m4a1/m4a1_us_01.wav",")arccw_go/m4a1/m4a1_us_02.wav",")arccw_go/m4a1/m4a1_us_03.wav"}
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound = {")arccw_go/m4a1/m4a1_us_distant.wav",")arccw_go/m4a1/m4a1_us_distant_02.wav",")arccw_go/m4a1/m4a1_us_distant_03.wav"}
 
+SWEP.Delay = 60 / 675
+
+SWEP.RecoilSide = 0.1

--- a/gamemodes/horde/entities/weapons/arccw_horde_aug.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_aug.lua
@@ -17,7 +17,22 @@ SWEP.WorldModel = "models/weapons/arccw_go/v_rif_aug.mdl"
 SWEP.Damage = 63
 SWEP.DamageMin = 47 -- damage done at maximum range
 
-SWEP.RecoilPunch = 0
+SWEP.RecoilPunch = 0.45
 
-SWEP.Delay = 60 / 700 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.Delay = 60 / 650
+
+SWEP.FirstShootSound = ")arccw_go/aug/aug_02.wav"
+SWEP.ShootSound =  {")arccw_go/aug/aug_01.wav",")arccw_go/aug/aug_03.wav",")arccw_go/aug/aug_04.wav"}
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound = ")arccw_go/aug/aug_distant.wav"
+
+SWEP.Firemodes = {
+    {
+        Mode = 2,
+    },
+    {
+        Mode = 1,
+    }
+}
+
+SWEP.RecoilSide = 0.1

--- a/gamemodes/horde/entities/weapons/arccw_horde_famas.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_famas.lua
@@ -23,9 +23,9 @@ SWEP.Range = 100 -- in METRES
 SWEP.Primary.ClipSize = 25 -- DefaultClip is automatically set.
 
 SWEP.RecoilRise = 0.4
-SWEP.RecoilPunch = 0
+SWEP.RecoilPunch = 0.65
 
-SWEP.Delay = 60 / 1000 -- 60 / RPM.
+SWEP.Delay = 60 / 900
 SWEP.Firemodes = {
     {
         Mode = 2,
@@ -33,18 +33,13 @@ SWEP.Firemodes = {
     {
         Mode = -3,
     },
-    {
-        Mode = 0
-    }
 }
 
 
-SWEP.ShootVol = 75 -- volume of shoot sound
-
-SWEP.FirstShootSound = "arccw_go/famas/famas_01.wav"
-SWEP.ShootSound = "arccw_go/famas/famas_04.wav"
-SWEP.ShootSoundSilenced = "arccw_go/m4a1/m4a1_silencer_01.wav"
-SWEP.DistantShootSound = "arccw_go/famas/famas-1-distant.wav"
+SWEP.FirstShootSound = ")arccw_go/famas/famas_02.wav"
+SWEP.ShootSound = {")arccw_go/famas/famas_01.wav",")arccw_go/famas/famas_03.wav",")arccw_go/famas/famas_04.wav"}
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound = ")arccw_go/famas/famas_distant_01.wav"
 
 SWEP.MeleeSwingSound = "arccw_go/m249/m249_draw.wav"
 SWEP.MeleeMissSound = "weapons/iceaxe/iceaxe_swing1.wav"
@@ -254,3 +249,5 @@ SWEP.Attachments = {
         },
     },
 }
+
+SWEP.RecoilSide = 0.1

--- a/gamemodes/horde/entities/weapons/arccw_horde_m4.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m4.lua
@@ -20,7 +20,22 @@ SWEP.WorldModel = "models/weapons/arccw_go/v_rif_m4a1.mdl"
 SWEP.Damage = 60
 SWEP.DamageMin = 45 -- damage done at maximum range
 SWEP.Range = 3000 * 0.025 -- in METRES
-SWEP.RecoilPunch = 0
+SWEP.RecoilPunch = 1
 
-SWEP.Delay = 60 / 800 --725 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.Delay = 60 / 750
+
+SWEP.FirstShootSound = {")arccw_go/m4a1/m4a1_01.wav",")arccw_go/m4a1/m4a1_04.wav"}
+SWEP.ShootSound =  {")arccw_go/m4a1/m4a1_02.wav",")arccw_go/m4a1/m4a1_03.wav"}
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound =  ")arccw_go/m4a1/m4a1_distant_01.wav"
+
+SWEP.Firemodes = {
+    {
+        Mode = 2,
+    },
+    {
+        Mode = 1,
+    }
+}
+
+SWEP.RecoilSide = 0.1

--- a/gamemodes/horde/entities/weapons/arccw_horde_sg556.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_sg556.lua
@@ -16,5 +16,20 @@ SWEP.WorldModel = "models/weapons/arccw_go/v_rif_sg556.mdl"
 
 SWEP.Damage = 64
 SWEP.DamageMin = 48  -- damage done at maximum range
-SWEP.RecoilPunch = 0
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.RecoilPunch = 0.4
+
+SWEP.FirstShootSound = {")arccw_go/sg556/sg556_02.wav",")arccw_go/sg556/sg556_03.wav"}
+SWEP.ShootSound =  {")arccw_go/sg556/sg556_01.wav",")arccw_go/sg556/sg556_04.wav"}
+SWEP.ShootSoundSilenced = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+SWEP.DistantShootSound = ")arccw_go/sg556/sg556_distant.wav"
+
+SWEP.Firemodes = {
+    {
+        Mode = 2,
+    },
+    {
+        Mode = 1,
+    }
+}
+
+SWEP.RecoilSide = 0.1


### PR DESCRIPTION
Because Arctic couldn't balance the Gunsmith Offensive weapons to actually be somewhat usable, I decided it was time to do some small changes to some of the rifles.

The following weapons have been changed:
- AK47
- AR15
- AUG
- FAMAS
- Galil
- M4A1
- SG556

### Changes
All weapons have had their horizontal recoil reduced to 0.1, this allows the user to actually rely on their recoil control and aim to hit their targets instead of playing a Parkinson's simulation with recoil.

In addition to the horizontal recoil changes, recoil punch has been increased in some cases.

The following weapons have had changes to their fire rate:
- AK47 - **525** _(Old 600)_
- AR15 - **675** _(Old 800)_
- AUG - **650** _(Old 700)_
- FAMAS - **900** _(Old 1000)_
- M4A1 - **750** _(Old 800)_

Lastly, changes were made to what sounds are played while shooting. Some guns will have a noticeable difference while others will not.

Overall some of the Gunsmith Offensive rifles should now feel better to shoot and control.