### PR TITLE
Port separation of base and subclass shop

### DIFF
--- a/gamemodes/horde/gamemode/gui/cl_shop.lua
+++ b/gamemodes/horde/gamemode/gui/cl_shop.lua
@@ -191,13 +191,13 @@ function PANEL:Init()
         return btn
     end
 
-    local class = MySelf:Horde_GetClass()
+    local class = MySelf:Horde_GetCurrentSubclass()
 
     for _, category in pairs(HORDE.categories) do
         local items = {}
 
         for _, item in pairs(HORDE.items) do
-            if item.category == category and ((item.whitelist == nil) or (item.whitelist and item.whitelist[class.name]) or (MySelf:Horde_GetCurrentSubclass() == "Gunslinger" and item.category == "Pistol")) then
+            if item.category == category and ((item.whitelist == nil) or (item.whitelist and item.whitelist[class])) then
                 if (item.category == "Gadget" and MySelf:Horde_GetGadget() == item.class) or MySelf:HasWeapon(item.class) then
                     item.cmp = -1
                 else

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -7,20 +7,20 @@ HORDE.ENTITY_PROPERTY_DROP = 3
 HORDE.ENTITY_PROPERTY_ARMOR = 4
 HORDE.ENTITY_PROPERTY_GADGET = 5
 
-HORDE.categories = {"Melee", "Pistol", "SMG", "Shotgun", "Rifle", "MG", "Explosive", "Special", "Equipment", "Attachment", "Gadget"}
-HORDE.entity_categories = {"Special", "Equipment"}
-HORDE.arccw_attachment_categories = {"Optic", "Underbarrel", "Tactical", "Barrel", "Muzzle", "Magazine", "Stock", "Slide", "Ammo Type", "Perk"}
+HORDE.categories = { "Melee", "Pistol", "SMG", "Shotgun", "Rifle", "MG", "Explosive", "Special", "Equipment", "Attachment", "Gadget" }
+HORDE.entity_categories = { "Special", "Equipment" }
+HORDE.arccw_attachment_categories = { "Optic", "Underbarrel", "Tactical", "Barrel", "Muzzle", "Magazine", "Stock", "Slide", "Ammo Type", "Perk" }
 HORDE.starter_weapons = {}
 
 HORDE.max_weight = 15
 HORDE.default_ammo_price = 10
 
 -- Creates a Horde item. The item will appear in the shop.
-function HORDE:CreateItem(category, name, class, price, weight, description, whitelist, ammo_price, secondary_ammo_price, entity_properties, shop_icon, levels, skull_tokens, dmgtype, infusions, starter_classes, hidden)
+function HORDE:CreateItem( category, name, class, price, weight, description, whitelist, ammo_price, secondary_ammo_price, entity_properties, shop_icon, levels, skull_tokens, dmgtype, infusions, starter_classes, hidden )
     if category == nil or name == nil or class == nil or price == nil or weight == nil or description == nil then return end
     if name == "" or class == "" then return end
-    if not table.HasValue(HORDE.categories, category) then return end
-    if string.len(name) <= 0 or string.len(class) <= 0 then return end
+    if not table.HasValue( HORDE.categories, category ) then return end
+    if string.len( name ) <= 0 or string.len( class ) <= 0 then return end
     if price < 0 or weight < 0 then return end
     local item = {}
     item.category = category
@@ -36,10 +36,10 @@ function HORDE:CreateItem(category, name, class, price, weight, description, whi
     if entity_properties then
         item.entity_properties = entity_properties
     else
-        item.entity_properties = {type=HORDE.ENTITY_PROPERTY_WPN}
+        item.entity_properties = { type = HORDE.ENTITY_PROPERTY_WPN }
     end
     if item.class == "_horde_armor_100" then
-        item.entity_properties = {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}
+        item.entity_properties = { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }
     end
     if shop_icon and shop_icon ~= "" then
         item.shop_icon = shop_icon
@@ -48,7 +48,7 @@ function HORDE:CreateItem(category, name, class, price, weight, description, whi
     if levels then
         item.levels = levels
         local total_levels = 0
-        for _, level in pairs(levels) do
+        for _, level in pairs( levels ) do
             total_levels = total_levels + level
         end
         item.total_levels = total_levels
@@ -61,21 +61,21 @@ function HORDE:CreateItem(category, name, class, price, weight, description, whi
     HORDE:SetItemsData()
 end
 
-function HORDE:CreateGadgetItem(class, price, weight, whitelist, levels, dmgtype, hidden)
+function HORDE:CreateGadgetItem( class, price, weight, whitelist, levels, dmgtype, hidden )
     local gadget = HORDE.gadgets[class]
     if not gadget then
-        print("[HORDE] Gadget " .. class .. " not found.")
+        print( "[HORDE] Gadget " .. class .. " not found." )
         return
     end
-    HORDE:CreateItem("Gadget", gadget.PrintName, class, price, weight, "", whitelist, 10, -1, {type=HORDE.ENTITY_PROPERTY_GADGET}, nil, levels, nil, dmgtype, nil, nil, hidden)
+    HORDE:CreateItem( "Gadget", gadget.PrintName, class, price, weight, "", whitelist, 10, -1, { type = HORDE.ENTITY_PROPERTY_GADGET }, nil, levels, nil, dmgtype, nil, nil, hidden )
 end
 
 HORDE.InvalidateHordeItemCache = 1
 HORDE.CachedHordeItems = nil
 HORDE.GetCachedHordeItems = function()
     if HORDE.InvalidateHordeItemCache == 1 then
-        local tab = util.TableToJSON(HORDE.items)
-        local str = util.Compress(tab)
+        local tab = util.TableToJSON( HORDE.items )
+        local str = util.Compress( tab )
         HORDE.CachedHordeItems = str
         HORDE.InvalidateHordeItemCache = 0
     end
@@ -85,34 +85,35 @@ end
 function HORDE:SyncItems()
     local str = HORDE.GetCachedHordeItems()
     if player then
-        for _, ply in pairs(player.GetAll()) do
-            net.Start("Horde_SyncItems")
-                net.WriteUInt(string.len(str), 32)
-                net.WriteData(str, string.len(str))
-            net.Send(ply)
+        for _, ply in pairs( player.GetAll() ) do
+            net.Start( "Horde_SyncItems" )
+                net.WriteUInt( string.len( str ), 32 )
+                net.WriteData( str, string.len( str ) )
+            net.Send( ply )
         end
     end
 end
 
 function HORDE:SetItemsData()
     if SERVER then
-        if GetConVarNumber("horde_default_item_config") == 1 then return end
-        if not file.IsDir("horde", "DATA") then
-            file.CreateDir("horde")
+        local defaultItemConf = GetConVar( "horde_default_item_config" ):GetInt()
+        if defaultItemConf then return end
+        if not file.IsDir( "horde", "DATA" ) then
+            file.CreateDir( "horde" )
         end
 
-        file.Write("horde/items.txt", util.TableToJSON(HORDE.items))
+        file.Write( "horde/items.txt", util.TableToJSON( HORDE.items ) )
 
         HORDE:SyncItems()
     end
 end
 
 local function GetStarterWeapons()
-    for class, item in pairs(HORDE.items) do
+    for class, item in pairs( HORDE.items ) do
         if item.starter_classes then
-            for _, starter_subclass in pairs(item.starter_classes) do
+            for _, starter_subclass in pairs( item.starter_classes ) do
                 if not HORDE.starter_weapons[starter_subclass] then HORDE.starter_weapons[starter_subclass] = {} end
-                table.insert(HORDE.starter_weapons[starter_subclass], class)
+                table.insert( HORDE.starter_weapons[starter_subclass], class )
             end
         end
     end
@@ -120,23 +121,23 @@ end
 
 local function GetItemsData()
     if SERVER then
-        if not file.IsDir("horde", "DATA") then
-            file.CreateDir("horde")
+        if not file.IsDir( "horde", "DATA" ) then
+            file.CreateDir( "horde" )
             return
         end
 
-        if file.Read("horde/items.txt", "DATA") then
-            local t = util.JSONToTable(file.Read("horde/items.txt", "DATA"))
+        if file.Read( "horde/items.txt", "DATA" ) then
+            local t = util.JSONToTable( file.Read( "horde/items.txt", "DATA" ) )
 
-            for _, item in pairs(t) do
+            for _, item in pairs( t ) do
                 if item.name == "" or item.class == "" or item.name == nil or item.category == nil or item.class == nil or item.ammo_price == nil or item.secondary_ammo_price == nil then
-                    HORDE:SendNotification("Item config file validation failed! Please update your file or delete it.", 1)
+                    HORDE:SendNotification( "Item config file validation failed! Please update your file or delete it.", 1 )
                     return
                 end
             end
             HORDE.items = t
 
-            print("[HORDE] - Loaded custom item config.")
+            print( "[HORDE] - Loaded custom item config." )
         end
 
         GetStarterWeapons()
@@ -146,93 +147,103 @@ local function GetItemsData()
 end
 
 function HORDE:GetDefaultGadgets()
-    HORDE:CreateGadgetItem("gadget_detoxifier", 1500, 0, nil, {Medic=4})
-    HORDE:CreateGadgetItem("gadget_heat_plating", 1500, 0, nil, {Cremator=4})
-    HORDE:CreateGadgetItem("gadget_arctic_plating", 1500, 0, nil)
-    HORDE:CreateGadgetItem("gadget_shock_plating", 1500, 0, nil, {Warden=4})
-    HORDE:CreateGadgetItem("gadget_blast_plating", 1500, 0, nil, {Demolition=4})
-    HORDE:CreateGadgetItem("gadget_diamond_plating", 1750, 0, nil, {Berserker=3,Heavy=3})
-    HORDE:CreateGadgetItem("gadget_corporate_mindset", 2000, 0, nil, {Survivor=5,Medic=5,Assault=5,Demolition=5,Berserker=5,Engineer=5,Warden=5,Cremator=5,Heavy=5,Ghost=5})
+    HORDE:CreateGadgetItem( "gadget_detoxifier", 1500, 0, nil, { Medic = 4 } )
+    HORDE:CreateGadgetItem( "gadget_heat_plating", 1500, 0, nil, { Cremator = 4 } )
+    HORDE:CreateGadgetItem( "gadget_arctic_plating", 1500, 0, nil )
+    HORDE:CreateGadgetItem( "gadget_shock_plating", 1500, 0, nil, { Warden = 4 } )
+    HORDE:CreateGadgetItem( "gadget_blast_plating", 1500, 0, nil, { Demolition = 4 } )
+    HORDE:CreateGadgetItem( "gadget_diamond_plating", 1750, 0, nil, { Heavy = 3, Berserker = 3 } )
+    HORDE:CreateGadgetItem( "gadget_corporate_mindset", 2000, 0, nil, { Survivor = 5, Assault = 5, Heavy = 5, Medic = 5, Demolition = 5, Ghost = 5, Engineer = 5, Berserker = 5, Warden = 5, Cremator = 5 } )
 
-    HORDE:CreateGadgetItem("gadget_vitality_booster", 2500, 1, {Survivor=true}, {Survivor=5})
-    HORDE:CreateGadgetItem("gadget_damage_booster", 2500, 1, {Survivor=true}, {Survivor=10})
-    HORDE:CreateGadgetItem("gadget_agility_booster", 2500, 1, {Survivor=true}, {Survivor=15})
-    HORDE:CreateGadgetItem("gadget_resistance_booster", 2500, 1, {Survivor=true}, {Survivor=20})
-    HORDE:CreateGadgetItem("gadget_ultimate_booster", 4000, 3, {Survivor=true}, {Survivor=25})
+    -- Survivor --
+    HORDE:CreateGadgetItem( "gadget_vitality_booster", 2500, 1, { Survivor = true, Psycho = true }, { Survivor = 5 } )
+    HORDE:CreateGadgetItem( "gadget_damage_booster", 2500, 1, { Survivor = true, Psycho = true }, { Survivor = 10 } )
+    HORDE:CreateGadgetItem( "gadget_agility_booster", 2500, 1, { Survivor = true, Psycho = true }, { Survivor = 15 } )
+    HORDE:CreateGadgetItem( "gadget_resistance_booster", 2500, 1, { Survivor = true, Psycho = true }, { Survivor = 20 } )
+    HORDE:CreateGadgetItem( "gadget_ultimate_booster", 4000, 3, { Survivor = true, Psycho = true }, { Survivor = 25 } )
 
-    HORDE:CreateGadgetItem("gadget_iv_injection", 2000, 1, {Assault=true}, {Assault=5})
-    HORDE:CreateGadgetItem("gadget_cortex", 2500, 1, {Assault=true}, {Assault=10})
-    HORDE:CreateGadgetItem("gadget_neuro_amplifier", 3000, 2, {Assault=true}, {Assault=15})
-    HORDE:CreateGadgetItem("gadget_ouroboros", 3000, 3, {Assault=true}, {Assault=20})
-    --HORDE:CreateGadgetItem("gadget_hyperdrive", 3250, 1, {Assault=true}, {Assault=25})
+    -- Assault --
+    HORDE:CreateGadgetItem( "gadget_iv_injection", 2000, 1, { Assault = true, SpecOps = true, Reverend = true }, { Assault = 5 } )
+    HORDE:CreateGadgetItem( "gadget_cortex", 2500, 1, { Assault = true, SpecOps = true, Reverend = true }, { Assault = 10 } )
+    HORDE:CreateGadgetItem( "gadget_neuro_amplifier", 3000, 2, { Assault = true, SpecOps = true, Reverend = true }, { Assault = 15 } )
+    HORDE:CreateGadgetItem( "gadget_ouroboros", 3000, 3, { Assault = true, SpecOps = true, Reverend = true }, { Assault = 20 } )
+    -- HORDE:CreateGadgetItem( "gadget_hyperdrive", 3250, 1, { Assault=true, SpecOps = true, Reverend = true }, { Assault = 25 } )
 
-    HORDE:CreateGadgetItem("gadget_life_diffuser", 2000, 1, {Medic=true}, {Medic=5}, {HORDE.DMG_POISON})
-    HORDE:CreateGadgetItem("gadget_projectile_launcher_heal", 2500, 2, {Medic=true}, {Medic=10}, {HORDE.DMG_POISON})
-    HORDE:CreateGadgetItem("gadget_healing_beam", 2500, 2, {Medic=true}, {Medic=15}, {HORDE.DMG_POISON})
-    HORDE:CreateGadgetItem("gadget_steroid", 3000, 1, {Medic=true}, {Medic=20})
-    HORDE:CreateGadgetItem("gadget_aegis", 3000, 1, {Medic=true}, {Medic=25})
+    -- Heavy --
+    HORDE:CreateGadgetItem( "gadget_energy_shield", 2000, 1, { Heavy = true, Carcass = true, Juggernaut = true }, { Heavy = 5 } )
+    HORDE:CreateGadgetItem( "gadget_hardening_injection", 2500, 1, { Heavy = true, Carcass = true, Juggernaut = true }, { Heavy = 10 } )
+    HORDE:CreateGadgetItem( "gadget_exoskeleton", 2750, 3, { Heavy = true, Carcass = true, Juggernaut = true }, { Heavy = 15 } )
+    HORDE:CreateGadgetItem( "gadget_ulpa_filter", 3000, 1, { Heavy = true, Carcass = true, Juggernaut = true }, { Heavy = 20 } )
+    HORDE:CreateGadgetItem( "gadget_armor_fusion", 3000, 2, { Heavy = true, Carcass = true, Juggernaut = true }, { Heavy = 25 } )
 
-    HORDE:CreateGadgetItem("gadget_energy_shield", 2000, 1, {Heavy=true}, {Heavy=5})
-    HORDE:CreateGadgetItem("gadget_hardening_injection", 2500, 1, {Heavy=true}, {Heavy=10})
-    HORDE:CreateGadgetItem("gadget_exoskeleton", 2750, 3, {Heavy=true}, {Heavy=15})
-    HORDE:CreateGadgetItem("gadget_ulpa_filter", 3000, 1, {Heavy=true}, {Heavy=20})
-    HORDE:CreateGadgetItem("gadget_armor_fusion",    3000, 2, {Heavy=true}, {Heavy=25})
+    -- Medic --
+    HORDE:CreateGadgetItem( "gadget_life_diffuser", 2000, 1, { Medic = true, Hatcher = true }, { Medic = 5 }, { HORDE.DMG_POISON } )
+    HORDE:CreateGadgetItem( "gadget_projectile_launcher_heal", 2500, 2, { Medic = true, Hatcher = true }, { Medic = 10 }, { HORDE.DMG_POISON } )
+    HORDE:CreateGadgetItem( "gadget_healing_beam", 2500, 2, { Medic = true, Hatcher = true }, { Medic = 15 }, { HORDE.DMG_POISON } )
+    HORDE:CreateGadgetItem( "gadget_steroid", 3000, 1, { Medic = true, Hatcher = true }, { Medic = 20 } )
+    HORDE:CreateGadgetItem( "gadget_aegis", 3000, 1, { Medic = true, Hatcher = true }, { Medic = 25 } )
 
-    HORDE:CreateGadgetItem("gadget_proximity_defense", 2000, 1, {Demolition=true}, {Demolition=5})
-    HORDE:CreateGadgetItem("gadget_projectile_launcher_blast", 2500, 2, {Demolition=true}, {Demolition=10}, {HORDE.DMG_BLAST})
-    HORDE:CreateGadgetItem("gadget_nitrous_propellor", 2500, 2, {Demolition=true}, {Demolition=15})
-    HORDE:CreateGadgetItem("gadget_ied", 3000, 3, {Demolition=true}, {Demolition=20}, {HORDE.DMG_BLAST})
-    HORDE:CreateGadgetItem("gadget_nuke", 3000, 4, {Demolition=true}, {Demolition=25}, {HORDE.DMG_BLAST})
+    -- Demolition --
+    HORDE:CreateGadgetItem( "gadget_proximity_defense", 2000, 1, { Demolition = true, Warlock = true }, { Demolition = 5 } )
+    HORDE:CreateGadgetItem( "gadget_projectile_launcher_blast", 2500, 2, { Demolition = true, Warlock = true }, { Demolition = 10 }, { HORDE.DMG_BLAST } )
+    HORDE:CreateGadgetItem( "gadget_nitrous_propellor", 2500, 2, { Demolition = true, Warlock = true }, { Demolition = 15 } )
+    HORDE:CreateGadgetItem( "gadget_ied", 3000, 3, { Demolition = true, Warlock = true }, { Demolition = 20 }, { HORDE.DMG_BLAST } )
+    HORDE:CreateGadgetItem( "gadget_nuke", 3000, 4, { Demolition = true, Warlock = true }, { Demolition = 25 }, { HORDE.DMG_BLAST } )
 
-    HORDE:CreateGadgetItem("gadget_optical_camouflage", 2500, 1, {Ghost=true}, {Ghost=5})
-    HORDE:CreateGadgetItem("gadget_projectile_launcher_ballistic", 2500, 2, {Ghost=true}, {Ghost=10}, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateGadgetItem("gadget_death_mark", 2500, 2, {Ghost=true}, {Ghost=15}, {HORDE.DMG_BLUNT})
-    HORDE:CreateGadgetItem("gadget_assassin_optics", 3000, 2, {Ghost=true}, {Ghost=20})
+    -- Ghost --
+    HORDE:CreateGadgetItem( "gadget_optical_camouflage", 2500, 1, { Ghost = true, Gunslinger = true }, { Ghost = 5 } )
+    HORDE:CreateGadgetItem( "gadget_projectile_launcher_ballistic", 2500, 2, { Ghost = true, Gunslinger = true }, { Ghost = 10 }, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateGadgetItem( "gadget_death_mark", 2500, 2, { Ghost = true, Gunslinger = true }, { Ghost = 15 }, { HORDE.DMG_BLUNT } )
+    HORDE:CreateGadgetItem( "gadget_assassin_optics", 3000, 2, { Ghost = true, Gunslinger = true }, { Ghost = 20 } )
 
-    HORDE:CreateGadgetItem("gadget_quantum_tunnel", 2000, 1, {Engineer=true}, {Engineer=5})
-    HORDE:CreateGadgetItem("gadget_voidout", 2250, 1, {Engineer=true}, {Engineer=10})
-    HORDE:CreateGadgetItem("gadget_turret_pack", 2500, 2, {Engineer=true}, {Engineer=15})
-    HORDE:CreateGadgetItem("gadget_e_parasite", 2750, 2, {Engineer=true}, {Engineer=20}, {HORDE.DMG_BLUNT})
-    --HORDE:CreateGadgetItem("gadget_aerial_turret", 2500, 3, {Engineer=true}, {Engineer=25})
+    -- Engineer --
+    HORDE:CreateGadgetItem( "gadget_quantum_tunnel", 2000, 1, { Engineer = true, Necromancer = true }, { Engineer = 5 } )
+    HORDE:CreateGadgetItem( "gadget_voidout", 2250, 1, { Engineer = true, Necromancer = true }, { Engineer = 10 } )
+    HORDE:CreateGadgetItem( "gadget_turret_pack", 2500, 2, { Engineer = true, Necromancer = true }, { Engineer = 15 } )
+    HORDE:CreateGadgetItem( "gadget_e_parasite", 2750, 2, { Engineer = true, Necromancer = true }, { Engineer = 20 }, { HORDE.DMG_BLUNT } )
+    -- HORDE:CreateGadgetItem( "gadget_aerial_turret", 2500, 3, { Engineer = true, Necromancer = true }, { Engineer = 25 } )
 
-    HORDE:CreateGadgetItem("gadget_chakra", 2500, 1, {Berserker=true}, {Berserker=5})
-    HORDE:CreateGadgetItem("gadget_flash", 2500, 2, {Berserker=true}, {Berserker=10}, {HORDE.DMG_SLASH})
-    HORDE:CreateGadgetItem("gadget_berserk_armor", 2500, 2, {Berserker=true}, {Berserker=15})
-    HORDE:CreateGadgetItem("gadget_hemocannon", 3000, 3, {Berserker=true}, {Berserker=20}, {HORDE.DMG_SLASH})
-    HORDE:CreateGadgetItem("gadget_omnislash", 3250, 2, {Berserker=true}, {Berserker=25}, {HORDE.DMG_SLASH})
+    -- Berserker --
+    HORDE:CreateGadgetItem( "gadget_chakra", 2500, 1, { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true }, { Berserker = 5 } )
+    HORDE:CreateGadgetItem( "gadget_flash", 2500, 2, { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true }, { Berserker = 10 }, { HORDE.DMG_SLASH } )
+    HORDE:CreateGadgetItem( "gadget_berserk_armor", 2500, 2, { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true }, { Berserker = 15 } )
+    HORDE:CreateGadgetItem( "gadget_hemocannon", 3000, 3, { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true }, { Berserker = 20 }, { HORDE.DMG_SLASH } )
+    HORDE:CreateGadgetItem( "gadget_omnislash", 3250, 2, { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true }, { Berserker = 25 }, { HORDE.DMG_SLASH } )
 
-    HORDE:CreateGadgetItem("gadget_solar_array", 2000, 1, {Warden=true}, {Warden=5})
-    HORDE:CreateGadgetItem("gadget_projectile_launcher_shock", 2500, 2, {Warden=true}, {Warden=10}, {HORDE.DMG_LIGHTNING})
-    HORDE:CreateGadgetItem("gadget_watchtower_pack", 2500, 1, {Warden=true}, {Warden=15})
-    HORDE:CreateGadgetItem("gadget_shock_nova", 3000, 2, {Warden=true}, {Warden=20}, {HORDE.DMG_LIGHTNING})
+    -- Warden --
+    HORDE:CreateGadgetItem( "gadget_solar_array", 2000, 1, { Warden = true }, { Warden = 5 } )
+    HORDE:CreateGadgetItem( "gadget_projectile_launcher_shock", 2500, 2, { Warden = true }, { Warden = 10 }, { HORDE.DMG_LIGHTNING } )
+    HORDE:CreateGadgetItem( "gadget_watchtower_pack", 2500, 1, { Warden = true }, { Warden = 15 } )
+    HORDE:CreateGadgetItem( "gadget_shock_nova", 3000, 2, { Warden = true }, { Warden = 20 }, { HORDE.DMG_LIGHTNING } )
 
-    HORDE:CreateGadgetItem("gadget_butane_can", 2000, 1, {Cremator=true}, {Cremator=5}, {HORDE.DMG_FIRE})
-    HORDE:CreateGadgetItem("gadget_projectile_launcher_fire", 2500, 2, {Cremator=true}, {Cremator=10}, {HORDE.DMG_FIRE})
-    HORDE:CreateGadgetItem("gadget_barbeque", 2750, 1, {Cremator=true}, {Cremator=15})
-    HORDE:CreateGadgetItem("gadget_hydrogen_burner", 3000, 3, {Cremator=true}, {Cremator=20})
-    --HORDE:CreateGadgetItem("gadget_ion_cannon", 3000, 3, {Cremator=true}, {Cremator=25})
+    -- Cremator
+    HORDE:CreateGadgetItem( "gadget_butane_can", 2000, 1, { Cremator = true, Artificer = true }, { Cremator = 5 }, { HORDE.DMG_FIRE } )
+    HORDE:CreateGadgetItem( "gadget_projectile_launcher_fire", 2500, 2, { Cremator = true, Artificer = true }, { Cremator = 10 }, { HORDE.DMG_FIRE } )
+    HORDE:CreateGadgetItem( "gadget_barbeque", 2750, 1, { Cremator = true, Artificer = true }, { Cremator = 15 } )
+    HORDE:CreateGadgetItem( "gadget_hydrogen_burner", 3000, 3, { Cremator = true, Artificer = true }, { Cremator = 20 } )
+    -- HORDE:CreateGadgetItem( "gadget_ion_cannon", 3000, 3, { Cremator = true, Artificer = true }, { Cremator = 25 } )
 
-    -- Droppable Gadgets
-    HORDE:CreateGadgetItem("gadget_vitality_shard", 500, 0)
-    HORDE:CreateGadgetItem("gadget_damage_shard", 500, 0)
-    HORDE:CreateGadgetItem("gadget_agility_shard", 500, 0)
-    HORDE:CreateGadgetItem("gadget_cleansing_shard", 500, 0)
-    HORDE:CreateGadgetItem("gadget_matriarch_womb", 50, 0, nil, nil, nil, true)
-    HORDE:CreateGadgetItem("gadget_unstable_injection", 50, 0, nil, nil, nil, true)
-    HORDE:CreateGadgetItem("gadget_hellfire_tincture", 50, 0, nil, nil, nil, true)
-    HORDE:CreateGadgetItem("gadget_specimen_crystal_small", 200, 0, nil, nil, nil, true)
-    HORDE:CreateGadgetItem("gadget_specimen_crystal_medium", 500, 0, nil, nil, nil, true)
-    HORDE:CreateGadgetItem("gadget_specimen_crystal_large", 1000, 0, nil, nil, nil, true)
-    HORDE:CreateGadgetItem("gadget_elixir", 1000, 0, nil, nil, nil, true)
+    -- Droppable Gadgets --
+    HORDE:CreateGadgetItem( "gadget_vitality_shard", 500, 0 )
+    HORDE:CreateGadgetItem( "gadget_damage_shard", 500, 0 )
+    HORDE:CreateGadgetItem( "gadget_agility_shard", 500, 0 )
+    HORDE:CreateGadgetItem( "gadget_cleansing_shard", 500, 0 )
+    HORDE:CreateGadgetItem( "gadget_matriarch_womb", 50, 0, nil, nil, nil, true )
+    HORDE:CreateGadgetItem( "gadget_unstable_injection", 50, 0, nil, nil, nil, true )
+    HORDE:CreateGadgetItem( "gadget_hellfire_tincture", 50, 0, nil, nil, nil, true )
+    HORDE:CreateGadgetItem( "gadget_specimen_crystal_small", 200, 0, nil, nil, nil, true )
+    HORDE:CreateGadgetItem( "gadget_specimen_crystal_medium", 500, 0, nil, nil, nil, true )
+    HORDE:CreateGadgetItem( "gadget_specimen_crystal_large", 1000, 0, nil, nil, nil, true )
+    HORDE:CreateGadgetItem( "gadget_elixir", 1000, 0, nil, nil, nil, true )
 end
 
 function HORDE:GetDefaultItemInfusions()
-    local melee_blunt_infusions = {HORDE.Infusion_Chrono, HORDE.Infusion_Concussive, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Rejuvenating}
-    local melee_slash_infusions = {HORDE.Infusion_Chrono, HORDE.Infusion_Hemo, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Rejuvenating}
+    local melee_blunt_infusions = { HORDE.Infusion_Chrono, HORDE.Infusion_Concussive, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Rejuvenating }
+    local melee_slash_infusions = { HORDE.Infusion_Chrono, HORDE.Infusion_Hemo, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Rejuvenating }
     HORDE.items["arccw_horde_stunstick"].infusions = melee_blunt_infusions
     HORDE.items["arccw_horde_crowbar"].infusions = melee_blunt_infusions
     HORDE.items["arccw_horde_knife"].infusions = melee_slash_infusions
-    HORDE.items["arccw_horde_kunai"].infusions = {HORDE.Infusion_Chrono, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Rejuvenating}
+    HORDE.items["arccw_horde_kunai"].infusions = { HORDE.Infusion_Chrono, HORDE.Infusion_Hemo, HORDE.Infusion_Concussive, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing, HORDE.Infusion_Septic, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Rejuvenating }
     HORDE.items["arccw_horde_machete"].infusions = melee_slash_infusions
     HORDE.items["arccw_horde_axe"].infusions = melee_slash_infusions
     HORDE.items["arccw_horde_katana"].infusions = melee_slash_infusions
@@ -243,7 +254,7 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_mjollnir"].infusions = melee_blunt_infusions
     HORDE.items["arccw_horde_zweihander"].infusions = melee_slash_infusions
 
-    local ballistic_infusions_light = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver}
+    local ballistic_infusions_light = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver }
     -- Pistols
     HORDE.items["arccw_horde_9mm"].infusions = ballistic_infusions_light
     HORDE.items["arccw_horde_medic_9mm"].infusions = ballistic_infusions_light
@@ -269,7 +280,7 @@ function HORDE:GetDefaultItemInfusions()
 
     --HORDE.items["arccw_horde_flaregun"].infusions = {HORDE.Infusion_Chrono, HORDE.Infusion_Quality}
 
-    local ballistic_infusions_smgs = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver}
+    local ballistic_infusions_smgs = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver }
     -- SMGs
     HORDE.items["arccw_horde_smg1"].infusions = ballistic_infusions_light
     HORDE.items["arccw_horde_mac10"].infusions = ballistic_infusions_smgs
@@ -280,7 +291,7 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_bizon"].infusions = ballistic_infusions_smgs
     HORDE.items["arccw_horde_p90"].infusions = ballistic_infusions_smgs
 
-    local infusions_medic = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Rejuvenating, HORDE.Infusion_Septic}
+    local infusions_medic = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Rejuvenating, HORDE.Infusion_Septic }
     HORDE.items["arccw_horde_mp5k"].infusions = infusions_medic
     HORDE.items["arccw_horde_mp9m"].infusions = infusions_medic
     HORDE.items["arccw_horde_mp7m"].infusions = infusions_medic
@@ -295,15 +306,15 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_mag7"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_m1014"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_doublebarrel"].infusions = ballistic_infusions_shotguns
-    HORDE.items["arccw_horde_trenchgun"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Flaming, HORDE.Infusion_Siphoning}
+    HORDE.items["arccw_horde_trenchgun"].infusions = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Flaming, HORDE.Infusion_Siphoning }
     HORDE.items["arccw_horde_spas12"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_striker"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_hsg1"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_aa12"].infusions = ballistic_infusions_shotguns
-    HORDE.items["arccw_horde_medic_shotgun"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Septic, HORDE.Infusion_Siphoning}
+    HORDE.items["arccw_horde_medic_shotgun"].infusions = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Septic, HORDE.Infusion_Siphoning }
     HORDE.items["arccw_horde_masterkey"].infusions = ballistic_infusions_shotguns
 
-    local ballistic_infusions_rifles = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning}
+    local ballistic_infusions_rifles = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning }
     -- Rifles
     HORDE.items["arccw_horde_ar15"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_famas"].infusions = ballistic_infusions_rifles
@@ -317,7 +328,7 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_scarl"].infusions = ballistic_infusions_rifles
     HORDE.items["arccw_horde_ar2"].infusions = ballistic_infusions_rifles
 
-    local ballistic_infusions_sniper_rifles = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning}
+    local ballistic_infusions_sniper_rifles = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Siphoning }
     HORDE.items["arccw_horde_m14"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_winchester"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_mosin_nagant"].infusions = ballistic_infusions_shotguns
@@ -332,10 +343,10 @@ function HORDE:GetDefaultItemInfusions()
     HORDE.items["arccw_horde_m99"].infusions = ballistic_infusions_sniper_rifles
     HORDE.items["arccw_horde_fucket_rifle"].infusions = ballistic_infusions_shotguns
     HORDE.items["arccw_horde_heat_crossbow"].infusions = ballistic_infusions_sniper_rifles
-    HORDE.items["arccw_horde_medic_rifle"].infusions = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Septic, HORDE.Infusion_Siphoning}
+    HORDE.items["arccw_horde_medic_rifle"].infusions = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Septic, HORDE.Infusion_Siphoning }
     HORDE.items["arccw_horde_m16m203"].infusions = ballistic_infusions_rifles
 
-    local ballistic_infusions_mg_rifles = {HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Titanium, HORDE.Infusion_Siphoning}
+    local ballistic_infusions_mg_rifles = { HORDE.Infusion_Ruination, HORDE.Infusion_Chrono, HORDE.Infusion_Impaling, HORDE.Infusion_Quality, HORDE.Infusion_Titanium, HORDE.Infusion_Siphoning }
     -- MG
     HORDE.items["arccw_horde_negev"].infusions = ballistic_infusions_mg_rifles
     HORDE.items["arccw_horde_m249"].infusions = ballistic_infusions_mg_rifles
@@ -350,370 +361,663 @@ function HORDE:GetDefaultItemInfusions()
     --local projectile_infusions = {}
     HORDE.items["weapon_frag"].infusions = {}
     HORDE.items["weapon_rpg"].infusions = {}
-    HORDE.items["arccw_horde_m79"].infusions = {HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Chrono, HORDE.Infusion_Ruination, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing}
+    HORDE.items["arccw_horde_m79"].infusions = { HORDE.Infusion_Quality, HORDE.Infusion_Quicksilver, HORDE.Infusion_Chrono, HORDE.Infusion_Ruination, HORDE.Infusion_Flaming, HORDE.Infusion_Arctic, HORDE.Infusion_Galvanizing }
     HORDE.items["horde_sticky_launcher"].infusions = {}
     HORDE.items["arccw_horde_m32"].infusions = {}
     HORDE.items["arccw_horde_rpg7"].infusions = {}
     HORDE.items["arccw_horde_usas12"].infusions = {}
     HORDE.items["arccw_horde_m202"].infusions = {}
     HORDE.items["arccw_horde_law"].infusions = {}
-    HORDE.items["arccw_horde_apollo"].infusions = {HORDE.Infusion_Quality}
+    HORDE.items["arccw_horde_apollo"].infusions = { HORDE.Infusion_Quality }
 end
 
 function HORDE:GetDefaultItemsData()
-    HORDE:CreateItem("Melee",      "Combat Knife",   "arccw_horde_knife",    100,  0, "A reliable bayonet.\nRMB to deal a heavy slash.",
-    nil, 10, -1, nil, nil, nil, nil, {HORDE.DMG_SLASH}, nil, {"Berserker", "Samurai", "Cyborg Ninja"})
-    HORDE:CreateItem("Melee",      "Crowbar",        "arccw_horde_crowbar", 750,  2, "A trusty crowbar.\nEasy to use.",
-    nil, 10, -1, nil, "items/hl2/weapon_crowbar.png", nil, nil, {HORDE.DMG_BLUNT})
-    HORDE:CreateItem("Melee",      "Machete",        "arccw_horde_machete", 750,  2, "A large machete.\nEasy to use.",
-    nil, 10, -1, nil, nil, nil, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Melee",      "Kunai",          "arccw_horde_kunai",     1750,  2, "Ranged throwing knives.\nThrown blades are non-retrieveable\n knives recharge every 3 seconds, with a total of 3 knives",
-    {Survivor=true, Berserker=true}, 10, -1, nil, nil, {Berserker=1}, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Melee",      "Fireaxe",        "arccw_horde_axe",       1500,  4, "Fireaxe.\nHeavy, but can chop most enemies in half.",
-    nil, 10, -1, nil, nil, nil, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Melee",      "Stunstick",      "arccw_horde_stunstick", 1500,  4, "Electric baton.\nDeals extra Lightning damage.",
-    nil, 10, -1, nil, "items/hl2/weapon_stunstick.png", nil, nil, {HORDE.DMG_BLUNT, HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Melee",      "Katana",         "arccw_horde_katana",  2000,  4, "Ninja sword.\nLong attack range and fast attack speed.",
-    {Survivor=true, Berserker=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Melee",      "Bat",            "arccw_horde_bat",     2000,  4, "Sturdy baseball bat.\nHits like a truck.",
-    {Survivor=true, Berserker=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BLUNT})
-    HORDE:CreateItem("Melee",      "Chainsaw",       "arccw_horde_chainsaw",2500, 6, "Brrrrrrrrrrrrrrrr.\n\nHold RMB to saw through enemies.\nDeals a lot more damage when using ammo.",
-    {Berserker=true}, 10, -1, nil, nil, {Berserker=2}, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Melee",      "Inferno",        "arccw_horde_inferno_blade",   2500, 6, "A blazing curved sword with hidden power.\n\nPress RMB to activate/deactivate the weapon.\n\nWhen deactivated, the weapon deals Slashing damage.\n\nWhen activated, the weapon deals extra splashing Fire damage.\nHowever, the user takes Fire damage over time.",
-    {Berserker=true, Cremator=true}, 10, -1, nil, nil, {Berserker=2, Cremator=2}, nil , {HORDE.DMG_SLASH, HORDE.DMG_FIRE})
-    HORDE:CreateItem("Melee",      "Jötunn",         "arccw_horde_jotuun",     2500, 6, "A cursed spiked mace forged with permafrost material.\n\nPress RMB to deliver a powerful ice blast.\nPerforming the ice blast increases Frostbite buildup on you.",
-    {Berserker=true}, 10, -1, nil, nil, {Berserker=4}, nil, {HORDE.DMG_BLUNT, HORDE.DMG_COLD})
-    HORDE:CreateItem("Melee",      "Mjölnir",       "arccw_horde_mjollnir",    3000, 6, "A warhammer embued with electric energy.\n\nPress RMB to charge the weapon.\nCharged attack creates a lightning storm on impact.",
-    {Berserker=true}, 10, -1, nil, nil, {Berserker=3}, nil, {HORDE.DMG_BLUNT, HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Melee",      "Zweihänder",     "arccw_horde_zweihander",  3000, 8, "A heavy, large two-handed longsword.\nCan easily decapitate enemies in a full swing.",
-    {Berserker=true}, 10, -1, nil, nil, {Berserker=5}, nil, {HORDE.DMG_SLASH})
+    HORDE:CreateItem( "Melee", "Combat Knife", "arccw_horde_knife", 100, 0,
+        "A reliable bayonet.\nRMB to deal a heavy slash.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_SLASH }, nil, { "Berserker", "Samurai", "Cyborg Ninja" } )
+    HORDE:CreateItem( "Melee", "Crowbar", "arccw_horde_crowbar", 750, 2,
+        "A trusty crowbar.\nEasy to use.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        10, -1, nil, "items/hl2/weapon_crowbar.png", nil, nil, { HORDE.DMG_BLUNT } )
+    HORDE:CreateItem( "Melee", "Machete", "arccw_horde_machete", 750, 2,
+        "A large machete.\nEasy to use.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Melee", "Kunai", "arccw_horde_kunai", 1750, 2,
+        "Ranged throwing knives.\nThrown blades are non-retrieveable\n knives recharge every 3 seconds, with a total of 3 knives",
+        { Survivor = true, Psycho = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, { Berserker = 1 }, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Melee", "Fireaxe", "arccw_horde_axe", 1500, 4,
+        "Fireaxe.\nHeavy, but can chop most enemies in half.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Melee", "Stunstick", "arccw_horde_stunstick", 1500, 4,
+        "Electric baton.\nDeals extra Lightning damage.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        10, -1, nil, "items/hl2/weapon_stunstick.png", nil, nil, { HORDE.DMG_BLUNT, HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Melee", "Katana", "arccw_horde_katana", 2000, 4,
+        "Ninja sword.\nLong attack range and fast attack speed.",
+        { Survivor = true, Psycho = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Melee", "Bat", "arccw_horde_bat", 2000, 4,
+        "Sturdy baseball bat.\nHits like a truck.",
+        { Survivor = true, Psycho = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BLUNT } )
+    HORDE:CreateItem( "Melee", "Chainsaw", "arccw_horde_chainsaw", 2500, 6,
+        "Brrrrrrrrrrrrrrrr.\n\nHold RMB to saw through enemies.\nDeals a lot more damage when using ammo.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, { Berserker = 2 }, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Melee", "Inferno", "arccw_horde_inferno_blade", 2500, 6,
+        "A blazing curved sword with hidden power.\n\nPress RMB to activate/deactivate the weapon.\n\nWhen deactivated, the weapon deals Slashing damage.\n\nWhen activated, the weapon deals extra splashing Fire damage.\nHowever, the user takes Fire damage over time.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Cremator = true },
+        10, -1, nil, nil, { Berserker = 2, Cremator = 2 }, nil, { HORDE.DMG_SLASH, HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Melee", "Jötunn", "arccw_horde_jotuun", 2500, 6,
+        "A cursed spiked mace forged with permafrost material.\n\nPress RMB to deliver a powerful ice blast.\nPerforming the ice blast increases Frostbite buildup on you.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, { Berserker = 4 }, nil, { HORDE.DMG_BLUNT, HORDE.DMG_COLD } )
+    HORDE:CreateItem( "Melee", "Mjölnir", "arccw_horde_mjollnir", 3000, 6,
+        "A warhammer embued with electric energy.\n\nPress RMB to charge the weapon.\nCharged attack creates a lightning storm on impact.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, { Berserker = 3 }, nil, { HORDE.DMG_BLUNT, HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Melee", "Zweihänder", "arccw_horde_zweihander", 3000, 8,
+        "A heavy, large two-handed longsword.\nCan easily decapitate enemies in a full swing.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, nil, nil, { Berserker = 5 }, nil, { HORDE.DMG_SLASH } )
 
-    HORDE:CreateItem("Pistol",     "9mm",            "arccw_horde_9mm",   50,  1, "Combine standard sidearm.",
-    nil, 2, -1, nil, "items/hl2/weapon_pistol.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Demolition", "Survivor", "Psycho"})
-    HORDE:CreateItem("Pistol",     "Medic 9mm",       "arccw_horde_medic_9mm", 75,  1, "Modified 9mm that provides ranged healing.\n\nPress B or ZOOM to fire healing darts.\nHealing dart recharges every 0.5 second.",
-    {Medic=true}, 2, -1, nil, "items/weapon_medic_9mm.png", nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON}, nil, {"Medic", "Hatcher"})
-    HORDE:CreateItem("Pistol",     "357",            "arccw_horde_357",        100,  2, "Colt Python magnum revolver.\nUsed by Black Mesa security guards.",
-    {Ghost=true}, 2, -1, nil, "items/hl2/weapon_357.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Ghost", "Gunslinger"})
-    HORDE:CreateItem("Pistol",     "Flare Gun",      "arccw_horde_flaregun",   100,  2, "Orion Safety Flare Gun.\nIgnites enemies and deals Fire damage. \nDraws from reserve ammo rather than reloading manually.",
-    {Cremator=true}, 1, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE}, nil, {"Cremator"})
-    HORDE:CreateItem("Pistol", "Flare Gun (Hidden)", "projectile_horde_flaregun_flare", 0, 0,
-        "This item is only here in the Pistol category to calculate pistol damage.", 
-        { Cremator = true, Gunslinger = true }, 10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 0 }, 
-        nil, nil, nil, { HORDE.DMG_FIRE }, nil, nil, true) --This must be hidden
-    HORDE:CreateItem("Pistol",     "Glock",          "arccw_horde_glock",    750,  2, "Glock 17.\nSemi-automatic pistol manufactured in Austria.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_glock", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "USP",            "arccw_horde_usp",      750,  2, "Universelle Selbstladepistole.\nA semi-automatic pistol developed in Germany by H&K.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_usp", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "P2000",          "arccw_horde_p2000",    750,  2, "Heckler & Koch P2000.\nA serviceable first-round pistol made by H&K.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_p2000", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "P250",           "arccw_horde_p250",     750,  2, "SIG Sauer P250.\nA low-recoil sidearm with a high rate of fire.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_p250", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "R8",             "arccw_horde_r8",       750,  2, "R8 Revolver.\nDelivers a highly accurate and powerful round,\nbut at the expense of a lengthy trigger-pull.",
-    {Survivor=true, Ghost=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_r8", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "M1911",          "arccw_horde_m1911",   750,  2, "Colt 1911.\nStandard-issue sidearm for the United States Armed Forces.",
-    {Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Deagle",         "arccw_horde_deagle",   750,  2, "Night Hawk .50C.\nAn iconic pistol that is diffcult to master.",
-    {Survivor=true, Ghost=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_deagle", {Ghost=1}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Anaconda",       "arccw_horde_anaconda",1000,  3, "Colt Anaconda.\nChambered for the powerful .44 Magnum.",
-    {Ghost=true}, 10, -1, nil, nil, {Ghost=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "CZ75",           "arccw_horde_cz75",     750,  2, "CZ 75.\nA semi-automatic pistol manufactured in Czech Republic.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_cz75", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "M9",             "arccw_horde_m9",       750,  2, "Beretta M9.\nSidearm used by the United States Armed Forces.",
-    {Survivor=true, Ghost=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_m9", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "FiveSeven",      "arccw_horde_fiveseven",750,  2, "ES Five-seven.\nA Belgian semi-automatic pistol made by FN Herstal.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 5, -1, nil, "arccw/weaponicons/arccw_go_fiveseven", {Medic=1, Assault=1, Heavy=1, Demolition=1, Survivor=1, Engineer=1, Warden=1, Cremator=1}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Tec-9",          "arccw_horde_tec9",    1000,  3, "A Swedish-made semi-automatic pistol.\nLethal in close quarters.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 8, -1, nil, "arccw/weaponicons/arccw_go_tec9", {Survivor=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Skorpion",          "arccw_horde_skorpion",    1000,  3, "Sa vz. 61 Skorpion.\nDeveloped in 1959 by Miroslav Rybar and produced \nunder the official designation 'Samopal vzor 61'.",
-    {Medic=true, Assault=true, Heavy=true, Demolition=true, Survivor=true, Engineer=true, Warden=true, Cremator=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem( "Pistol", "9mm", "arccw_horde_9mm", 50, 1,
+        "Combine standard sidearm.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        2, -1, nil, "items/hl2/weapon_pistol.png", nil, nil, { HORDE.DMG_BALLISTIC }, nil, { "Demolition", "Survivor", "Psycho" } )
+    HORDE:CreateItem( "Pistol", "Medic 9mm", "arccw_horde_medic_9mm", 75, 1,
+        "Modified 9mm that provides ranged healing.\n\nPress B or ZOOM to fire healing darts.\nHealing dart recharges every 0.5 second.",
+        { Medic = true, Hatcher = true, Gunslinger = true },
+        2, -1, nil, "items/weapon_medic_9mm.png", nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON }, nil, { "Medic", "Hatcher" } )
+    HORDE:CreateItem( "Pistol", "357", "arccw_horde_357", 100, 2,
+        "Colt Python magnum revolver.\nUsed by Black Mesa security guards.",
+        { Ghost = true, Gunslinger = true },
+        2, -1, nil, "items/hl2/weapon_357.png", nil, nil, { HORDE.DMG_BALLISTIC }, nil, { "Ghost", "Gunslinger" } )
+    HORDE:CreateItem( "Pistol", "Flare Gun", "arccw_horde_flaregun", 100, 2,
+        "Orion Safety Flare Gun.\nIgnites enemies and deals Fire damage. \nDraws from reserve ammo rather than reloading manually.",
+        { Gunslinger = true, Cremator = true },
+        1, -1, nil, nil, nil, nil, { HORDE.DMG_FIRE }, nil, { "Cremator" } )
+    HORDE:CreateItem( "Pistol", "Flare Gun (Hidden)", "projectile_horde_flaregun_flare", 0, 0,
+        "This item is only here in the Pistol category to calculate pistol damage.",
+        { Gunslinger = true, Cremator = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 0 }, nil, nil, nil, { HORDE.DMG_FIRE }, nil, nil, true ) -- This must be hidden
+    HORDE:CreateItem( "Pistol", "Glock", "arccw_horde_glock", 750, 2,
+        "Glock 17.\nSemi-automatic pistol manufactured in Austria.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_glock", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "USP", "arccw_horde_usp", 750, 2,
+        "Universelle Selbstladepistole.\nA semi-automatic pistol developed in Germany by H&K.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_usp", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "P2000", "arccw_horde_p2000", 750, 2,
+        "Heckler & Koch P2000.\nA serviceable first-round pistol made by H&K.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_p2000", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "P250", "arccw_horde_p250", 750, 2,
+        "SIG Sauer P250.\nA low-recoil sidearm with a high rate of fire.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_p250", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "R8", "arccw_horde_r8", 750, 2,
+        "R8 Revolver.\nDelivers a highly accurate and powerful round,\nbut at the expense of a lengthy trigger-pull.",
+        { Survivor = true, Psycho = true, Ghost = true, Gunslinger = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_r8", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "M1911", "arccw_horde_m1911", 750, 2,
+        "Colt 1911.\nStandard-issue sidearm for the United States Armed Forces.",
+        { Ghost = true, Gunslinger = true },
+        5, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "Deagle", "arccw_horde_deagle", 750, 2,
+        "Night Hawk .50C.\nAn iconic pistol that is diffcult to master.",
+        { Survivor = true, Psycho = true, Ghost = true, Gunslinger = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_deagle", { Ghost = 1 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "Anaconda", "arccw_horde_anaconda", 1000, 3,
+        "Colt Anaconda.\nChambered for the powerful .44 Magnum.",
+        { Ghost = true, Gunslinger = true },
+        10, -1, nil, nil, { Ghost = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "CZ75", "arccw_horde_cz75", 750, 2,
+        "CZ 75.\nA semi-automatic pistol manufactured in Czech Republic.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_cz75", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "M9", "arccw_horde_m9", 750, 2,
+        "Beretta M9.\nSidearm used by the United States Armed Forces.",
+        { Survivor = true, Psycho = true, Ghost = true, Gunslinger = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_m9", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "FiveSeven", "arccw_horde_fiveseven", 750, 2,
+        "ES Five-seven.\nA Belgian semi-automatic pistol made by FN Herstal.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        5, -1, nil, "arccw/weaponicons/arccw_go_fiveseven", { Survivor = 1, Assault = 1, Heavy = 1, Medic = 1, Demolition = 1, Engineer = 1, Warden = 1, Cremator = 1 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "Tec-9", "arccw_horde_tec9", 1000, 3,
+        "A Swedish-made semi-automatic pistol.\nLethal in close quarters.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        8, -1, nil, "arccw/weaponicons/arccw_go_tec9", { Survivor = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "Skorpion", "arccw_horde_skorpion", 1000, 3,
+        "Sa vz. 61 Skorpion.\nDeveloped in 1959 by Miroslav Rybar and produced \nunder the official designation 'Samopal vzor 61'.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Gunslinger = true, Engineer = true, Warden = true, Cremator = true },
+        8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
 
-    HORDE:CreateItem("Pistol",     "Dual M9",        "arccw_horde_akimbo_m9",       1500,  4, "Dual Beretta M9.\nA pair of pistols used by the United States Armed Forces.",
-    {Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Dual Glock17",   "arccw_horde_akimbo_glock17",  1750,  5, "Dual Glock 17.\nA pair of pistols widely used by law enforcements.",
-    {Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Pistol",     "Dual Deagle",    "arccw_horde_akimbo_deagle",   2000,  6, "Dual Night Hawk .50C.\nA pair of handcannons that are difficult to master.",
-    {Ghost=true}, 5, -1, nil, nil, {Ghost=1}, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem( "Pistol", "Dual M9", "arccw_horde_akimbo_m9", 1500, 4,
+        "Dual Beretta M9.\nA pair of pistols used by the United States Armed Forces.",
+        { Ghost = true, Gunslinger = true },
+        5, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "Dual Glock17", "arccw_horde_akimbo_glock17", 1750, 5,
+        "Dual Glock 17.\nA pair of pistols widely used by law enforcements.",
+        { Ghost = true, Gunslinger = true },
+        5, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Pistol", "Dual Deagle", "arccw_horde_akimbo_deagle", 2000, 6,
+        "Dual Night Hawk .50C.\nA pair of handcannons that are difficult to master.",
+        { Ghost = true, Gunslinger = true },
+        5, -1, nil, nil, { Ghost = 1 }, nil, { HORDE.DMG_BALLISTIC } )
 
-    HORDE:CreateItem("Pistol",     "Raygun Mark II",    "arccw_horde_raygun_mk2",   2500,  7, "Raygun Mark II.\nSecond iteration of the classic Ray Gun, now in the format of a burst-fire laser.",
-    {Warden=true, Engineer=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_LIGHTNING})
+    HORDE:CreateItem( "Pistol", "Raygun", "arccw_horde_raygun", 3000, 8,
+        "Raygun. \nFires explosive electric bolts that deal Lightning damage.",
+        { Gunslinger = true, Engineer = true, Warden = true },
+        20, -1, nil, nil, nil, nil, { HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Pistol", "Raygun (Hidden)", "horde_projectile_raygun_bolt", 0, 0,
+        "This item is only here in the Pistol category to calculate pistol damage.",
+        { Gunslinger = true, Engineer = true, Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 0 }, nil, nil, nil, { HORDE.DMG_LIGHTNING }, nil, nil, true ) -- This must be hidden
+    HORDE:CreateItem( "Pistol", "Raygun Mark II", "arccw_horde_raygun_mk2", 2500, 7,
+        "Raygun Mark II.\nSecond iteration of the classic Ray Gun, now in the format of a burst-fire laser.",
+        { Gunslinger = true, Engineer = true, Warden = true },
+        5, -1, nil, nil, nil, nil, { HORDE.DMG_LIGHTNING } )
 
-    HORDE:CreateItem("SMG",        "SMG1",           "arccw_horde_smg1",   100, 3, "A compact, fully automatic firearm.",
-    {Assault=true, Heavy=true}, 5, -1, nil, "items/hl2/weapon_smg1.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Assault", "SpecOps", "Reverend", "Heavy", "Juggernaut"})
-    HORDE:CreateItem("SMG",        "UZI",            "arccw_horde_uzi",   1250, 3, "UZI Submachine Gun.\nDesigned by Captain (later Major) Uziel Gal of the IDF following the 1948 Arab–Israeli War.",
-    {Medic=true, Assault=true, Heavy=true, Survivor=true, Engineer=true, Cremator=true}, 8, -1, nil, nil, {Survivor=3}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "MP40",           "arccw_horde_mp40",  1250, 3, "Maschinenpistole 40.\nDeveloped in Nazi Germany and used extensively by the Axis powers during World War II.",
-    {Medic=true, Assault=true, Heavy=true, Survivor=true, Engineer=true, Cremator=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "MAC-10",          "arccw_horde_mac10",    1500, 4, "Military Armament Corporation Model 10.\nBoasts a high rate of fire,\nwith poor spread accuracy and high recoil as trade-offs.",
-    {Medic=true, Assault=true, Heavy=true, Survivor=true, Engineer=true, Cremator=true}, 8, -1, nil, "arccw/weaponicons/arccw_go_mac10", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "MP5",            "arccw_horde_mp5",      1500, 4, "Heckler & Koch MP5.\nOften imitated but never equaled,\nthe MP5 is perhaps the most versatile SMG in the world.",
-    {Medic=true, Assault=true, Heavy=true, Survivor=true, Engineer=true, Cremator=true}, 8, -1, nil, "arccw/weaponicons/arccw_go_mp5", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "UMP45",          "arccw_horde_ump",      1500, 4, "KM UMP45.\nA lighter and cheaper successor to the MP5.",
-    {Medic=true, Assault=true, Heavy=true, Survivor=true, Engineer=true, Cremator=true}, 8, -1, nil, "arccw/weaponicons/arccw_go_ump", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "TMP",            "arccw_horde_tmp",   1500, 4, "Steyr TMP.\nA select-fire 9×19mm Parabellum caliber machine pistol.",
-    {Medic=true, Assault=true, Heavy=true, Survivor=true, Engineer=true, Cremator=true}, 8, -1, nil, nil, {Survivor=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "PP Bizon",       "arccw_horde_bizon",    2000, 5, "PP-19 Bizon.\nOffers a high-capacity magazine that reloads quickly.",
-    {Assault=true, Survivor=true}, 15, -1, nil, "arccw/weaponicons/arccw_go_bizon", {Assault=1, Medic=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "P90",            "arccw_horde_p90",      2000, 5, "ES C90.\nA Belgian bullpup PDW with a magazine of 50 rounds.",
-    {Assault=true, Survivor=true}, 15, -1, nil, "arccw/weaponicons/arccw_go_p90", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("SMG",        "MP5K Medic PDW",  "arccw_horde_mp5k",  2000, 4, "MP5K-PDW.\nA more compact MP5 equipped with a healing dart launcher.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 0.8 second cooldown.",
-    {Medic=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
-    HORDE:CreateItem("SMG",        "MP9 Medic PDW",  "arccw_horde_mp9m",  2500, 4, "Brügger & Thomet MP9.\nManufactured in Switzerland,\nthe MP9 is favored by private security firms world-wide.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
-    {Medic=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
-    HORDE:CreateItem("SMG",        "MP7A1 Medic PDW","arccw_horde_mp7m"  ,2500, 4, "A modified version of the MP7A1 for medical purposes.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
-    {Medic=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
-    HORDE:CreateItem("SMG",        "Vector Medic PDW","arccw_horde_vector",3000, 5, "KRISS Vector Gen I equipped with a medical dart launcher.\nUses an unconventional blowback system that provides a high firerate with low recoil.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 20 health and has a 1.5 second cooldown.",
-    {Medic=true}, 8, -1, nil, nil, {Medic=3}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
+    HORDE:CreateItem( "SMG", "SMG1", "arccw_horde_smg1", 100, 3,
+        "A compact, fully automatic firearm.",
+        { Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true },
+        5, -1, nil, "items/hl2/weapon_smg1.png", nil, nil, { HORDE.DMG_BALLISTIC }, nil, { "Assault", "SpecOps", "Reverend", "Heavy", "Juggernaut" } )
+    HORDE:CreateItem( "SMG", "UZI", "arccw_horde_uzi", 1250, 3,
+        "UZI Submachine Gun.\nDesigned by Captain (later Major) Uziel Gal of the IDF following the 1948 Arab-sraeli War.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Engineer = true, Cremator = true },
+        8, -1, nil, nil, { Survivor = 3 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "MP40", "arccw_horde_mp40", 1250, 3,
+        "Maschinenpistole 40.\nDeveloped in Nazi Germany and used extensively by the Axis powers during World War II.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Engineer = true, Cremator = true },
+        8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "MAC-10", "arccw_horde_mac10", 1500, 4,
+        "Military Armament Corporation Model 10.\nBoasts a high rate of fire,\nwith poor spread accuracy and high recoil as trade-offs.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Engineer = true, Cremator = true },
+        8, -1, nil, "arccw/weaponicons/arccw_go_mac10", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "MP5", "arccw_horde_mp5", 1500, 4,
+        "Heckler & Koch MP5.\nOften imitated but never equaled,\nthe MP5 is perhaps the most versatile SMG in the world.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Engineer = true, Cremator = true },
+        8, -1, nil, "arccw/weaponicons/arccw_go_mp5", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "UMP45", "arccw_horde_ump", 1500, 4,
+        "KM UMP45.\nA lighter and cheaper successor to the MP5.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Engineer = true, Cremator = true },
+        8, -1, nil, "arccw/weaponicons/arccw_go_ump", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "TMP", "arccw_horde_tmp", 1500, 4,
+        "Steyr TMP.\nA select-fire 9×19mm Parabellum caliber machine pistol.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Engineer = true, Cremator = true },
+        8, -1, nil, nil, { Survivor = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "PP Bizon", "arccw_horde_bizon", 2000, 5,
+        "PP-19 Bizon.\nOffers a high-capacity magazine that reloads quickly.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
+        15, -1, nil, "arccw/weaponicons/arccw_go_bizon", { Assault = 1, Medic = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "P90", "arccw_horde_p90", 2000, 5,
+        "ES C90.\nA Belgian bullpup PDW with a magazine of 50 rounds.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
+        15, -1, nil, "arccw/weaponicons/arccw_go_p90", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "SMG", "MP5K Medic PDW", "arccw_horde_mp5k",  2000, 4,
+        "MP5K-PDW.\nA more compact MP5 equipped with a healing dart launcher.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 0.8 second cooldown.",
+        { Medic = true, Hatcher = true },
+        8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
+    HORDE:CreateItem( "SMG", "MP9 Medic PDW", "arccw_horde_mp9m", 2500, 4,
+        "Brügger & Thomet MP9.\nManufactured in Switzerland,\nthe MP9 is favored by private security firms world-wide.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
+        { Medic = true, Hatcher = true },
+        8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
+    HORDE:CreateItem( "SMG", "MP7A1 Medic PDW", "arccw_horde_mp7m", 2500, 4,
+        "A modified version of the MP7A1 for medical purposes.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
+        { Medic = true, Hatcher = true },
+        8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
+    HORDE:CreateItem( "SMG", "Vector Medic PDW", "arccw_horde_vector", 3000, 5,
+        "KRISS Vector Gen I equipped with a medical dart launcher.\nUses an unconventional blowback system that provides a high firerate with low recoil.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 20 health and has a 1.5 second cooldown.",
+        { Medic = true, Hatcher = true },
+        8, -1, nil, nil, { Medic = 3 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
 
-    HORDE:CreateItem("Shotgun",    "Medic Shotgun",        "arccw_horde_medic_shotgun",  2250, 5, "Modified Winchester 1897.\nFires special darts that heal players on hit. \n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
-    {Medic=true, Warden=true}, 10, -1, nil, nil, {Medic=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
+    HORDE:CreateItem( "Shotgun", "Medic Shotgun", "arccw_horde_medic_shotgun", 2250, 5,
+        "Modified Winchester 1897.\nFires special darts that heal players on hit. \n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
+        { Medic = true, Hatcher = true, Warden = true },
+        10, -1, nil, nil, { Medic = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
 
-    HORDE:CreateItem("Shotgun",    "Shotgun",    "arccw_horde_shotgun", 100, 2, "A standard 12-Gauge shotgun.",
-    {Warden=true, Engineer=true, Cremator=true}, 2, -1, nil, "items/hl2/weapon_shotgun.png", nil, nil, {HORDE.DMG_BALLISTIC}, nil, {"Warden", "Engineer"})
-    HORDE:CreateItem("Shotgun",    "Nova",           "arccw_horde_nova",     1000, 4, "Benelli Nova.\nItalian pump-action 12-gauge shotgun.",
-    {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, "arccw/weaponicons/arccw_go_nova", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",     "Masterkey",          "arccw_horde_masterkey",    1250,  3, "Usually seen mounted as an underbarrel shotgun intended for breaching doors\nthis Masterkey is fitted with a removeable grip\nfor use as an easily concealable shotgun.",
-    {Medic = true, Assault = true, Heavy = true, Demolition = true, Survivor = true, Engineer = true, Warden = true, Cremator = true, Ghost = true, Berserker = true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "M870",           "arccw_horde_870",      1500, 4, "Remington 870 Shotgun.\nManufactured in the United States.",
-    {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, "arccw/weaponicons/arccw_go_870", {Engineer=1}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "MAG7",           "arccw_horde_mag7",     1500, 4, "Techno Arms MAG-7.\nFires a specialized 60mm 12 gauge shell.",
-    {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, "arccw/weaponicons/arccw_go_mag7", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "XM1014",         "arccw_horde_m1014",    2000, 5, "Benelli M4 Super 90.\nFully automatic shotgun.",
-    {Assault=true, Heavy=true, Survivor=true, Engineer=true, Warden=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "Trench Gun",     "arccw_horde_trenchgun", 2250, 6, "Winchester Model 1200.\nShoots incendiary pellets.",
-    {Warden=true, Cremator=true}, 15, -1, nil, nil, {Warden=1, Cremator=1}, nil, {HORDE.DMG_FIRE}, {HORDE.Infusion_Quality, HORDE.Infusion_Impaling})
-    HORDE:CreateItem("Shotgun",    "Double Barrel",  "arccw_horde_doublebarrel",    2250, 5, "Double Barrel Shotgun.\nDevastating power at close range.",
-    {Survivor=true, Warden=true, Assault=true, Heavy=true, Engineer=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "SPAS-12",        "arccw_horde_spas12",  2500, 6, "Franchi SPAS-12.\nA combat shotgun manufactured by Italian firearms company Franchi.",
-    {Survivor=true, Warden=true, Assault=true, Heavy=true, Engineer=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "Striker",        "arccw_horde_striker", 2750, 7, "Armsel Striker.\nA 12-gauge shotgun with a revolving cylinder from South Africa.",
-    {Warden=true, Assault=true, Heavy=true, Engineer=true}, 15, -1, nil, nil, {Warden=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "HSG-1",           "arccw_horde_hsg1",  3000, 8, "Modified version of the Kel-Tec KSG. \nUses a box magazine instead of being tube-fed.",
-    {Warden=true}, 15, -1, nil, nil, {Warden=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Shotgun",    "AA12",           "arccw_horde_aa12",  3750, 9, "Atchisson Assault Shotgun.\nDevastating firepower at close to medium range.",
-    {Warden=true, Heavy=true}, 25, -1, nil, nil, {Warden=3}, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem( "Shotgun", "Shotgun", "arccw_horde_shotgun", 100, 2,
+        "A standard 12-Gauge shotgun.",
+        { Engineer = true, Warden = true, Cremator = true },
+        2, -1, nil, "items/hl2/weapon_shotgun.png", nil, nil, { HORDE.DMG_BALLISTIC }, nil, { "Engineer", "Warden" } )
+    HORDE:CreateItem( "Shotgun", "Nova", "arccw_horde_nova", 1000, 4,
+        "Benelli Nova.\nItalian pump-action 12-gauge shotgun.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        10, -1, nil, "arccw/weaponicons/arccw_go_nova", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "Masterkey", "arccw_horde_masterkey", 1250, 3,
+        "Usually seen mounted as an underbarrel shotgun intended for breaching doors\nthis Masterkey is fitted with a removeable grip\nfor use as an easily concealable shotgun.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Cremator = true },
+        5, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "M870", "arccw_horde_870", 1500, 4,
+        "Remington 870 Shotgun.\nManufactured in the United States.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        10, -1, nil, "arccw/weaponicons/arccw_go_870", { Engineer = 1 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "MAG7", "arccw_horde_mag7", 1500, 4, "Techno Arms MAG-7.\nFires a specialized 60mm 12 gauge shell.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        10, -1, nil, "arccw/weaponicons/arccw_go_mag7", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "XM1014", "arccw_horde_m1014", 2000, 5,
+        "Benelli M4 Super 90.\nFully automatic shotgun.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "Trench Gun", "arccw_horde_trenchgun", 2250, 6,
+        "Winchester Model 1200.\nShoots incendiary pellets.",
+        { Warden = true, Cremator = true },
+        15, -1, nil, nil, { Warden = 1, Cremator = 1 }, nil, { HORDE.DMG_FIRE }, { HORDE.Infusion_Quality, HORDE.Infusion_Impaling } )
+    HORDE:CreateItem( "Shotgun", "Double Barrel", "arccw_horde_doublebarrel", 2250, 5,
+        "Double Barrel Shotgun.\nDevastating power at close range.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "SPAS-12", "arccw_horde_spas12", 2500, 6,
+        "Franchi SPAS-12.\nA combat shotgun manufactured by Italian firearms company Franchi.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        15, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "Striker", "arccw_horde_striker", 2750, 7, "Armsel Striker.\nA 12-gauge shotgun with a revolving cylinder from South Africa.",
+        { Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Engineer = true, Warden = true },
+        15, -1, nil, nil, { Warden = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "HSG-1", "arccw_horde_hsg1", 3000, 8,
+        "Modified version of the Kel-Tec KSG. \nUses a box magazine instead of being tube-fed.",
+        { Warden = true }, 15, -1, nil, nil, { Warden = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Shotgun", "AA12", "arccw_horde_aa12", 3750, 9,
+        "Atchisson Assault Shotgun.\nDevastating firepower at close to medium range.",
+        { Heavy = true, Juggernaut = true, Warden = true }, 25, -1, nil, nil, { Warden = 3 }, nil, { HORDE.DMG_BALLISTIC } )
 
-    HORDE:CreateItem("Rifle",      "AR15",           "arccw_horde_ar15",     2000, 6, "AR-15 Style Rifle.\nA lightweight semi-automatic rifle based on the ArmaLite AR-15 design.",
-    {Medic=true, Assault=true, Survivor=true, Ghost=true}, 10, -1, nil, nil, {Assault=2,Ghost=1}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "FAMAS",          "arccw_horde_famas",    2500, 6, "FAMAS bullpup assault rifle.\nRecognised for its high rate of fire.",
-    {Assault=true, Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "Galil",          "arccw_horde_ace",      2500, 6, "Galil ACE 22.\nDeveloped and originally manufactured by IMI.",
-    {Assault=true, Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "AK47",           "arccw_horde_ak47",     3000, 7, "Avtomat Kalashnikova.\nA gas-operated, 7.62×39mm assault rifle developed in the Soviet Union.",
-    {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "M4A1",           "arccw_horde_m4",       3000, 7, "Colt M4.\nA 5.56×45mm NATO, air-cooled, gas-operated, select fire carbine.",
-    {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "SG556",          "arccw_horde_sg556",    3000, 7, "SIG SG 556.\nAn assault rifle manufactured by Sig Sauer AG.",
-    {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "AUG",            "arccw_horde_aug",      3000, 7, "Steyr AUG.\nAn Austrian bullpup assault rifle.",
-    {Assault=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "F2000",          "arccw_horde_f2000", 3250, 7, "FN F2000.\nAn ambidextrous bullpup rifle developed by FN. \nEquipped with an M203 underbarrel incendiary grenade launcher.\nPress USE+RELOAD to equip M203.",
-    {Assault=true, Cremator=true}, 10, 10, nil, nil, {Assault=2, Cremator=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_FIRE})
-    HORDE:CreateItem("Rifle",      "Tavor",          "arccw_horde_tavor", 3250, 7, "IWI Tavor-21.\nDesigned to maximize reliability, durability, and simplicity. \nEquipped with an M203 underbarrel shock grenade launcher.\nPress USE+RELOAD to equip M203.",
-    {Assault=true, Warden=true}, 10, 10, nil, nil, {Assault=2, Warden=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Rifle",      "SCAR-L",         "arccw_horde_scarl", 3500, 8, "FN SCAR-L.\nAn assault rifle developed by Belgian manufacturer FN Herstal.\nLight version, chambered in 5.56x45mm NATO. \nEquipped with an M203 underbarrel cryo grenade launcher.\nPress USE+RELOAD to equip M203.",
-    {Assault=true, Ghost=true}, 15, 10, nil, nil, {Assault=2, Ghost=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_COLD})
-    HORDE:CreateItem("Rifle",      "OSIPR",          "arccw_horde_ar2",   3500, 9, "Overwatch Standard Issue Pulse Rifle.\n\nPress ZOOM or B to change firemode.\nFires regular ballistic ammo or energy balls that deal Lightning damage and builds up Shock.",
-    {Assault=true, Warden=true}, 15, -1, nil, "items/hl2/weapon_ar2.png", {Assault=5}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING})
+    HORDE:CreateItem( "Rifle", "AR15", "arccw_horde_ar15", 2000, 6,
+        "AR-15 Style Rifle.\nA lightweight semi-automatic rifle based on the ArmaLite AR-15 design.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Medic = true, Hatcher = true, Ghost = true },
+        10, -1, nil, nil, { Assault = 2, Ghost = 1 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "FAMAS", "arccw_horde_famas", 2500, 6,
+        "FAMAS bullpup assault rifle.\nRecognised for its high rate of fire.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "Galil", "arccw_horde_ace", 2500, 6,
+        "Galil ACE 22.\nDeveloped and originally manufactured by IMI.",
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "AK47", "arccw_horde_ak47", 3000, 7,
+        "Avtomat Kalashnikova.\nA gas-operated, 7.62x39mm assault rifle developed in the Soviet Union.",
+        { Assault = true, SpecOps = true, Reverend = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "M4A1", "arccw_horde_m4", 3000, 7,
+        "Colt M4.\nA 5.56x45mm NATO, air-cooled, gas-operated, select fire carbine.",
+        { Assault = true, SpecOps = true, Reverend = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "SG556", "arccw_horde_sg556", 3000, 7,
+        "SIG SG 556.\nAn assault rifle manufactured by Sig Sauer AG.",
+        { Assault = true, SpecOps = true, Reverend = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "AUG", "arccw_horde_aug", 3000, 7,
+        "Steyr AUG.\nAn Austrian bullpup assault rifle.",
+        { Assault = true, SpecOps = true, Reverend = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "F2000", "arccw_horde_f2000", 3250, 7,
+        "FN F2000.\nAn ambidextrous bullpup rifle developed by FN. \nEquipped with an M203 underbarrel incendiary grenade launcher.\nPress USE+RELOAD to equip M203.",
+        { Assault = true, SpecOps = true, Reverend = true, Cremator = true },
+        10, 10, nil, nil, { Assault = 2, Cremator = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Rifle", "Tavor", "arccw_horde_tavor", 3250, 7,
+        "IWI Tavor-21.\nDesigned to maximize reliability, durability, and simplicity. \nEquipped with an M203 underbarrel shock grenade launcher.\nPress USE+RELOAD to equip M203.",
+        { Assault = true, SpecOps = true, Reverend = true, Warden = true },
+        10, 10, nil, nil, { Assault = 2, Warden = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Rifle", "SCAR-L", "arccw_horde_scarl", 3500, 8,
+        "FN SCAR-L.\nAn assault rifle developed by Belgian manufacturer FN Herstal.\nLight version, chambered in 5.56x45mm NATO. \nEquipped with an M203 underbarrel cryo grenade launcher.\nPress USE+RELOAD to equip M203.",
+        { Assault = true, SpecOps = true, Reverend = true, Ghost = true },
+        15, 10, nil, nil, { Assault = 2, Ghost = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_COLD } )
+    HORDE:CreateItem( "Rifle", "OSIPR", "arccw_horde_ar2", 3500, 9, "Overwatch Standard Issue Pulse Rifle.\n\nPress ZOOM or B to change firemode.\nFires regular ballistic ammo or energy balls that deal Lightning damage and builds up Shock.",
+        { Assault = true, SpecOps = true, Reverend = true, Warden = true },
+        15, -1, nil, "items/hl2/weapon_ar2.png", { Assault = 5 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING } )
 
-    HORDE:CreateItem("Rifle",      "Springfield M14",     "arccw_horde_m14",1250, 4, "Springfield semi-auto rifle.\nClassic, affordable, zombie-killing machine.",
-    {Ghost=true, Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "Winchester LAR",     "arccw_horde_winchester",1000, 4, "Winchester Lever Action Rifle.\nAn all-time classic.",
-    {Ghost=true, Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "Mosin-Nagant",     "arccw_horde_mosin_nagant",1500, 5, "M1891 Mosin-Nagant.\nOne of the most mass-produced military bolt-action rifles in history, \nwith over 37 million units produced since 1891.",
-    {Survivor=true, Ghost=true}, 5, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "SSG08",          "arccw_horde_ssg08",     2000, 6, "Steyr SSG 08.\nAustrian bolt-action sniper rifle developed and produced by Steyr Mannlicher.\nProvides unparalled mobility as a sniper rifle.",
-    {Survivor=true, Ghost=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "SCAR-H",         "arccw_horde_scarh",       2750, 7, "FN SCAR-H.\nAn assault rifle developed by Belgian manufacturer FN Herstal.",
-    {Survivor=true,  Ghost=true}, 15, -1, nil, nil, {Ghost=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "G3",             "arccw_horde_g3",      3000, 8, "G3 Battle Rifle.\nA 7.62×51mm NATO, select-fire battle rifle developed by H&K.",
-    {Ghost=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "FN FAL",         "arccw_horde_fal",     3000, 8, "FN FAL.\nA battle rifle designed by Belgium and manufactured by FN Herstal.",
-    {Ghost=true}, 15, -1, nil, nil, {Ghost=3}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "AWP",            "arccw_horde_awp",     2500, 8, "Arctic Warfare Police.\nUnited Kingdom designed sniper rifle.\n This variant is widely used by law enforcement and counterterrorism units.",
-    {Ghost=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "Fucket",            "arccw_horde_fucket_rifle",     2750, 7, "Break-action double-barrel musket.\ndebatable whether its unholy or not",
-    {Survivor = true, Ghost = true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    
-    HORDE:CreateItem("Rifle",      "M200",           "arccw_horde_m200",    3000, 9, "CheyTec M200 Intervention.\nAmerican bolt-action sniper rifle.",
-    {Ghost=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "Barrett AMR",    "arccw_horde_barret",  3500, 10, ".50 Cal Anti-Material Sniper Rifle.\nDoes huge amounts of ballistic damage.",
-    {Ghost=true}, 50, -1, nil, nil, {Ghost=5}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",      "Barrett M99",    "arccw_horde_m99",  4000, 10, "Barrett M99. \nDeals a higher amount of damage than the Barrett AMR, but can only carry 1 round at a time.",
-    {Ghost=true}, 5, -1, nil, nil, {Ghost=5}, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem( "Rifle", "Springfield M14", "arccw_horde_m14", 1250, 4,
+        "Springfield semi-auto rifle.\nClassic, affordable, zombie-killing machine.",
+        { Survivor = true, Psycho = true, Ghost = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "Winchester LAR", "arccw_horde_winchester", 1000, 4,
+        "Winchester Lever Action Rifle.\nAn all-time classic.",
+        { Survivor = true, Psycho = true, Ghost = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "Mosin-Nagant", "arccw_horde_mosin_nagant", 1500, 5,
+        "M1891 Mosin-Nagant.\nOne of the most mass-produced military bolt-action rifles in history, \nwith over 37 million units produced since 1891.",
+        { Survivor = true, Psycho = true, Ghost = true },
+        5, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "SSG08", "arccw_horde_ssg08", 2000, 6,
+        "Steyr SSG 08.\nAustrian bolt-action sniper rifle developed and produced by Steyr Mannlicher.\nProvides unparalled mobility as a sniper rifle.",
+        { Survivor = true, Psycho = true, Ghost = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "SCAR-H", "arccw_horde_scarh", 2750, 7,
+        "FN SCAR-H.\nAn assault rifle developed by Belgian manufacturer FN Herstal.",
+        { Survivor = true, Psycho = true, Ghost = true },
+        15, -1, nil, nil, { Ghost = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "G3", "arccw_horde_g3", 3000, 8,
+        "G3 Battle Rifle.\nA 7.62×51mm NATO, select-fire battle rifle developed by H&K.",
+        { Ghost = true },
+        15, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "FN FAL", "arccw_horde_fal", 3000, 8,
+        "FN FAL.\nA battle rifle designed by Belgium and manufactured by FN Herstal.",
+        { Ghost = true },
+        15, -1, nil, nil, { Ghost = 3 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "AWP", "arccw_horde_awp", 2500, 8,
+        "Arctic Warfare Police.\nUnited Kingdom designed sniper rifle.\n This variant is widely used by law enforcement and counterterrorism units.",
+        { Ghost = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "Fucket", "arccw_horde_fucket_rifle", 2750, 7,
+        "Break-action double-barrel musket.\ndebatable whether its unholy or not",
+        { Survivor = true, Psycho = true, Ghost = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
 
-    HORDE:CreateItem("Rifle",      "Winchester Incendiary",         "arccw_horde_winchester_fire",  2500, 6, "Winchester 1894. \nUses incendiary rounds.",
-    {Cremator=true}, 10, -1, nil, nil, {Ghost=1, Cremator=1}, nil, {HORDE.DMG_FIRE})
-    HORDE:CreateItem("Rifle",      "Apollo",         "arccw_horde_apollo",  3000, 8, "Apollo Plasma rifle.\nFires plasma balls that melt down enemies.",
-    {Cremator=true}, 50, -1, nil, nil, {Cremator=5}, nil, {HORDE.DMG_FIRE})
+    HORDE:CreateItem( "Rifle", "M200", "arccw_horde_m200", 3000, 9,
+        "CheyTec M200 Intervention.\nAmerican bolt-action sniper rifle.",
+        { Ghost = true },
+        15, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "Barrett AMR", "arccw_horde_barret", 3500, 10,
+        ".50 Cal Anti-Material Sniper Rifle.\nDoes huge amounts of ballistic damage.",
+        { Ghost = true },
+        50, -1, nil, nil, { Ghost = 5 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "Barrett M99", "arccw_horde_m99", 4000, 10,
+        "Barrett M99. \nDeals a higher amount of damage than the Barrett AMR, but can only carry 1 round at a time.",
+        { Ghost = true },
+        5, -1, nil, nil, { Ghost = 5 }, nil, { HORDE.DMG_BALLISTIC } )
 
-    HORDE:CreateItem("Rifle",    "SSG08 Medic SR",   "arccw_horde_medic_rifle",  1500,   6, "A medic sniper rifle that shoots healing darts.\nDamages enemies and heals players.",
-    {Medic=true, Ghost=true}, 10, -1, nil, nil, {Medic=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Rifle",    "ACR Medic AR",     "arccw_horde_medic_acr",    3000, 8, "Remington Adaptive Combat Rifle.\nEquipped with healing dart and medic grenade launcher.\n\nPress USE+RELOAD to equip medic grenade launcher.\nPress B or ZOOM to fire healing dart.\nHealing dart heals 20 health and has a 1.5 second cooldown.",
-    {Medic=true}, 10, 10, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_POISON})
-    HORDE:CreateItem("Rifle",    "M16 M203",         "arccw_horde_m16m203",2250,7, "M16A4 equipped with an M203 underbarrel grenade launcher.\nPress USE+RELOAD to equip M203.",
-    {Assault=true, Demolition=true}, 10, 10, nil, nil, {Assault=2, Demolition=2}, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST})
+    HORDE:CreateItem( "Rifle", "Winchester Incendiary", "arccw_horde_winchester_fire", 2500, 6,
+        "Winchester 1894. \nUses incendiary rounds.",
+        { Cremator = true },
+        10, -1, nil, nil, { Ghost = 1, Cremator = 1 }, nil, { HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Rifle", "Apollo", "arccw_horde_apollo", 3000, 8,
+        "Apollo Plasma rifle.\nFires plasma balls that melt down enemies.",
+        { Cremator = true },
+        50, -1, nil, nil, { Cremator = 5 }, nil, { HORDE.DMG_FIRE } )
 
-    HORDE:CreateItem("MG",         "AUG HBAR",       "arccw_horde_aug_hbar", 2000, 9, "Steyr AUG HBAR.\nA light-support machine gun variant of the AUG assault rifle.",
-    {Heavy=true, Survivor=true}, 25, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "Negev",          "arccw_horde_negev",     2250, 9, "IWI Negev.\nIWI developed light machine gun chambered in either 5.56×45mm intermediate rounds, or 7.62x51mm heavy rounds.",
-    {Heavy=true, Survivor=true}, 25, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "M249",           "arccw_horde_m249",  2500, 9, "M249 light machine gun.\nA gas operated and air-cooled weapon of destruction.",
-    {Heavy=true, Survivor=true}, 40, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "L86 LSW",       "arccw_horde_l86",    2500, 9, "SA80 L86 LSW.\nBullpup light machine gun operated by the British Army.",
-    {Heavy=true}, 25, -1, nil, nil, {Heavy=2}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "RPD",          "arccw_horde_rpd",      3000, 10, "Ruchnoy Pulemyot Degtyaryova.\na 7.62x39mm light machine gun developed in the Soviet Union by Vasily Degtyaryov.",
-    {Heavy=true}, 50, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "MG4",           "arccw_horde_mg4",      3000, 10, "Heckler & Koch MG4.\nA belt-fed 5.56 mm light machine gun designed to replace the MG3.",
-    {Heavy=true}, 40, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "M240",          "arccw_horde_m240",     3000, 10, "M240 Bravo.\nFires powerful 7.62x51mm NATO rounds.\nEquipped by U.S. Armed Forces.",
-    {Heavy=true}, 50, -1, nil, nil, {Heavy=3}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "M2 Browning",         "arccw_horde_m2_browning",     3500, 14, "M2 Browning .50 caliber machine gun.\nKnown for extensive use as a vehicle weapon or \naircraft armament by the United States since the 1930s.",
-    {Heavy=true}, 20, -1, nil, nil, {Heavy=5}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("MG",         "M-134D",         "arccw_horde_gau",     3500, 14, "M-134D rotary machine gun.\nFires 7.62 x 51mm cartridges at up to 3,000 rounds per minute.\n\nMust spin up before firing.",
-    {Heavy=true}, 50, -1, nil, nil, {Heavy=5}, nil, {HORDE.DMG_BALLISTIC})
+    HORDE:CreateItem( "Rifle", "SSG08 Medic SR", "arccw_horde_medic_rifle", 1500, 6,
+        "A medic sniper rifle that shoots healing darts.\nDamages enemies and heals players.",
+        { Medic = true, Hatcher = true, Ghost = true },
+        10, -1, nil, nil, { Medic = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Rifle", "ACR Medic AR", "arccw_horde_medic_acr", 3000, 8,
+        "Remington Adaptive Combat Rifle.\nEquipped with healing dart and medic grenade launcher.\n\nPress USE+RELOAD to equip medic grenade launcher.\nPress B or ZOOM to fire healing dart.\nHealing dart heals 20 health and has a 1.5 second cooldown.",
+        { Medic = true, Hatcher = true },
+        10, 10, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
+    HORDE:CreateItem( "Rifle", "M16 M203", "arccw_horde_m16m203", 2250, 7,
+        "M16A4 equipped with an M203 underbarrel grenade launcher.\nPress USE+RELOAD to equip M203.",
+        { Assault = true, SpecOps = true, Reverend = true, Demolition = true },
+        10, 10, nil, nil, { Assault = 2, Demolition = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST } )
+
+    HORDE:CreateItem( "MG", "AUG HBAR", "arccw_horde_aug_hbar", 2000, 9,
+        "Steyr AUG HBAR.\nA light-support machine gun variant of the AUG assault rifle.",
+        { Survivor = true, Psycho = true, Heavy = true, Juggernaut = true },
+        25, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "Negev", "arccw_horde_negev", 2250, 9,
+        "IWI Negev.\nIWI developed light machine gun chambered in either 5.56x45mm intermediate rounds, or 7.62x51mm heavy rounds.",
+        { Survivor = true, Psycho = true, Heavy = true, Juggernaut = true },
+        25, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "M249", "arccw_horde_m249", 2500, 9,
+        "M249 light machine gun.\nA gas operated and air-cooled weapon of destruction.",
+        { Survivor = true, Psycho = true, Heavy = true, Juggernaut = true },
+        40, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "L86 LSW", "arccw_horde_l86", 2500, 9,
+        "SA80 L86 LSW.\nBullpup light machine gun operated by the British Army.",
+        { Heavy = true, Juggernaut = true },
+        25, -1, nil, nil, { Heavy = 2 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "RPD", "arccw_horde_rpd", 3000, 10,
+        "Ruchnoy Pulemyot Degtyaryova.\na 7.62x39mm light machine gun developed in the Soviet Union by Vasily Degtyaryov.",
+        { Heavy = true, Juggernaut = true },
+        50, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "MG4", "arccw_horde_mg4", 3000, 10,
+        "Heckler & Koch MG4.\nA belt-fed 5.56 mm light machine gun designed to replace the MG3.",
+        { Heavy = true, Juggernaut = true },
+        40, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "M240", "arccw_horde_m240", 3000, 10,
+        "M240 Bravo.\nFires powerful 7.62x51mm NATO rounds.\nEquipped by U.S. Armed Forces.",
+        { Heavy = true, Juggernaut = true },
+        50, -1, nil, nil, { Heavy = 3 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "M2 Browning", "arccw_horde_m2_browning", 3500, 14,
+        "M2 Browning .50 caliber machine gun.\nKnown for extensive use as a vehicle weapon or \naircraft armament by the United States since the 1930s.",
+        { Heavy = true, Juggernaut = true },
+        20, -1, nil, nil, { Heavy = 5 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "MG", "M-134D", "arccw_horde_gau", 3500, 14,
+        "M-134D rotary machine gun.\nFires 7.62 x 51mm cartridges at up to 3,000 rounds per minute.\n\nMust spin up before firing.",
+        { Heavy = true, Juggernaut = true },
+        50, -1, nil, nil, { Heavy = 5 }, nil, { HORDE.DMG_BALLISTIC } )
 
     -- Class specific grenades
-    HORDE:CreateItem("Explosive",  "Frag Grenade",   "weapon_frag",                    10,  0, "A standard frag grenade.\nGood for crowd control.",
-    {Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Explosive",  "Stun Grenade",   "arccw_horde_nade_stun",          100,  0, "A grenade that deals minor damage and stuns enemy for 3 seconds.\nStun cooldown is 10 seconds.",
-    {Assault=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Explosive",  "Shrapnel Grenade",   "arccw_horde_nade_shrapnel",  100,  0, "A grenade that explodes into shrapnels, dealing Ballistic damage in an area.",
-    {Heavy=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Explosive",  "Sonar Grenade",   "arccw_horde_nade_sonar",        100,  0, "A grenade that reveals and marks nearby enemies while active.\nMarked enemies take 15% more headshot damage.",
-    {Ghost=true}, 100, -1)
-    HORDE:CreateItem("Explosive",  "M67 Frag Grenade",    "arccw_horde_m67",                100,  0, "M67 High Explosive Fragmentation Grenade.\nMilitary grade, does large amounts of Blast damage.",
-    {Demolition=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Explosive",  "Medic Grenade",  "arccw_nade_medic",               100,  0, "A grenade that releases contiuous bursts of detoxication clouds.\nHeals players and damages enemies.",
-    {Medic=true}, 100, -1, nil, "items/arccw_nade_medic.png", nil,  nil, {HORDE.DMG_POISON})
-    HORDE:CreateItem("Explosive",  "Nanobot Grenade",   "arccw_horde_nade_nanobot",    100,  0, "A grenade that releases streams of repair nanobots.\nHeals minions and players over time.\nHealing is more potent for minions.",
-    {Engineer=true}, 100, -1)
-    HORDE:CreateItem("Explosive",  "Hemo Grenade",   "arccw_horde_nade_hemo",          100,  0, "A grenade that deals Slashing damage in the area.\nIncreases Bleeding buildup.",
-    {Berserker=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Explosive",  "EMP Grenade",   "arccw_horde_nade_emp",  100,  0, "A grenade that deals rapid Lightning damage in the area.\nYou are safe from the EMP blast.",
-    {Warden=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Explosive",  "Molotov",   "arccw_horde_nade_molotov",            100,  0, "Generates a pool of fire on impact.\nSets everything on fire within its effect.",
-    {Cremator=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE})
+    HORDE:CreateItem( "Explosive", "Frag Grenade", "weapon_frag", 10, 0,
+        "A standard frag grenade.\nGood for crowd control.",
+        { Survivor = true, Psycho = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Explosive", "Stun Grenade", "arccw_horde_nade_stun", 100, 0,
+        "A grenade that deals minor damage and stuns enemy for 3 seconds.\nStun cooldown is 10 seconds.",
+        { Assault = true, SpecOps = true, Reverend = true },
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Explosive", "Shrapnel Grenade", "arccw_horde_nade_shrapnel", 100, 0,
+        "A grenade that explodes into shrapnels, dealing Ballistic damage in an area.",
+        { Heavy = true, Juggernaut = true },
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Explosive", "Sonar Grenade", "arccw_horde_nade_sonar", 100, 0,
+        "A grenade that reveals and marks nearby enemies while active.\nMarked enemies take 15% more headshot damage.",
+        { Ghost = true, Gunslinger = true },
+        100, -1 )
+    HORDE:CreateItem( "Explosive", "M67 Frag Grenade", "arccw_horde_m67", 100, 0,
+        "M67 High Explosive Fragmentation Grenade.\nMilitary grade, does large amounts of Blast damage.",
+        { Demolition = true },
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Explosive", "Medic Grenade", "arccw_nade_medic", 100, 0,
+        "A grenade that releases contiuous bursts of detoxication clouds.\nHeals players and damages enemies.",
+        { Medic = true, Hatcher = true },
+        100, -1, nil, "items/arccw_nade_medic.png", nil, nil, { HORDE.DMG_POISON } )
+    HORDE:CreateItem( "Explosive", "Nanobot Grenade", "arccw_horde_nade_nanobot", 100, 0,
+        "A grenade that releases streams of repair nanobots.\nHeals minions and players over time.\nHealing is more potent for minions.",
+        { Engineer = true },
+        100, -1 )
+    HORDE:CreateItem( "Explosive", "Hemo Grenade", "arccw_horde_nade_hemo", 100, 0,
+        "A grenade that deals Slashing damage in the area.\nIncreases Bleeding buildup.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Explosive", "EMP Grenade", "arccw_horde_nade_emp", 100, 0,
+        "A grenade that deals rapid Lightning damage in the area.\nYou are safe from the EMP blast.",
+        { Warden = true },
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Explosive", "Molotov", "arccw_horde_nade_molotov", 100, 0,
+        "Generates a pool of fire on impact.\nSets everything on fire within its effect.",
+        { Cremator = true },
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_FIRE } )
 
-    HORDE:CreateItem("Explosive",  "SLAM",           "horde_slam",          950,  2, "Selectable Lightweight Attack Munition.\nRMB to detonate. Attach to wall to active laser mode.\n\nA maximum of 4 SLAMs can be active at the same time.",
-    {Demolition=true}, 40, 0, nil, "items/hl2/weapon_slam.png", nil, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Explosive",  "Resistance RPG", "weapon_rpg",         1500,  5, "Laser-guided rocket propulsion device.",
-    {Demolition=true, Survivor=true}, 8, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    --HORDE:CreateItem("Explosive",  "Hopper Mine",  "horde_hopper_mine",  2000,  5, "Combine reactive mines that explode when enemies come in proximity.\nYou can plant at most 5 reactive mines.",
-    --{Demolition=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    --HORDE:CreateItem("Explosive",  "Static Mine",  "horde_static_mine",  2000,  5, "Combine reactive mines that hovers in air.\nExplode when enemies come in proximity.\nYou can plant at most 5 reactive mines.",
-    --{Demolition=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "M79 GL",         "arccw_horde_m79",    1500,  5, "M79 Thumper.\nShoots 40x46mm grenades that explode on impact.",
-    {Demolition=true, Survivor=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "China Lake GL",         "arccw_horde_chinalake",    2000,  6, "Pump-Action Grenade Launcher.\nHolds a total of four 40mm grenades,\nand cycles similar to a pump-action shotgun. \nPress B or ZOOM to switch grenade type.",
-    {Demolition=true, Survivor=true, Cremator=true, Warden=true, Engineer=true }, 30, -1, nil, nil, {Demolition=2}, nil, {HORDE.DMG_BLAST, HORDE.DMG_FIRE, HORDE.DMG_LIGHTNING, HORDE.DMG_COLD}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "Sticky Launcher",  "horde_sticky_launcher", 2500,  7, "Sticky grenade launcher.\nLaunches grenades that stick to surfaces and entities.\n\nRMB to detonate.",
-    {Demolition=true}, 50, -1, nil, nil, {Demolition=2}, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "M32 GL",         "arccw_horde_m32",    3000,  8, "Milkor Multiple Grenade Launcher.\nA lightweight 40mm six-shot revolver grenade launcher.",
-    {Demolition=true}, 50, -1, nil, nil, {Demolition=3}, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "RPG-7",          "arccw_horde_rpg7",   3000,  9, "Ruchnoy Protivotankoviy Granatomyot.\nAnti-tank rocket launcher developed by the Soviet Union.",
-    {Demolition=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "USAS-12",         "arccw_horde_usas12",    3000,  9, "USAS-12 automatic shotgun.\nShoots explosive slugs that deal either Ballistic or Explosive damage. \nPress B or ZOOM to switch grenade type.",
-    {Demolition=true, Heavy=true, Warden=true, Assault=true}, 20, -1, nil, nil, nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "LAW",        "arccw_horde_law",   3250,  9, "Light Anti-Armor Weapon.\nFocuses on raw destructive power instead of area of effect.",
-    {Demolition=true}, 15, -1, nil, nil, {Demolition=4}, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "FGM-148 JAVELIN",        "arccw_horde_javelin",   3500,  10, "FGM-148 Javelin.\nFires guided rockets that require a lock-on.",
-    {Demolition=true}, 15, -1, nil, nil, {Demolition=5}, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    HORDE:CreateItem("Explosive",  "M202",          "arccw_horde_m202",   3500,  10, "M202 Flame Assault Shoulder.\nAmerican rocket launcher designed to replace the flamethrowers used in World War II.",
-    {Demolition=true}, 20, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, {HORDE.Infusion_Quality})
-    --HORDE:CreateItem("Explosive",  "Thermite",       "arccw_horde_nade_incendiary",   1500,   1, "Generates a pool of fire after some delay.\nSets everything on fire within its effect.",
-    --{Cremator=true}, 100, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE})
+    HORDE:CreateItem( "Explosive", "SLAM", "horde_slam", 950, 2,
+        "Selectable Lightweight Attack Munition.\nRMB to detonate. Attach to wall to active laser mode.\n\nA maximum of 4 SLAMs can be active at the same time.",
+        { Demolition = true },
+        40, 0, nil, "items/hl2/weapon_slam.png", nil, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Explosive", "Resistance RPG", "weapon_rpg", 1500, 5,
+        "Laser-guided rocket propulsion device.",
+        { Survivor = true, Psycho = true, Demolition = true },
+        8, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    -- HORDE:CreateItem( "Explosive", "HopperMine", "horde_hopper_mine", 2000, 5,
+        -- "Combine reactive mines that explode when enemies come in proximity.\nYou can plant at most 5 reactive mines.",
+        -- { Demolition = true },
+        -- 15, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    -- HORDE:CreateItem( "Explosive", "StaticMine", "horde_static_mine", 2000, 5,
+        -- "Combine reactive mines that hovers in air.\nExplode when enemies come in proximity.\nYou can plant at most 5 reactive mines.",
+        -- { Demolition = true },
+        -- 15, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "M79 GL", "arccw_horde_m79", 1500, 5,
+        "M79 Thumper.\nShoots 40x46mm grenades that explode on impact.",
+        { Survivor = true, Psycho = true, Demolition = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "China Lake GL", "arccw_horde_chinalake", 2000, 6,
+        "Pump-Action Grenade Launcher.\nHolds a total of four 40mm grenades,\nand cycles similar to a pump-action shotgun. \nPress B or ZOOM to switch grenade type.",
+        { Survivor = true, Psycho = true, Demolition = true, Engineer = true, Warden = true, Cremator = true },
+        30, -1, nil, nil, { Demolition = 2 }, nil, { HORDE.DMG_BLAST, HORDE.DMG_FIRE, HORDE.DMG_LIGHTNING, HORDE.DMG_COLD }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "Sticky Launcher", "horde_sticky_launcher", 2500, 7,
+        "Sticky grenade launcher.\nLaunches grenades that stick to surfaces and entities.\n\nRMB to detonate.",
+        { Demolition = true },
+        50, -1, nil, nil, { Demolition = 2 }, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "M32 GL", "arccw_horde_m32", 3000, 8,
+        "Milkor Multiple Grenade Launcher.\nA lightweight 40mm six-shot revolver grenade launcher.",
+        { Demolition = true },
+        50, -1, nil, nil, { Demolition = 3 }, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "RPG-7", "arccw_horde_rpg7", 3000, 9,
+        "Ruchnoy Protivotankoviy Granatomyot.\nAnti-tank rocket launcher developed by the Soviet Union.",
+        { Demolition = true },
+        15, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "USAS-12", "arccw_horde_usas12", 3000, 9,
+        "USAS-12 automatic shotgun.\nShoots explosive slugs that deal either Ballistic or Explosive damage. \nPress B or ZOOM to switch grenade type.",
+        { Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Demolition = true, Warden = true },
+        20, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "LAW", "arccw_horde_law", 3250, 9,
+        "Light Anti-Armor Weapon.\nFocuses on raw destructive power instead of area of effect.",
+        { Demolition = true },
+        15, -1, nil, nil, { Demolition = 4 }, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "FGM-148 JAVELIN", "arccw_horde_javelin", 3500, 10,
+        "FGM-148 Javelin.\nFires guided rockets that require a lock-on.",
+        { Demolition = true },
+        15, -1, nil, nil, { Demolition = 5 }, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    HORDE:CreateItem( "Explosive", "M202", "arccw_horde_m202", 3500, 10,
+        "M202 Flame Assault Shoulder.\nAmerican rocket launcher designed to replace the flamethrowers used in World War II.",
+        { Demolition = true },
+        20, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, { HORDE.Infusion_Quality } )
+    -- HORDE:CreateItem( "Explosive", "Thermite", "arccw_horde_nade_incendiary", 1500, 1,
+        -- "Generates a pool of fire after some delay.\nSets everything on fire within its effect.",
+        -- { Cremator = true },
+        -- 100, -1, nil, nil, nil, nil, { HORDE.DMG_FIRE } )
 
+    HORDE:CreateItem( "Special", "Welder", "horde_welder", 100, 0,
+        "Engineering welder.\nDamages enemies and heals minions.",
+        { Engineer = true },
+        10, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST }, nil, { "Engineer" } )
+    HORDE:CreateItem( "Special", "Manhack", "npc_manhack", 900, 3,
+        "Manhack that regenerates on death.\nManhack deals its health as damage to enemies.\nManhack dies on impact.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/npc_manhack.png", nil, nil, { HORDE.DMG_SLASH } )
+    HORDE:CreateItem( "Special", "SMG Turret", "npc_vj_horde_smg_turret", 1000, 4,
+        "Combine Overwatch turret.\n\nUsed to guard chocke points and vital areas.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/npc_turret_floor.png", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Special", "Shotgun Turret", "npc_vj_horde_shotgun_turret", 1250, 4,
+        "Combine shotgun turret.\n\nFires in a shotgun pattern.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/shotgun_turret.png", nil, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Special", "Rocket Turret", "npc_vj_horde_rocket_turret", 1500, 4,
+        "Aperture Science rocket turret.\n\nShoots mini-missiles that deal Blast damage.\nCovers all angles.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/rocket_turret.png", nil, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Special", "Laser Turret", "npc_vj_horde_laser_turret", 1500, 4,
+        "Aperture Science laser turret.\n\nFires tracing laser at the enemy.\nCovers all angles.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/laser_turret.png", { Engineer = 3 }, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Special", "Sniper Turret", "npc_vj_horde_sniper_turret", 1500, 4,
+        "Combine heavy sniper turret.\n\nCovers a long range and deals heavy damage, but with limited sight.\nAims for the head if possible.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/sniper_turret.png", { Engineer = 4 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Special", "Vortigaunt", "npc_vj_horde_vortigaunt", 1750, 5,
+        "Xen Vortigaunts that can conjure concentrated shock energy blasts.\nThe energy blasts have long range and deal splash damage.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/npc_vortigaunt.png", { Engineer = 2 }, nil, { HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Special", "Combat Bot", "npc_vj_horde_combat_bot", 2750, 8,
+        "A resilient humanoid robot designed to engage enemies head-on.\nUses powerful melee attacks and ranged boulder attacks.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 1 }, "items/npc_combat_bot.png", { Engineer = 3 }, nil, { HORDE.DMG_BLUNT } )
+    HORDE:CreateItem( "Special", "Survivor", "npc_vj_horde_class_survivor", 1250, 4,
+        "A Survivor class human that acts as a multipurpose fighter. \nUses an AR15 rifle and grenades.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 3 }, "items/combine_merc.png", { Engineer = 4 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Special", "Assault", "npc_vj_horde_class_assault", 1750, 5,
+        "An Assault class human that uses automatic rifles. \nUses an M16 rifle with M203 UBGL and stun grenades.",
+        { Engineer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/combine_merc.png", { Engineer = 5 }, nil, { HORDE.DMG_BALLISTIC } )
 
-    HORDE:CreateItem("Special",    "Welder",         "horde_welder",         100,  0, "Engineering welder.\nDamages enemies and heals minions.",
-    {Engineer=true}, 10, -1, nil, nil, nil, nil, {HORDE.DMG_BLAST}, nil, {"Engineer"})
-    HORDE:CreateItem("Special",    "Manhack",        "npc_manhack",          900,  3, "Manhack that regenerates on death.\nManhack deals its health as damage to enemies.\nManhack dies on impact.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/npc_manhack.png", nil, nil, {HORDE.DMG_SLASH})
-    HORDE:CreateItem("Special",    "SMG Turret",         "npc_vj_horde_smg_turret",    1000,  4, "Combine smg turret.\n\nUsed to guard choke points and vital areas.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/npc_turret_floor.png", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Special",    "Shotgun Turret", "npc_vj_horde_shotgun_turret",   1250,  4, "Combine shotgun turret.\n\nFires in a shotgun pattern.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/shotgun_turret.png", nil, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Special",    "Rocket Turret",  "npc_vj_horde_rocket_turret",    1500,  4, "Aperture Science rocket turret.\n\nShoots mini-missiles that deal Blast damage.\nCovers all angles.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/rocket_turret.png", nil, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Special",    "Laser Turret",  "npc_vj_horde_laser_turret",    1500,  4, "Aperture Science laser turret.\n\nFires tracing laser at the enemy.\nCovers all angles.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/laser_turret.png", {Engineer=3}, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Special",    "Sniper Turret",  "npc_vj_horde_sniper_turret",   1500,  4, "Combine heavy sniper turret.\n\nCovers a long range and deals heavy damage, but with limited sight.\nAims for the head if possible.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/sniper_turret.png", {Engineer=4}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Special",    "Vortigaunt",     "npc_vj_horde_vortigaunt",  1750,  5, "Xen Vortigaunts that can conjure concentrated shock energy blasts.\nThe energy blasts have long range and deal splash damage.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/npc_vortigaunt.png", {Engineer=2}, nil, {HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Special",    "Combat Bot",     "npc_vj_horde_combat_bot",   2750, 8, "A resilient humanoid robot designed to engage enemies head-on.\nUses powerful melee attacks and ranged boulder attacks.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=1}, "items/npc_combat_bot.png", {Engineer=3}, nil, {HORDE.DMG_BLUNT})
-    HORDE:CreateItem("Special",    "Survivor",     "npc_vj_horde_class_survivor",   1250, 4, "A Survivor class human that acts as a multipurpose fighter. \nUses an AR15 rifle and grenades.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=3}, "items/combine_merc.png", {Engineer=4}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Special",    "Assault",     "npc_vj_horde_class_assault",   1750, 5, "An Assault class human that uses automatic rifles. \nUses an M16 rifle with M203 UBGL and stun grenades.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/combine_merc.png", {Engineer=5}, nil, {HORDE.DMG_BALLISTIC})
-    
-    HORDE:CreateItem("Special",    "Hivehand",       "horde_hivehand",       2000,  5, "Organic weapon used by Xen soldiers.\nHas infinite ammo.\nPrimary fire generates homing ricocheting shots.\nSecondary fire rapidly unloads the entire weapon.",
-    {Engineer=true}, 2, -1, nil, nil, {Engineer=4}, nil, {HORDE.DMG_BALLISTIC})
-    HORDE:CreateItem("Special",    "Spore Launcher", "horde_spore_launcher", 1750,  6, "Improvised biological weapon.\nShoots out acidic projectiles that explodes after a short delay.\nHeals players and damages enemies.",
-    {Medic=true, Survivor=true}, 10, -1, nil, nil, {Medic=2, Survivor=2}, nil, {HORDE.DMG_POISON})
-    HORDE:CreateItem("Special",    "M2 Health Thrower", "horde_healingthrower", 3250,  7, "M2-2 Health Thrower.\nAn American man-portable backpack flamethrower converted to heal stuff to death.\nsmells faintly of lime and mint (who hurt you)",
-    {Medic=true}, 35, -1, nil, nil, nil, nil, {HORDE.DMG_POISON})
-    HORDE:CreateItem("Explosive",  "Medic RPG",          "arccw_horde_medic_rpg",   3500,  8, "Medic Missile.\nAnti-Death Rocket Propelled Grenade \nmade in the Gamestop ventilation of an abandoned mall. \nnot to be confused with the infamous magic missile.",
-    {Medic=true}, 15, -1, nil, nil, nil, nil, {HORDE.DMG_POISON})
+    HORDE:CreateItem( "Special", "Hivehand", "horde_hivehand", 2000, 5,
+        "Organic weapon used by Xen soldiers.\nHas infinite ammo.\nPrimary fire generates homing ricocheting shots.\nSecondary fire rapidly unloads the entire weapon.",
+        { Engineer = true },
+        2, -1, nil, nil, { Engineer = 4 }, nil, { HORDE.DMG_BALLISTIC } )
+    HORDE:CreateItem( "Special", "Spore Launcher", "horde_spore_launcher", 1750, 6,
+        "Improvised biological weapon.\nShoots out acidic projectiles that explodes after a short delay.\nHeals players and damages enemies.",
+        { Survivor = true, Psycho = true, Medic = true, Hatcher = true },
+        10, -1, nil, nil, { Survivor = 2, Medic = 2 }, nil, { HORDE.DMG_POISON } )
+    HORDE:CreateItem( "Special", "M2 Health Thrower", "horde_healingthrower", 3250, 7,
+        "M2-2 Health Thrower.\nAn American man-portable backpack flamethrower converted to heal stuff to death.\nsmells faintly of lime and mint (who hurt you)",
+        { Medic = true, Hatcher = true },
+        35, -1, nil, nil, nil, nil, { HORDE.DMG_POISON } )
+    HORDE:CreateItem( "Explosive", "Medic RPG", "arccw_horde_medic_rpg", 3500, 8,
+        "Medic Missile.\nAnti-Death Rocket Propelled Grenade \nmade in the Gamestop ventilation of an abandoned mall. \nnot to be confused with the infamous magic missile.",
+        { Medic = true, Hatcher = true },
+        15, -1, nil, nil, nil, nil, { HORDE.DMG_POISON } )
 
-    HORDE:CreateItem("Pistol",    "Raygun",  "arccw_horde_raygun", 3000,  8, "Raygun. \nFires explosive electric bolts that deal Lightning damage.",
-    {Warden=true, Engineer=true}, 20, -1, nil, nil, nil, nil, {HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Pistol", "Raygun (Hidden)", "horde_projectile_raygun_bolt", 0, 0,
-        "This item is only here in the Pistol category to calculate pistol damage.", 
-        { Warden = true, Gunslinger = true, Engineer = true }, 10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 0 }, 
-        nil, nil, nil, { HORDE.DMG_LIGHTNING }, nil, nil, true) --This must be hidden
+    HORDE:CreateItem( "Special", "Watchtower", "horde_watchtower", 800, 1,
+        "A watchtower that provides resupply.\nGenerates 1 ammobox every 30 seconds.\n(Entity Class: horde_watchtower)",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/horde_watchtower.png" )
+    HORDE:CreateItem( "Special", "Watchtower MKII", "horde_watchtower_mk2", 1000, 2,
+        "A watchtower that provides resupply.\nGenerates 1 health vial every 30 seconds.\n(Entity Class: horde_watchtower_mk2)",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/horde_watchtower.png" )
+    HORDE:CreateItem( "Special", "Watchtower MKIII", "horde_watchtower_mk3", 1500, 3,
+        "A watchtower that deters enemies.\nShocks 1 nearby enemy every 1 second.\nDoes 100 Lightning damage.\n(Entity Class: horde_watchtower_mk3)",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/horde_watchtower.png", { Warden = 3 }, nil, { HORDE.DMG_LIGHTNING } )
+    HORDE:CreateItem( "Special", "Watchtower Type-Interceptor", "horde_watchtower_interceptor", 2000, 3,
+        "A watchtower that fires constant laser beams to nearby watchtowers.\nThe laser beam deals Fire damage.\n(Entity Class: horde_watchtower_interceptor)",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/horde_watchtower.png", { Warden = 4 }, nil, { HORDE.DMG_BLAST } )
+    HORDE:CreateItem( "Special", "Watchtower Type-Guardian", "horde_watchtower_guardian", 2000, 4,
+        "A watchtower that provides armor regeneration in an area.\nArmor regeneration does not stack with itself.\n(Entity Class: horde_watchtower_guardian)",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/horde_watchtower.png", { Warden = 5 }, nil, nil )
+    HORDE:CreateItem( "Special", "Watchtower Type-Beacon", "horde_watchtower_beacon", 2000, 4,
+        "A watchtower that acts as a shop during waves.\nProvides additional lighting.\n(Entity Class: horde_watchtower_beacon)",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 2 }, "items/horde_watchtower.png", nil, nil, nil )
 
-    HORDE:CreateItem("Special",    "Watchtower",      "horde_watchtower",        800,  1, "A watchtower that provides resupply.\nGenerates 1 ammobox every 30 seconds.\n(Entity Class: horde_watchtower)",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/horde_watchtower.png")
-    HORDE:CreateItem("Special",    "Watchtower MKII",  "horde_watchtower_mk2",  1000,  2, "A watchtower that provides resupply.\nGenerates 1 health vial every 30 seconds.\n(Entity Class: horde_watchtower_mk2)",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/horde_watchtower.png")
-    HORDE:CreateItem("Special",    "Watchtower MKIII", "horde_watchtower_mk3",   1500,  3, "A watchtower that deters enemies.\nShocks 1 nearby enemy every 1 second.\nDoes 100 Lightning damage.\n(Entity Class: horde_watchtower_mk3)",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/horde_watchtower.png", {Warden=3}, nil, {HORDE.DMG_LIGHTNING})
-    HORDE:CreateItem("Special",    "Watchtower Type-Interceptor",  "horde_watchtower_interceptor",   2000,  3, "A watchtower that fires constant laser beams to nearby watchtowers.\nThe laser beam deals Fire damage.\n(Entity Class: horde_watchtower_interceptor)",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/horde_watchtower.png", {Warden=4}, nil, {HORDE.DMG_BLAST})
-    HORDE:CreateItem("Special",    "Watchtower Type-Guardian",  "horde_watchtower_guardian", 2000,  4, "A watchtower that provides armor regeneration in an area.\nArmor regeneration does not stack with itself.\n(Entity Class: horde_watchtower_guardian)",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=2}, "items/horde_watchtower.png", {Warden=5}, nil, nil)
-    HORDE:CreateItem("Special",    "Watchtower Type-Beacon",  "horde_watchtower_beacon", 2000,  4, "A watchtower that acts as a shop during waves.\nProvides additional lighting.\n(Entity Class: horde_watchtower_beacon)",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=1}, "items/horde_watchtower.png", nil, nil, nil)
-
-    HORDE:CreateItem("Special",    "Heat Crossbow",  "arccw_horde_heat_crossbow", 2000,  5, "Improvised sniper weapon.\nHas two firemodes that can be swapped between to deal either Ballistic or Fire damage.\n\nDeals 300% headshot damage.",
-    {Survivor=true, Ghost=true, Cremator=true}, 1, -1, nil, "items/hl2/weapon_crossbow.png", nil, nil, {HORDE.DMG_BALLISTIC, HORDE.DMG_FIRE})
-    HORDE:CreateItem("Special",    "M2 Flamethrower", "horde_m2",            2500,  7, "M2-2 Flamethrower.\nAn American man-portable backpack flamethrower.",
-    {Cremator=true}, 50, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE})
-    HORDE:CreateItem("Special",    "Tau Cannon",      "horde_tau",         3000,  7, "A device that uses electromagnetism to ionize particles.\nHold RMB to charge and release a powerful shot.\nDeals more damage as you charge.\nDevice explodes if you overcharge.",
-    {Cremator=true}, 15, -1, nil, nil, {Cremator=3}, nil, {HORDE.DMG_FIRE})
-    HORDE:CreateItem("Special",    "Gluon Gun", "horde_gluon",            3000,   8, "Quantum Destabilizer.\nAn experimental weapon that fires a devastating laser.",
-    {Cremator=true}, 40, -1, nil, nil, {Cremator=4}, nil, {HORDE.DMG_FIRE})
-    HORDE:CreateItem("Special",    "Heat Blaster",  "arccw_horde_heat_blaster", 3000,  8, "A projectile launcher that shoots flaming fireballs.\nHold RMB to charge a shot.",
-    {Cremator=true}, 50, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE})
+    HORDE:CreateItem( "Special", "Heat Crossbow", "arccw_horde_heat_crossbow", 2000, 5,
+        "Improvised sniper weapon.\nHas two firemodes that can be swapped between to deal either Ballistic or Fire damage.\n\nDeals 300% headshot damage.",
+        { Survivor = true, Psycho = true, Ghost = true, Cremator = true },
+        1, -1, nil, "items/hl2/weapon_crossbow.png", nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Special", "M2 Flamethrower", "horde_m2", 2500, 7,
+        "M2-2 Flamethrower.\nAn American man-portable backpack flamethrower.",
+        { Cremator = true },
+        50, -1, nil, nil, nil, nil, { HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Special", "Tau Cannon", "horde_tau", 3000, 7,
+        "A device that uses electromagnetism to ionize particles.\nHold RMB to charge and release a powerful shot.\nDeals more damage as you charge.\nDevice explodes if you overcharge.",
+        { Cremator = true },
+        15, -1, nil, nil, { Cremator = 3 }, nil, { HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Special", "Gluon Gun", "horde_gluon", 3000, 8,
+        "Quantum Destabilizer.\nAn experimental weapon that fires a devastating laser.",
+        { Cremator = true },
+        40, -1, nil, nil, { Cremator = 4 }, nil, { HORDE.DMG_FIRE } )
+    HORDE:CreateItem( "Special", "Heat Blaster", "arccw_horde_heat_blaster", 3000, 8,
+        "A projectile launcher that shoots flaming fireballs.\nHold RMB to charge a shot.",
+        { Cremator = true },
+        50, -1, nil, nil, nil, nil, { HORDE.DMG_FIRE } )
     --[[HORDE:CreateItem("Special",    "Taser",           "arccw_go_taser",      1000,  1, "Taser.",
     {Engineer=true}, 50, -1)]]--
 
-    HORDE:CreateItem("Special",    "Void Projector",   "horde_void_projector",   0,  11,
+    HORDE:CreateItem( "Special", "Void Projector", "horde_void_projector", 0, 11,
     [[Only usable by Necromancer subclass!
     Manipulates dark energy to inflict hypothermia and conjure entities.]],
-    {Engineer=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_COLD, HORDE.DMG_PHYSICAL}, nil, {"Necromancer"}, true)
+    { Necromancer = true },
+    -1, -1, nil, nil, nil, nil, { HORDE.DMG_COLD, HORDE.DMG_PHYSICAL }, nil, { "Necromancer" } )
 
-    HORDE:CreateItem("Special",    "Solar Seal",   "horde_solar_seal",   0,  11,
+    HORDE:CreateItem( "Special", "Solar Seal", "horde_solar_seal", 0, 11,
     [[Only usable by Artificer subclass!
     Manipulates solar energy to wreak destruction.]],
-    {Cremator=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_FIRE, HORDE.DMG_LIGHTNING}, nil, {"Artificer"}, true)
+    { Artificer = true },
+    -1, -1, nil, nil, nil, nil, { HORDE.DMG_FIRE, HORDE.DMG_LIGHTNING }, nil, { "Artificer" } )
 
-    HORDE:CreateItem("Special",    "Astral Relic",   "horde_astral_relic",   0,  11,
+    HORDE:CreateItem( "Special", "Astral Relic", "horde_astral_relic", 0, 11,
     [[Only usable by Warlock subclass!
     Manipulates negative energy fields.]],
-    {Demolition=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_PHYSICAL}, nil, {"Warlock"}, true)
+    { Warlock = true },
+    -1, -1, nil, nil, nil, nil, { HORDE.DMG_PHYSICAL }, nil, { "Warlock" } )
 
-    HORDE:CreateItem("Special",    "Carcass Biosystem",   "horde_carcass",   0,  12,
+    HORDE:CreateItem( "Special", "Carcass Biosystem", "horde_carcass", 0, 12,
     [[Only usable by Carcass subclass!
     Advanced combat biosystem that completely screws up the appearance of its user.
     Leaves behind an unpleasant stench.
 
     LMB: Punch.
     Hold for a charged punch that deals increased damage in an area.]],
-    {Heavy=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_PHYSICAL}, nil, {"Carcass"}, true)
+    { Carcass = true },
+    -1, -1, nil, nil, nil, nil, { HORDE.DMG_PHYSICAL }, nil, { "Carcass" } )
 
-    HORDE:CreateItem("Special",    "Pheropod",   "horde_pheropod",   0,  9,
+    HORDE:CreateItem( "Special", "Pheropod", "horde_pheropod", 0, 9,
     [[Only usable by Hatcher subclass!
     Pheropods that can hatch and control alien Antlions.
 
@@ -735,50 +1039,75 @@ function HORDE:GetDefaultItemsData()
         - Increased health, damage and attack speed.
         - Increased Aroma Pulse radius and reduce Bug Pulse cooldown.
         - Immune to Poison damage and Break.]],
-    {Medic=true}, -1, -1, nil, nil, nil, nil, {HORDE.DMG_SLASH, HORDE.DMG_POISON}, nil, {"Hatcher"}, true)
+    { Hatcher = true },
+    -1, -1, nil, nil, nil, nil, { HORDE.DMG_SLASH, HORDE.DMG_POISON }, nil, { "Hatcher" } )
 
-    HORDE:CreateItem("Equipment",  "Medkit",         "weapon_horde_medkit",      50,   0, "Rechargeble medkit.\nRMB to self-heal, LMB to heal others.",
-    nil, 10, -1, nil, "items/weapon_medkit.png", nil, nil, nil, nil, {"Survivor", "Psycho", "Assault", "SpecOps", "Reverend", "Heavy", "Carcass", "Juggernaut", "Medic", "Hatcher", "Demolition", "Warlock", "Ghost", "Gunslinger", "Engineer", "Necromancer", "Berserker", "Samurai", "Cyborg Ninja", "Warden", "Cremator", "Artificer"})
-    HORDE:CreateItem("Equipment",  "Health Vial",    "item_healthvial",    15,   0, "A capsule filled with sticky green liquid.\nHeals instantly when picked up.",
-    {Medic=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_DROP, x=50, z=15, yaw=0, limit=5}, nil)
-    HORDE:CreateItem("Equipment", "Kevlar Armor Battery", "item_battery", 160, 0, "Armor battery.\nEach one provides 15 armor. Personal use only.",
-    nil, 10, -1, {type=HORDE.ENTITY_PROPERTY_GIVE}, "items/armor_15.png")
-    HORDE:CreateItem("Equipment", "Full Kevlar Armor", "armor100", 1000, 0, "Full kevlar armor set.\nFills up 100% of your armor bar.",
-    nil, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_100.png")
-    HORDE:CreateItem("Equipment", "Advanced Kevlar Armor", "armor_survivor", 1000, 0, "Distinguished Survivor armor.\n\nFills up 100% of your armor bar.\nProvides 5% increased damage resistance.",
-    {Survivor=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_survivor.png", {Survivor=30}, 1)
-    HORDE:CreateItem("Equipment", "Assault Vest", "armor_assault", 1000, 0, "Distinguished Assault armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Ballistic damage resistance.",
-    {Assault=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_assault.png", {Assault=30}, 1)
-    HORDE:CreateItem("Equipment", "Bulldozer Suit", "armor_heavy", 1000, 0, "Distinguished Heavy armor.\n\nFills up 125% of your armor bar.\n\nIncreases max armor by 25%.",
-    {Heavy=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=125}, "items/armor_heavy.png", {Heavy=30}, 1)
-    HORDE:CreateItem("Equipment", "Hazmat Suit", "armor_medic", 1000, 0, "Distinguished Medic armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Poison damage resistance.",
-    {Medic=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_medic.png", {Medic=30}, 1)
-    HORDE:CreateItem("Equipment", "Bomb Suit", "armor_demolition", 1000, 0, "Distinguished Demolition armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Blast damage resistance.",
-    {Demolition=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_demolition.png", {Demolition=30}, 1)
-    HORDE:CreateItem("Equipment", "Assassin's Cloak", "armor_ghost", 1000, 0, "Distinguished Ghost armor.\n\nFills up 100% of your armor bar.\nProvides 5% increased evasion.",
-    {Ghost=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_ghost.png", {Ghost=30}, 1)
-    HORDE:CreateItem("Equipment", "Defense Matrix", "armor_engineer", 1000, 0, "Distinguished Engineer armor.\n\nFills up 100% of your armor bar.\nProvides 5% increased damage resistance.",
-    {Engineer=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_engineer.png", {Engineer=30}, 1)
-    HORDE:CreateItem("Equipment", "Riot Armor", "armor_warden", 1000, 0, "Distinguished Warden armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Shock and Sonic damage resistance.",
-    {Warden=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_warden.png", {Warden=30}, 1)
-    HORDE:CreateItem("Equipment", "Molten Armor", "armor_cremator", 1000, 0, "Distinguished Cremator armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Fire damage resistance.",
-    {Cremator=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_cremator.png", {Cremator=30}, 1)
-    HORDE:CreateItem("Equipment", "Battle Vest", "armor_berserker", 1000, 0, "Distinguished Berserker armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Slashing/Blunt damage resistance.",
-    {Berserker=true}, 10, -1, {type=HORDE.ENTITY_PROPERTY_ARMOR, armor=100}, "items/armor_berserker.png", {Berserker=30}, 1)
-
+    HORDE:CreateItem( "Equipment", "Medkit", "weapon_horde_medkit", 50, 0,
+        "Rechargeble medkit.\nRMB to self-heal, LMB to heal others.",
+        nil, 10, -1, nil, "items/weapon_medkit.png", nil, nil, nil, nil, { "Survivor", "Psycho", "Assault", "SpecOps", "Reverend", "Heavy", "Carcass", "Juggernaut", "Medic", "Hatcher", "Demolition", "Warlock", "Ghost", "Gunslinger", "Engineer", "Necromancer", "Berserker", "Samurai", "Cyborg Ninja", "Warden", "Cremator", "Artificer" } )
+    HORDE:CreateItem( "Equipment", "Health Vial", "item_healthvial", 15, 0,
+        "A capsule filled with sticky green liquid.\nHeals instantly when picked up.",
+        { Medic = true, Hatcher = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_DROP, x = 50, z = 15, yaw = 0, limit = 5 }, nil )
+    HORDE:CreateItem( "Equipment", "Kevlar Armor Battery", "item_battery", 160, 0,
+        "Armor battery.\nEach one provides 15 armor. Personal use only.",
+        nil, 10, -1, { type = HORDE.ENTITY_PROPERTY_GIVE }, "items/armor_15.png" )
+    HORDE:CreateItem( "Equipment", "Full Kevlar Armor", "armor100", 1000, 0,
+        "Full kevlar armor set.\nFills up 100% of your armor bar.",
+        nil, 10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_100.png" )
+    HORDE:CreateItem( "Equipment", "Advanced Kevlar Armor", "armor_survivor", 1000, 0,
+        "Distinguished Survivor armor.\n\nFills up 100% of your armor bar.\nProvides 5% increased damage resistance.",
+        { Survivor = true, Psycho = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_survivor.png", { Survivor = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Assault Vest", "armor_assault", 1000, 0,
+        "Distinguished Assault armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Ballistic damage resistance.",
+        { Assault = true, SpecOps = true, Reverend = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_assault.png", { Assault = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Bulldozer Suit", "armor_heavy", 1000, 0,
+        "Distinguished Heavy armor.\n\nFills up 125% of your armor bar.\n\nIncreases max armor by 25%.",
+        { Heavy = true, Carcass = true, Juggernaut = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 125 }, "items/armor_heavy.png", { Heavy = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Hazmat Suit", "armor_medic", 1000, 0,
+        "Distinguished Medic armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Poison damage resistance.",
+        { Medic = true, Hatcher = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_medic.png", { Medic = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Bomb Suit", "armor_demolition", 1000, 0,
+        "Distinguished Demolition armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Blast damage resistance.",
+        { Demolition = true, Warlock = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_demolition.png", { Demolition = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Assassin's Cloak", "armor_ghost", 1000, 0,
+        "Distinguished Ghost armor.\n\nFills up 100% of your armor bar.\nProvides 5% increased evasion.",
+        { Ghost = true, Gunslinger = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_ghost.png", { Ghost = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Defense Matrix", "armor_engineer", 1000, 0,
+        "Distinguished Engineer armor.\n\nFills up 100% of your armor bar.\nProvides 5% increased damage resistance.",
+        { Engineer = true, Necromancer = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_engineer.png", { Engineer = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Battle Vest", "armor_berserker", 1000, 0,
+        "Distinguished Berserker armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Slashing/Blunt damage resistance.",
+        { Berserker = true, Samurai = true, ["Cyborg Ninja"] = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_berserker.png", { Berserker = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Riot Armor", "armor_warden", 1000, 0,
+        "Distinguished Warden armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Shock and Sonic damage resistance.",
+        { Warden = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_warden.png", { Warden = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "Molten Armor", "armor_cremator", 1000, 0,
+        "Distinguished Cremator armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Fire damage resistance.",
+        { Cremator = true },
+        10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_cremator.png", { Cremator = 30 }, 1 )
 
     HORDE:GetDefaultGadgets()
     HORDE:GetDefaultItemInfusions()
 
-    if ArcCWInstalled == true and GetConVar("horde_arccw_attinv_free"):GetInt() == 0 then
-        print("[HORDE] ArcCW detected. Loading attachments into shop.")
-        HORDE.GetArcCWAttachments()
+    if ArcCWInstalled == true and GetConVar( "horde_arccw_attinv_free" ):GetInt() == 0 then
+        print( "[HORDE] ArcCW detected. Loading attachments into shop." )
+        HORDE:GetArcCWAttachments()
     end
 
-    print("[HORDE] - Loaded default item config.")
+    print( "[HORDE] - Loaded default item config." )
 end
 
-HORDE.GetArcCWAttachments = function ()
+function HORDE:GetArcCWAttachments()
     -- Optics
     HORDE:CreateItem("Attachment", "C-MORE (RDS)",   "go_optic_cmore",  100,  0, "RDS",
     nil, 10, -1, {type=HORDE.ENTITY_PROPERTY_GIVE, is_arccw_attachment=true, arccw_attachment_type="Optic"})
@@ -1188,17 +1517,17 @@ HORDE.GetArcCWAttachments = function ()
     nil, 10, -1, {type=HORDE.ENTITY_PROPERTY_GIVE, is_arccw_attachment=true, arccw_attachment_type="Perk"})
 end
 
-function HORDE:IsWatchTower(ent)
+function HORDE:IsWatchTower( ent )
     return ent:IsValid() and ent.Horde_WatchTower
 end
 
 -- Startup
 if SERVER then
-    util.AddNetworkString("Horde_SetItemsData")
+    util.AddNetworkString( "Horde_SetItemsData" )
+    util.AddNetworkString( "Horde_SetUpgrades" )
 
-    if GetConVar("horde_external_lua_config"):GetString() and GetConVar("horde_external_lua_config"):GetString() ~= "" then
-    else
-        if GetConVarNumber("horde_default_item_config") == 0 then
+    if not GetConVar( "horde_external_lua_config" ):GetString() or GetConVar( "horde_external_lua_config" ):GetString() == "" then
+        if GetConVar( "horde_default_item_config" ):GetBool() == 0 then
             GetItemsData()
         else
             HORDE:GetDefaultItemsData()
@@ -1207,88 +1536,83 @@ if SERVER then
         end
     end
 
-
-    net.Receive("Horde_SetItemsData", function (len, ply)
+    net.Receive( "Horde_SetItemsData", function ( _, ply )
         if not ply:IsSuperAdmin() then return end
-        local items_len = net.ReadUInt(32)
-        local data = net.ReadData(items_len)
-        local str = util.Decompress(data)
-        HORDE.items = util.JSONToTable(str)
+        local itemsLen = net.ReadUInt( 32 )
+        local data = net.ReadData( itemsLen )
+        local str = util.Decompress( data )
+        HORDE.items = util.JSONToTable( str )
         HORDE.InvalidateHordeItemCache = 1
         HORDE:SetItemsData()
-    end)
-end
-
-if SERVER then
-    util.AddNetworkString("Horde_SetUpgrades")
+    end )
 end
 
 if CLIENT then
-    net.Receive("Horde_SetUpgrades", function(len, ply)
+    net.Receive( "Horde_SetUpgrades", function()
         local class = net.ReadString()
-        local level = net.ReadUInt(8)
-        MySelf:Horde_SetUpgrade(class, level)
-    end)
+        local level = net.ReadUInt( 8 )
+        MySelf:Horde_SetUpgrade( class, level )
+    end )
 end
 
-local plymeta = FindMetaTable("Player")
+local plymeta = FindMetaTable( "Player" )
 
-function plymeta:Horde_GetUpgrade(class)
+function plymeta:Horde_GetUpgrade( class )
     if not self.Horde_Upgrades then self.Horde_Upgrades = {} end
     return self.Horde_Upgrades[class] or 0
 end
 
-function plymeta:Horde_SetUpgrade(class, level)
+function plymeta:Horde_SetUpgrade( class, level )
     if not self.Horde_Upgrades then self.Horde_Upgrades = {} end
     if SERVER then
-        net.Start("Horde_SetUpgrades")
-            net.WriteString(class)
-            net.WriteUInt(level, 8)
-        net.Send(self)
+        net.Start( "Horde_SetUpgrades" )
+            net.WriteString( class )
+            net.WriteUInt( level, 8 )
+        net.Send( self )
     end
     self.Horde_Upgrades[class] = level
 end
 
-function HORDE:IsMeleeItem(class)
+function HORDE:IsMeleeItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Melee"
 end
 
-function HORDE:IsPistolItem(class)
+function HORDE:IsPistolItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Pistol"
 end
 
-function HORDE:IsSMGItem(class)
+function HORDE:IsSMGItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "SMG"
 end
 
-function HORDE:IsRifleItem(class)
+function HORDE:IsRifleItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Rifle"
 end
 
-function HORDE:IsShotgunItem(class)
+function HORDE:IsShotgunItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Shotgun"
 end
 
-function HORDE:IsMGItem(class)
+function HORDE:IsMGItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "MG"
 end
 
-function HORDE:IsExplosiveItem(class)
+function HORDE:IsExplosiveItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Explosive"
 end
 
-function HORDE:IsSpecialItem(class)
+function HORDE:IsSpecialItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Special"
 end
 
-function HORDE:IsEquipmentItem(class)
+function HORDE:IsEquipmentItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Equipment"
 end
 
-function HORDE:IsAttachmentItem(class)
+function HORDE:IsAttachmentItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Attachment"
 end
 
-function HORDE:IsGadgetItem(class)
+function HORDE:IsGadgetItem( class )
     return HORDE.items[class] and HORDE.items[class].category == "Gadget"
 end

--- a/gamemodes/horde/gamemode/sv_economy.lua
+++ b/gamemodes/horde/gamemode/sv_economy.lua
@@ -449,24 +449,25 @@ hook.Add("PlayerCanPickupWeapon", "Horde_Economy_Pickup", function (ply, wpn)
 
     if HORDE.items[wpn:GetClass()] then
         local item = HORDE.items[wpn:GetClass()]
+        local class = ply:Horde_GetCurrentSubclass()
         if (ply:Horde_GetWeight() - item.weight < 0) then
             return false
         end
         if ply:Horde_GetCurrentSubclass() == "Gunslinger" and item.category == "Pistol" then return true end
-        if (item.whitelist and (not item.whitelist[ply:Horde_GetClass().name])) then
+        if (item.whitelist and (not item.whitelist[class])) then
             return false
         end
 
         if item.starter_classes then
-            if (item.class == "horde_void_projector" and ply:Horde_GetCurrentSubclass() ~= "Necromancer") or
-               (item.class == "horde_solar_seal" and ply:Horde_GetCurrentSubclass() ~= "Artificer") or
-               (item.class == "horde_astral_relic" and ply:Horde_GetCurrentSubclass() ~= "Warlock") or
-               (item.class == "horde_carcass" and ply:Horde_GetCurrentSubclass() ~= "Carcass") or
-               (item.class == "horde_pheropod" and ply:Horde_GetCurrentSubclass() ~= "Hatcher") then
+            if (item.class == "horde_void_projector" and class ~= "Necromancer") or
+               (item.class == "horde_solar_seal" and class ~= "Artificer") or
+               (item.class == "horde_astral_relic" and class ~= "Warlock") or
+               (item.class == "horde_carcass" and class ~= "Carcass") or
+               (item.class == "horde_pheropod" and class ~= "Hatcher") then
                 return false
             end
         end
-        if ply:Horde_GetCurrentSubclass() == "Carcass"
+        if class == "Carcass"
         and (item.class ~= "horde_carcass" and item.class ~= "weapon_horde_medkit") then
             return false
         end
@@ -480,14 +481,15 @@ end)
 
 hook.Add("WeaponEquip", "Horde_Economy_Equip", function (wpn, ply)
     if not ply:IsValid() then return end
+    local class = ply:Horde_GetCurrentSubclass()
     if HORDE.items[wpn:GetClass()] then
         local item = HORDE.items[wpn:GetClass()]
-        if ply:Horde_GetCurrentSubclass() == "Gunslinger" and item.category == "Pistol" then
+        if class == "Gunslinger" and item.category == "Pistol" then
             ply:Horde_AddWeight(-item.weight)
             ply:Horde_SyncEconomy()
             return
         end
-        if (ply:Horde_GetWeight() - item.weight < 0) or (item.whitelist and (not item.whitelist[ply:Horde_GetClass().name])) then
+        if (ply:Horde_GetWeight() - item.weight < 0) or (item.whitelist and (not item.whitelist[class])) then
             timer.Simple(0, function ()
                 ply:DropWeapon(wpn)
             end)


### PR DESCRIPTION
Separates base and subclass shop items so they can have their own items

## Changes
- Improvement of readability (excluding attachments) in sh_item.lua
- Styling fixes (excluding attachments) in sh_item.lua
- Removed guns and grenade from Carcass 
Carcass can't even use them the player just loses money and doesn't get given the item if they try
- Removed rifles and masterkey from Gunslinger
Can re-add them easily if needed
- Added glock to Ghost
it has the akimbo glock17 and all other weapons have their non-akimbo versions so why not
  
## Issues
- Attachment shop will not have subclasses properly whitelisted
Attachment shop isn't even enabled so this shouldn't be a issue