### PR TITLE
Engineer Hotfix

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_smg_turret/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_smg_turret/init.lua
@@ -91,10 +91,15 @@ ENT.Immune_AcidPoisonRadiation = true
 function ENT:CustomOnInitialize()
     self:SetCollisionBounds( Vector( 13, 13, 60 ), Vector( -13, -13, 0 ) )
     self:PhysicsInit( SOLID_VPHYSICS )
-    self:SetCollisionGroup( COLLISION_GROUP_PASSABLE_DOOR )
+    self:SetCollisionGroup( COLLISION_GROUP_WORLD )
 
-    timer.Simple( 0.1, function ()
+    timer.Simple( 0, function ()
         HORDE:DropTurret( self )
+
+        if self.Horde_Is_Mini_Sentry then
+            self:SetMaxHealth(200)
+            self:SetHealth(200)
+        end
     end )
 end
 

--- a/gamemodes/horde/entities/entities/npc_vj_horde_sniper_turret/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_sniper_turret/init.lua
@@ -5,7 +5,7 @@ include('shared.lua')
 	No parts of this code or any of its contents may be reproduced, copied, modified or adapted,
 	without the prior written consent of the author, unless otherwise indicated for stand-alone materials.
 -----------------------------------------------*/
-ENT.Model = {"models/combine_turrets/ground_turret.mdl"} -- The game will pick a random model from the table when the SNPC is spawned | Add as many as you want
+ENT.Model = "models/combine_turrets/floor_turret.mdl" -- The game will pick a random model from the table when the SNPC is spawned | Add as many as you want
 ENT.StartHealth = 400
 ENT.SightDistance = 8000
 ENT.HullType = HULL_HUMAN
@@ -87,14 +87,16 @@ ENT.Horde_Immune_Status = {
 }
 ENT.Immune_AcidPoisonRadiation = true
 
-function ENT:CustomOnInitialize()
-	self:SetModelScale(1.5, 0)
-	self:PhysicsInitBox(Vector(20, 20, -0.1), Vector(-20, -20, -40))
-	self:SetCollisionBounds(Vector(13, 13, 20), Vector(-13, -13, 0))
-	self:PhysWake()
+function ENT:CustomOnInitialize() -- phoenix_storms/stripes
+	self:SetModelScale(1.3, 0)
+	self:SetCollisionBounds(Vector(15, 15, 60), Vector(-15, -15, 0))
+	self:PhysicsInit(SOLID_VPHYSICS)
+	self:SetCollisionGroup(COLLISION_GROUP_WORLD)
+
+	self:SetMaterial("phoenix_storms/stripes")
+	self:SetColor(Color(150, 0, 0))
 
 	timer.Simple(0, function()
-		self:SetAngles(Angle(0,0,180))
 		timer.Simple(0.1, function()
 			HORDE:DropTurret(self)
 		end)

--- a/gamemodes/horde/entities/entities/npc_vj_horde_sniper_turret/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_sniper_turret/init.lua
@@ -90,7 +90,7 @@ ENT.Immune_AcidPoisonRadiation = true
 function ENT:CustomOnInitialize()
 	self:SetModelScale(1.5, 0)
 	self:PhysicsInitBox(Vector(20, 20, -0.1), Vector(-20, -20, -40))
-	self:SetCollisionBounds(Vector(13, 13, 60), Vector(-13, -13, 0))
+	self:SetCollisionBounds(Vector(13, 13, 20), Vector(-13, -13, 0))
 	self:PhysWake()
 
 	timer.Simple(0, function()

--- a/gamemodes/horde/entities/entities/npc_vj_horde_sniper_turret/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_sniper_turret/init.lua
@@ -88,13 +88,16 @@ ENT.Horde_Immune_Status = {
 ENT.Immune_AcidPoisonRadiation = true
 
 function ENT:CustomOnInitialize()
+	self:SetModelScale(1.5, 0)
+	self:PhysicsInitBox(Vector(20, 20, -0.1), Vector(-20, -20, -40))
 	self:SetCollisionBounds(Vector(13, 13, 60), Vector(-13, -13, 0))
-	self:SetModelScale(1.5)
-	self:PhysicsInit(SOLID_VPHYSICS)
+	self:PhysWake()
 
-	timer.Simple(0.1, function ()
+	timer.Simple(0, function()
 		self:SetAngles(Angle(0,0,180))
-		HORDE:DropTurret(self)
+		timer.Simple(0.1, function()
+			HORDE:DropTurret(self)
+		end)
 	end)
 end
 
@@ -171,18 +174,9 @@ end
 VJ.AddNPC("Sniper Turret","npc_vj_horde_sniper_turret", "Horde")
 ENT.Horde_TurretMinion = true
 
--- This is the only turret that really needs the cooldown as it tends to get stuck in the ground without one
-ENT.Horde_PickupCooldown = ENT.Horde_PickupCooldown or 0
-
 function ENT:Follow(ply)
 	if self:GetNWEntity("HordeOwner") ~= ply then return end
-	if self.Horde_PickupCooldown > CurTime() then
-		HORDE:SendNotification("Please wait to pick up your turret again...", 1, ply)
-		return
-	end
 
 	self:GetPhysicsObject():EnableMotion(true)
 	ply:PickupObject(self)
-
-	self.Horde_PickupCooldown = CurTime() + 0.57
 end

--- a/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
@@ -24,6 +24,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,0,0,255))
     ent:Spawn()
+    ent.Horde_Is_Mini_Sentry = true
 
     local npc_info = list.Get("NPC")[ent:GetClass()]
     if not npc_info then

--- a/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
@@ -2,7 +2,7 @@ GADGET.PrintName = "Turret Pack"
 GADGET.Description = "Deploys a temporary turret.\nTurret has 50% less health.\nTurret is destroyed when duration expires."
 GADGET.Icon = "items/gadgets/turret_pack.png"
 GADGET.Duration = 20
-GADGET.Cooldown = 1
+GADGET.Cooldown = 30
 GADGET.Active = true
 GADGET.Params = {
 }
@@ -24,7 +24,6 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,0,0,255))
     ent:Spawn()
-    ent.Horde_Is_Mini_Sentry = true
 
     local npc_info = list.Get("NPC")[ent:GetClass()]
     if not npc_info then

--- a/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
@@ -2,7 +2,7 @@ GADGET.PrintName = "Turret Pack"
 GADGET.Description = "Deploys a temporary turret.\nTurret has 50% less health.\nTurret is destroyed when duration expires."
 GADGET.Icon = "items/gadgets/turret_pack.png"
 GADGET.Duration = 20
-GADGET.Cooldown = 30
+GADGET.Cooldown = 1
 GADGET.Active = true
 GADGET.Params = {
 }
@@ -25,6 +25,13 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetColor(Color(255,0,0,255))
     ent:Spawn()
     ent.Horde_Is_Mini_Sentry = true
+
+    local npc_info = list.Get("NPC")[ent:GetClass()]
+    if not npc_info then
+        print("[HORDE] NPC does not exist in ", list.Get("NPC"))
+    end
+
+    HORDE:DropTurret(ent)
 
     ply:Horde_SetMinionCount(ply:Horde_GetMinionCount() + 1)
 

--- a/gamemodes/horde/gamemode/perks/engineer/engineer_base.lua
+++ b/gamemodes/horde/gamemode/perks/engineer/engineer_base.lua
@@ -13,44 +13,11 @@ PERK.Params = {
     [4] = {value = 400},
     [5] = {value = 15},
 }
-
 PERK.Hooks = {}
-PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
-    if SERVER and perk == "engineer_base" then
-    end
-end
-
-PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
-    if SERVER and perk == "engineer_base" then
-    end
-end
 
 PERK.Hooks.Horde_OnPlayerMinionDamage = function (ply, npc, bonus, dmginfo)
     if ply:Horde_GetPerk("engineer_base") then
-        local class = dmginfo:GetInflictor():GetClass()
-        if class == "npc_vj_smg_turret" then
-            bonus.more = bonus.more * 5
-        end
         bonus.increase = bonus.increase + ply:Horde_GetPerkLevelBonus("engineer_base")
-    end
-end
-
-if SERVER then
-    PERK.Hooks.OnEntityCreated = function(ent)
-        if not ent:IsValid() then return end
-        timer.Simple( 0.1, function()
-            if not ent:IsValid() then return end
-            local ply = ent:GetNWEntity("HordeOwner")
-            if ply:IsPlayer() and ply:Horde_GetPerk("engineer_base") and ent:IsNPC() and ent:GetClass() == "npc_vj_horde_smg_turret" and ent:GetMaxHealth() < 400 then
-                if ent.Horde_Is_Mini_Sentry then
-                    ent:SetMaxHealth(200)
-                    ent:SetHealth(200)
-                else
-                    ent:SetMaxHealth(400)
-                    ent:SetHealth(400)
-                end
-            end
-        end )
     end
 end
 

--- a/gamemodes/horde/gamemode/sv_economy.lua
+++ b/gamemodes/horde/gamemode/sv_economy.lua
@@ -728,9 +728,11 @@ function HORDE:DropTurret(ent)
     local turret_class = ent:GetClass()
     local turret_pos = ent:GetPos()
 
-    local tr = util.TraceLine({
+    local tr = util.TraceHull({
         start = turret_pos,
-        endpos = turret_pos + Vector(0,0,-1) * 10000,
+        endpos = turret_pos + Vector(0, 0, -1) * 10000,
+        mins = ent:OBBMins(),
+        maxs = ent:OBBMaxs(),
         filter = {"prop_static", "prop_dynamic"},
         whitelist = true,
         mask = MASK_SOLID,
@@ -743,7 +745,12 @@ function HORDE:DropTurret(ent)
         ent:SetPos(Vector(turret_pos.x, turret_pos.y, tr.HitPos.z) + vector_up)
 
         if not ent:IsValid() then return end
-        ent:GetPhysicsObject():EnableMotion(false)
+        timer.Simple(0, function()
+            local phys = ent:GetPhysicsObject()
+            if phys then
+                phys:EnableMotion(false)
+            end
+        end)
     end
 
     -- Turrets should always stay straight.

--- a/gamemodes/horde/gamemode/sv_economy.lua
+++ b/gamemodes/horde/gamemode/sv_economy.lua
@@ -757,9 +757,7 @@ function HORDE:DropTurret(ent)
     local ang = ent:GetAngles()
     ang.p = 0
     ang.r = 0
-    if turret_class == "npc_vj_horde_sniper_turret" then
-        ang.r = 180
-    elseif turret_class == "npc_vj_horde_rocket_turret" or ent:GetClass() == "npc_vj_horde_laser_turret" then
+    if turret_class == "npc_vj_horde_rocket_turret" or ent:GetClass() == "npc_vj_horde_laser_turret" then
         ang.y = 0
     end
     ent:SetAngles(ang)

--- a/gamemodes/horde/gamemode/sv_economy.lua
+++ b/gamemodes/horde/gamemode/sv_economy.lua
@@ -725,37 +725,41 @@ function GM:PlayerUse(other_ply, target)    -- This will make it to be default b
 end
 
 function HORDE:DropTurret(ent)
+    local turret_class = ent:GetClass()
     local turret_pos = ent:GetPos()
+
     local tr = util.TraceLine({
         start = turret_pos,
         endpos = turret_pos + Vector(0,0,-1) * 10000,
-        filter = ent,
-        collisiongroup =  COLLISION_GROUP_WORLD
+        filter = {"prop_static", "prop_dynamic"},
+        whitelist = true,
+        mask = MASK_SOLID,
     })
 
     if IsValid(tr.Entity) or tr.HitWorld then
         local dist_sqr = turret_pos:DistToSqr(tr.HitPos)
         -- If you drop turrets from somewhere too high, they will just fall over.
         if dist_sqr >= 40000 then return end
-        ent:SetPos(Vector(turret_pos.x, turret_pos.y, tr.HitPos.z))
+        ent:SetPos(Vector(turret_pos.x, turret_pos.y, tr.HitPos.z) + vector_up)
 
         if not ent:IsValid() then return end
         ent:GetPhysicsObject():EnableMotion(false)
     end
+
+    -- Turrets should always stay straight.
+    local ang = ent:GetAngles()
+    ang.p = 0
+    ang.r = 0
+    if turret_class == "npc_vj_horde_sniper_turret" then
+        ang.r = 180
+    elseif turret_class == "npc_vj_horde_rocket_turret" or ent:GetClass() == "npc_vj_horde_laser_turret" then
+        ang.y = 0
+    end
+    ent:SetAngles(ang)
 end
 
 hook.Add("OnPlayerPhysicsDrop", "Horde_TurretDrop", function (ply, ent, thrown)
     if ent:GetNWEntity("HordeOwner") and ent.Horde_TurretMinion then
-        -- Turrets should always stay straight.
-        local a = ent:GetAngles()
-        if ent:GetClass() == "npc_vj_horde_sniper_turret" then
-            ent:SetAngles(Angle(a.x,a.y,180))
-        elseif ent:GetClass() == "npc_vj_horde_rocket_turret" || ent:GetClass() == "npc_vj_horde_laser_turret" then
-            ent:SetAngles(angle_zero)
-        else
-            ent:SetAngles(Angle(0, a.y, 0))
-        end
-
         HORDE:DropTurret(ent)
     end
 end)


### PR DESCRIPTION
## Changes
**Turrets**
- Fix SMG turret collisions
- Fix Sniper turret getting stuck (and removed cooldown)
Made the sniper turret just a resized floor turret

**Turret Pack**
- Fix missing HORDE:DropTurret()
- Fix missing missing NPC check

**Engineer Base**
- Removed empty Horde_OnSetPerk and Horde_OnUnsetPerk hooks
- Removed dmg buff for SMG turret (No longer needed as SMG turret's dmg can be manually increased)
- Removed Horde_Is_Mini_Sentry Health Set (Now handled by the turret's init)

**sv_economy**
- Improved HORDE:DropTurret() Code

## Issues:
- Turrets phase though prop_static and prop_dynamic and can float inside of them (Issue with their collisions being COLLISION_GROUP_WORLD)