### PR TITLE
MW2 Sub-base Ports and Improvements + Tweaks

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_f2000.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_f2000.lua
@@ -21,20 +21,9 @@ SWEP.DamageMin = 57
 SWEP.Recoil = 0.42
 SWEP.RecoilSide = 0.35
 
-SWEP.ShootVol = 75
-
-SWEP.ShootSound = ")weapons/fesiugmw2/fire/f2000.wav"
-SWEP.ShootMechSound = {
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
-}
-SWEP.ShootSoundSilenced = ")weapons/fesiugmw2/fire/m4_sil.wav"
+SWEP.ShootSound = "ArcCW_Horde.F2000_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.F2000_Fire_Mech"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.F2000_Fire_Sil"
 
 SWEP.AttachmentElements = {
     ["wepcamo-desert"]      = { VMSkin = 1 },
@@ -62,6 +51,8 @@ SWEP.AttachmentElements = {
     },
 }
 
+SWEP.RejectAttachments = {["mw2_ubgl_m203"] = true, ["mw2_ubgl_masterkey"] = true}
+
 SWEP.Attachments = {
     {
         PrintName = "Optic",
@@ -87,7 +78,7 @@ SWEP.Attachments = {
     },
     {
         PrintName = "Underbarrel",
-        Slot = {"foregrip", "horde_ubgl_incendiary", "", ""},
+        Slot = {"foregrip", "horde_ubgl_incendiary"},
         Bone = "tag_weapon",
         Offset = {
             vpos = Vector(10, 0, -1.04),
@@ -167,116 +158,38 @@ SWEP.Hook_TranslateAnimation = function(wep, anim)
     end
 end
 
-SWEP.Animations = {
-    ["draw"] = {
-        Source = "pullout",
-        Time = 33/30,
-        SoundTable = {{s = "weapons/fesiugmw2/wpnarm_2.wav", c = CHAN_ITEM, t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["ready"] = {
-        Source = "pullout_first",
-        Time = 35/30,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_first_lift_v1.wav", c = CHAN_ITEM, t = 0/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_first_chamber_v1.wav", c = CHAN_ITEM, t = 13/30},
-        },
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["reload"] = {
-        Source = "reload",
-        Time = 90/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipout_v1.wav", c = CHAN_ITEM, t = 16/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipin_v1.wav", c = CHAN_ITEM, t = 60/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        Time = 103/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipout_v1.wav", c = CHAN_ITEM, t = 15/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipin_v1.wav", c = CHAN_ITEM, t = 61/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_chamber_v1.wav", c = CHAN_ITEM, t = 76/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 79/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", c = CHAN_ITEM, t = 12/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", c = CHAN_ITEM, t = 39/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", c = CHAN_ITEM, t = 60/30},
-        },
-    },
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-}
-function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride)
-    local fsound = self.ShootSound
-    local msound = self.ShootMechSound
-    local suppressed = self:GetBuff_Override("Silencer")
+sound.Add({
+    name = "ArcCW_Horde.F2000_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/f2000.wav"
+})
 
-    fsound = self:GetBuff_Hook("Hook_GetShootSound", fsound)
-
-    local spv    = self.ShootPitchVariation
-    local volume = self.ShootVol
-    local pitch  = self.ShootPitch * math.Rand(1 - spv, 1 + spv) * self:GetBuff_Mult("Mult_ShootPitch")
-
-    local v = GetConVar("arccw_weakensounds"):GetFloat()
-    volume = volume - v
-
-    volume = volume * self:GetBuff_Mult("Mult_ShootVol")
-
-    volume = math.Clamp(volume, 50, 140)
-    pitch  = math.Clamp(pitch, 0, 255)
-
-    if sndoverride then fsound = sndoverride end
-    if voloverride then volume = voloverride end
-    if pitchoverride then pitch = pitchoverride end
-
-    if suppressed then
-        fsound = self.ShootSoundSilenced
-        pitch = 100
-        msound = nil
-    end
-
-    if fsound then self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON) end
-    if msound then self:MyEmitSound(msound, 45, math.Rand(95, 105), .45, CHAN_AUTO) end
-
-    local data = {
-        sound   = fsound,
-        volume  = volume,
-        pitch   = pitch,
+sound.Add({
+    name = "ArcCW_Horde.F2000_Fire_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {95, 110},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
     }
+})
 
-    self:GetBuff_Hook("Hook_AddShootSound", data)
-end
+sound.Add({
+    name = "ArcCW_Horde.F2000_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/m4_sil.wav"
+})

--- a/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
@@ -3,129 +3,24 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_mw2_m4")
     killicon.Add("arccw_horde_m16m203", "arccw/weaponicons/arccw_mw2_m4", Color(0, 0, 0, 255))
 end
-SWEP.Base = "arccw_mw2_abase"
+
+SWEP.Base = "arccw_mw2_m16"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
---SWEP.CamAttachment = 3
 
 SWEP.PrintName = "M16A4"
-SWEP.Trivia_Class = "Assault Rifle"
-SWEP.Trivia_Desc = "3 round burst."
-
-SWEP.Slot = 2
-
-SWEP.UseHands = true
 
 SWEP.ViewModel = "models/weapons/arccw/fesiugmw2_2/c_m16.mdl"
-SWEP.MirrorVMWM = true
-SWEP.WorldModelOffset = {
-    pos = Vector(-5, 3, -5),
-    ang = Angle(-10, 0, 180),
-    scale = 1.25
-}
 SWEP.WorldModel = "models/weapons/w_rif_m4a1.mdl"
-SWEP.ViewModelFOV = 65
 
 SWEP.Damage = 47
 SWEP.DamageMin = 36
-SWEP.RangeMin = 1500 * 0.025  -- GAME UNITS * 0.025 = METRES
-SWEP.Range = 2000 * 0.025  -- GAME UNITS * 0.025 = METRES
-SWEP.Penetration = 7
-SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
 
-
-SWEP.ChamberSize = 0
-SWEP.Primary.ClipSize = 30 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 45
-SWEP.ReducedClipSize = 15
-
-SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 0.5
-SWEP.RecoilSide = 0.4
-SWEP.RecoilRise = 0.1
-
-SWEP.Delay = 0.064 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
-SWEP.Firemodes = {
-    {
-        Mode = -3,
-		RunawayBurst = true,
-        PostBurstDelay = 0.2,
-    },
-    {
-        Mode = 1,
-    },
-    {
-        Mode = 0
-    }
-}
-
-SWEP.NPCWeaponType = {"weapon_ar2", "weapon_smg1"}
-SWEP.NPCWeight = 100
-
-SWEP.AccuracyMOA = 2.5 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 500 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 150
-
-SWEP.Primary.Ammo = "smg1" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =			"weapons/fesiugmw2/fire/m4.wav"
-SWEP.ShootMechSound =       ArcCW_MW2_Mech
---SWEP.DistantShootSound =	"weapons/fesiugmw2/fire_distant/m4_mp.wav"
-SWEP.ShootSoundSilenced =	"weapons/fesiugmw2/fire/m4_sil.wav"
-
-SWEP.MuzzleEffect = "muzzleflash_4"
-SWEP.ShellModel = "models/shells/shell_556.mdl"
-SWEP.ShellPitch = 95
-SWEP.ShellScale = 1
-
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-
-SWEP.SpeedMult = 0.95
-SWEP.SightedSpeedMult = 0.38
-SWEP.SightTime = 0.25
-SWEP.ShellRotateAngle = Angle(0, 90, 0)
-
-SWEP.BulletBones = { -- the bone that represents bullets in gun/mag
-    -- [0] = "bulletchamber",
-    -- [1] = "bullet1"
-}
-
-SWEP.IronSightStruct = {
-    Pos = Vector(-2.595, -3.512, -0.1), --
-    Ang = Angle(0.8, 0, 0),
-    ViewModelFOV = 65 / 1.3,
-    Magnification = 1.3,
-}
-
-SWEP.HoldtypeHolstered = "passive"
-SWEP.HoldtypeActive = "ar2"
-SWEP.HoldtypeSights = "rpg"
-
-SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2
-
-SWEP.ActivePos = Vector(0, 0, 1)
-SWEP.ActiveAng = Angle(0, 0, 0)
-
-SWEP.CustomizePos = Vector(10.479, 0, -1.321)
-SWEP.CustomizeAng = Angle(18.2, 39.4, 14.8)
-
-SWEP.HolsterPos = Vector(1, 0, 1)
-SWEP.HolsterAng = Angle(-10, 12, 0)
-
-SWEP.SprintPos = Vector(0, 0, 1)
-SWEP.SprintAng = Angle(0, 0, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.BarrelLength = 27
+SWEP.ShootSound = "ArcCW_Horde.M16_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.M16_Fire_Mech"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.M16_Fire_Sil"
 
 SWEP.AttachmentElements = {
     ["nors"] = {
@@ -135,27 +30,24 @@ SWEP.AttachmentElements = {
     ["grip"] = {
         VMBodygroups = {{ind = 2, bg = 3}},
     },
-    ["wepcamo-desert"]		= { VMSkin = 1 },
-    ["wepcamo-arctic"]		= { VMSkin = 2 },
-    ["wepcamo-woodland"]	= { VMSkin = 3 },
-    ["wepcamo-digital"]		= { VMSkin = 4 },
-    ["wepcamo-urban"]		= { VMSkin = 5 },
-    ["wepcamo-bluetiger"]	= { VMSkin = 6 },
-    ["wepcamo-redtiger"]	= { VMSkin = 7 },
-    ["wepcamo-fall"]		= { VMSkin = 8 },
-    ["wepcamo-whiteout"]	= { VMSkin = 9 },
-    ["wepcamo-blackout"]        = { VMSkin = 10 },
-    ["wepcamo-bushdweller"]     = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"]    = { VMSkin = 12 },
-            ["horde_ubgl_m203"] = {
-                VMBodygroups = {{ind = 2, bg = 1}},
-            },
-            ["mw2_ubgl_masterkey"] = {
-                VMBodygroups = {{ind = 2, bg = 2}},
-            },
+    ["wepcamo-desert"] = { VMSkin = 1 },
+    ["wepcamo-arctic"] = { VMSkin = 2 },
+    ["wepcamo-woodland"] = { VMSkin = 3 },
+    ["wepcamo-digital"] = { VMSkin = 4 },
+    ["wepcamo-urban"] = { VMSkin = 5 },
+    ["wepcamo-bluetiger"] = { VMSkin = 6 },
+    ["wepcamo-redtiger"] = { VMSkin = 7 },
+    ["wepcamo-fall"] = { VMSkin = 8 },
+    ["wepcamo-whiteout"] = { VMSkin = 9 },
+    ["wepcamo-blackout"] = { VMSkin = 10 },
+    ["wepcamo-bushdweller"] = { VMSkin = 11 },
+    ["wepcamo-thunderstorm"] = { VMSkin = 12 },
+    ["horde_ubgl_m203"] = {
+        VMBodygroups = {{ind = 2, bg = 1}},
+    },
 }
 
-SWEP.ExtraSightDist = 5
+SWEP.RejectAttachments = {["mw2_ubgl_m203"] = true, ["mw2_ubgl_masterkey"] = true}
 
 SWEP.Attachments = {
     {
@@ -166,13 +58,10 @@ SWEP.Attachments = {
         Offset = {
             vpos = Vector(6.972, 0, 4.018),
             vang = Angle(0, 0, 0),
-            wang = Angle(-9.738, 0, 180)
         },
         SlideAmount = {
             vmin = Vector(0.5, 0, 2.95),
             vmax = Vector(4, 0, 2.95),
-            wmin = Vector(5.36, 0.739, -5.401),
-            wmax = Vector(5.36, 0.739, -5.401),
         },
         InstalledEles = {"nors"},
     },
@@ -182,40 +71,31 @@ SWEP.Attachments = {
         Slot = "muzzle",
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(21.7, 0, 2),
+            vpos = Vector(22.5, 0, 2),
             vang = Angle(0, 0, 0),
-            wpos = Vector(33.719, -2.122, -5.573),
-            wang = Angle(0, 6.034, 180)
         },
-		WMScale = Vector(1, 1, 1),
+        VMScale = Vector(1.2, 1.2, 1.2),
     },
     {
         PrintName = "Underbarrel",
-        Slot = {"foregrip", "bipod",--[[] "foregrip_mw2exclusive",]] "horde_ubgl_m203"},
+        Slot = {"foregrip", "horde_ubgl_m203"},
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(18.427, 0, -1.04),
+            vpos = Vector(12.2, 0, 0.8),
             vang = Angle(0, 0, 0),
-            wpos = Vector(14.329, 0.602, -4.453),
-            wang = Angle(-2.461, -6.525, 176.662)
         },
         SlideAmount = {
-            vmin = Vector(6.748, 0, 1.04),
-            vmax = Vector(12.427, 0, 1.04),
-            wmin = Vector(20.996, -0.991, -3.837),
-            wmax = Vector(13.661, -0.078, -3.837),
+            vmin = Vector(8, 0, 0.8),
+            vmax = Vector(12.2, 0, 0.8),
         },
-        Installed = "horde_ubgl_m203",
     },
     {
         PrintName = "Tactical",
         Slot = "tac",
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(12.5, -1, 2.25),
+            vpos = Vector(12.5, -1.2, 1.95),
             vang = Angle(0, 0, 90),
-            wpos = Vector(15.625, -0.253, -6.298),
-            wang = Angle(-8.829, -0.556, 90)
         },
     },
     {
@@ -237,7 +117,7 @@ SWEP.Attachments = {
         Slot = "mw2_wepcamo",
         FreeSlot = true,
     },
-	{
+    {
         PrintName = "Charm",
         Slot = "charm",
         FreeSlot = true,
@@ -251,390 +131,60 @@ SWEP.Attachments = {
     },
 }
 
-
-
 SWEP.Hook_TranslateAnimation = function(wep, anim)
-	local attached = wep.Attachments[3].Installed
-
-	-- m203 is 1, masterkey is 2, fgrip is 3
-	local attthing
-		if 		attached == "horde_ubgl_m203" 		then attthing = 1
-		elseif 	attached == "mw2_ubgl_masterkey" 	then attthing = 2
-		else 											 attthing = 0
-	end
-
-	-- when entering ubgl
-	if anim == "enter_ubgl" then
-		if attthing == 1 then
-			return "switch2_alt_m203"
-		elseif attthing == 2 then
-			return "switch2_alt_masterkey"
-		end
-	elseif anim == "exit_ubgl" then
-		if attthing == 1 then
-			return "switch2_gun_m203"
-		elseif attthing == 2 then
-			return "switch2_gun_masterkey"
-		end
-	end
-
+    local attached = wep.Attachments[3].Installed
+    local attthing
+        if attached == "horde_ubgl_m203" then attthing = 1
+        else attthing = 0
+    end
+    if anim == "enter_ubgl" then
+        if attthing == 1 then
+            return "switch2_alt_m203"
+        end
+    elseif anim == "exit_ubgl" then
+        if attthing == 1 then
+            return "switch2_gun_m203"
+        end
+    end
     if attthing == 1 and wep:GetInUBGL() then
         return "alt_" .. anim .. "_m203"
-		elseif attthing == 1 then
-			return anim .. "_m203"
-
-	elseif attthing == 2 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_masterkey"
-		elseif attthing == 2 then
-			return anim .. "_masterkey"
-
+    elseif attthing == 1 then
+        return anim .. "_m203"
     end
 end
 
-SWEP.Animations = {
-		["enter_ubgl"] = {
-			Source = "idle",
-			Time = 1/60
-		},
-		["exit_ubgl"] = {
-			Source = "idle",
-			Time = 1/60
-		}, 						-- Fuck you.
-    ["idle"] = {
-        Source = "idle",
-        Time = 0--100/30
-    },
-    ["enter_sprint"] = {
-        Source = "sprint_in",
-        Time = 10/30
-    },
-    ["idle_sprint"] = {
-        Source = "sprint_loop",
-        Time = 30/40
-    },
-    ["exit_sprint"] = {
-        Source = "sprint_out",
-        Time = 10/30
-    },
-    ["draw"] = {
-        Source = "pullout",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster"] = {
-        Source = "putaway",
-        Time = 20/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire"] = {
-        Source = "fire",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron"] = {
-        Source = "fire_ads",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["reload"] = {
-        Source = "reload",
-        Time = 61/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        Time = 70/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_chamber_v10.wav",		t = 52/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies M203 ANIMATIONS ... AWESOME ---
-------------------------------------------------
-    ["idle_m203"] = {
-        Source = "idle_m203",
-        Time = 0--100/30
-    },
-    ["enter_sprint_m203"] = {
-        Source = "sprint_in_m203",
-        Time = 10/30
-    },
-    ["idle_sprint_m203"] = {
-        Source = "sprint_loop_m203",
-        Time = 30/40
-    },
-    ["exit_sprint_m203"] = {
-        Source = "sprint_out_m203",
-        Time = 10/30
-    },
-    ["draw_m203"] = {
-        Source = "pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster_m203"] = {
-        Source = "putaway_m203",
-        Time = 20/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire_m203"] = {
-        Source = "fire_m203",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron_m203"] = {
-        Source = "fire_ads_m203",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["reload_m203"] = {
-        Source = "reload_m203",
-        Time = 61/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty_m203"] = {
-        Source = "reload_empty_m203",
-        Time = 70/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_chamber_v10.wav",		t = 52/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies M203 IN THE ANIMATIONS........... ... AWESOME ---
-------------------------------------------------
-    ["alt_idle_m203"] = {
-        Source = "alt_idle_m203",
-        Time = 0--100/30
-    },
-    ["alt_enter_sprint_m203"] = {
-        Source = "alt_sprint_in_m203",
-        Time = 10/30
-    },
-    ["alt_idle_sprint_m203"] = {
-        Source = "alt_sprint_loop_m203",
-        Time = 30/40
-    },
-    ["alt_exit_sprint_m203"] = {
-        Source = "alt_sprint_out_m203",
-        Time = 10/30
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["alt_holster_m203"] = {
-        Source = "alt_putaway_m203",
-        Time = 20/30,
-    },
-    ["alt_fire_m203"] = {
-        Source = "alt_fire_m203",
-        Time = 10/30,
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 78/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", 		t = 12/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", 	t = 39/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", 	t = 60/30},
-					},
-    },
-------------------------------------------------
------- Here lies MASTERKEY ANIMATIONS ... AWESOME ---
-------------------------------------------------
-    ["idle_masterkey"] = {
-        Source = "idle_masterkey",
-        Time = 0--100/30
-    },
-    ["enter_sprint_masterkey"] = {
-        Source = "sprint_in_masterkey",
-        Time = 10/30
-    },
-    ["idle_sprint_masterkey"] = {
-        Source = "sprint_loop_masterkey",
-        Time = 30/40
-    },
-    ["exit_sprint_masterkey"] = {
-        Source = "sprint_out_masterkey",
-        Time = 10/30
-    },
-    ["draw_masterkey"] = {
-        Source = "pullout_masterkey",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster_masterkey"] = {
-        Source = "putaway_masterkey",
-        Time = 20/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire_masterkey"] = {
-        Source = "fire_masterkey",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron_masterkey"] = {
-        Source = "fire_ads_masterkey",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["reload_masterkey"] = {
-        Source = "reload_masterkey",
-        Time = 61/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty_masterkey"] = {
-        Source = "reload_empty_masterkey",
-        Time = 70/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_chamber_v10.wav",		t = 52/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies MASTERKEY IN THE ANIMATIONS........... ... AWESOME ---
-------------------------------------------------
-    ["alt_idle_masterkey"] = {
-        Source = "alt_idle_masterkey",
-        Time = 0--100/30
-    },
-    ["alt_enter_sprint_masterkey"] = {
-        Source = "alt_sprint_in_masterkey",
-        Time = 10/30
-    },
-    ["alt_idle_sprint_masterkey"] = {
-        Source = "alt_sprint_loop_masterkey",
-        Time = 30/40
-    },
-    ["alt_exit_sprint_masterkey"] = {
-        Source = "alt_sprint_out_masterkey",
-        Time = 10/30
-    },
-    ["alt_draw_masterkey"] = {
-        Source = "alt_pullout_masterkey",
-        Time = 25/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["alt_holster_masterkey"] = {
-        Source = "alt_putaway_masterkey",
-        Time = 20/30,
-    },
-    ["alt_fire_masterkey"] = {
-        Source = "alt_fire_masterkey",
-        Time = 10/24,
-    },
-    ["alt_cycle_masterkey"] = {
-        Source = "alt_cycle_masterkey",
-        SoundTable = {{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 		t = 3/30}},
-        Time = 15/30,
-    },
-    ["alt_reload_start_masterkey"] = {
-        Source = "alt_reload_start_masterkey",
-        Time = 35/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_lift_v1.wav", 		t = 0/30},
-						{s = "MW2Common.Masterkey_Load", 		t = 35/30},
-					},
-    },
-    ["alt_reload_loop_masterkey"] = {
-        Source = "alt_reload_loop_masterkey",
-        Time = 33/40,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "MW2Common.Masterkey_Load", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_end_v1.wav", 	t = 33/30},
-					},
-    },
-    ["alt_reload_finish_masterkey"] = {
-        Source = "alt_reload_finish_masterkey",
-        Time = 50/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_end_v1.wav", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 	t = 22/30},
-					},
-    },
------------------------------------------------------
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 24/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 24/30
-    },
-    ["switch2_gun_masterkey"] = {
-        Source = "switch2_gun_masterkey",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 22/30
-    },
-    ["switch2_alt_masterkey"] = {
-        Source = "switch2_alt_masterkey",
-        SoundTable = {
-						{s = "MW2Common.Underbarrel", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 		t = 14/30},
-					},
-        Time = 25/30
-    },
-}
+sound.Add({
+    name = "ArcCW_Horde.M16_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/m4.wav"
+})
+
+sound.Add({
+    name = "ArcCW_Horde.M16_Fire_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {95, 110},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
+    }
+})
+
+sound.Add({
+    name = "ArcCW_Horde.M16_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/m4_sil.wav"
+})

--- a/gamemodes/horde/entities/weapons/arccw_horde_m200.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m200.lua
@@ -1,148 +1,24 @@
 if not ArcCWInstalled then return end
-SWEP.Base = "arccw_mw2_abase"
+
+SWEP.Base = "arccw_mw2_intervention"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
-SWEP.WeaponCamBone = tag_camera
 
-SWEP.PrintName = "M200 Intervention"
-SWEP.Trivia_Class = "Sniper Rifle"
-SWEP.Trivia_Desc = "American bolt-action sniper rifle"
-
-SWEP.Slot = 2
-
-SWEP.UseHands = true
+SWEP.PrintName = "Intervention"
 
 SWEP.ViewModel = "models/weapons/arccw/fesiugmw2/c_intervention.mdl"
-SWEP.MirrorVMWM = true
-SWEP.WorldModelOffset = {
-    pos = Vector(-6.5, 4, -6),
-    ang = Angle(-10, 0, 180),
-    scale = 1.125
-}
-SWEP.ViewModelFOV = 65
+SWEP.WorldModel = "models/weapons/w_snip_awp.mdl"
 
 SWEP.Damage = 725
 SWEP.DamageMin = 725
-SWEP.Range = 4000 * 0.025 -- in METRES
-SWEP.Penetration = 22
 
-SWEP.ChamberSize = 0
-SWEP.Primary.ClipSize = 10 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 10
-SWEP.ReducedClipSize = 3
+SWEP.ShootSound = "ArcCW_Horde.Intervention_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.Intervention_Fire_Sil"
 
-SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 2
-SWEP.RecoilSide = 2
+SWEP.MuzzleEffect = "muzzleflash_5"
 
-SWEP.AccuracyMOA = 0.04 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 800 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 200
-
-
-SWEP.ManualAction = true
-SWEP.NoLastCycle = true -- do not cycle on last shot
-
-SWEP.Delay = 60 / 400 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
-SWEP.Firemodes = {
-    {
-        PrintName = "BOLT",
-        Mode = 1,
-    },
-    {
-        Mode = 0
-    }
-}
-
-SWEP.NPCWeaponType = {"weapon_crossbow"}
-SWEP.NPCWeight = 100
-
-SWEP.ManualAction = true
-SWEP.NoLastCycle = true -- do not cycle on last shot
-
-SWEP.Primary.Ammo = "SniperPenetratedRound" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =			"weapons/fesiugmw2/fire/cheytac_mp.wav"
---SWEP.DistantShootSound =	"weapons/fesiugmw2/fire_distant/cheytac_mp.wav"
-SWEP.ShootSoundSilenced =	"weapons/fesiugmw2/fire/sniper_sil.wav"
-
-SWEP.MuzzleEffect = "muzzleflash_6"
-SWEP.ShellModel = "models/shells/shell_338mag.mdl"
-SWEP.ShellPitch = 80
-SWEP.ShellScale = 1
-SWEP.ShellRotateAngle = Angle(0, 90, 0)
-
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-
-SWEP.SpeedMult = 0.95
-SWEP.SightedSpeedMult = 0.40
-SWEP.SightTime = 0.4 / 1.15
-
-SWEP.IronSightStruct = {
-    Pos = Vector(-3.778, -3, 0.93),
-    Ang = Angle(0.513, 0, 0),
-    ViewModelFOV = 65 / 1.3,
-    Magnification = 1.3,
-}
-
-SWEP.HoldtypeHolstered = "passive"
-SWEP.HoldtypeActive = "ar2"
-SWEP.HoldtypeSights = "rpg"
-
-SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_SHOTGUN
-
-SWEP.ActivePos = Vector(0, 0, 1)
-SWEP.ActiveAng = Angle(0, 0, 0)
-
-SWEP.HolsterPos = Vector(1, 0, 1)
-SWEP.HolsterAng = Angle(-10, 12, 0)
-
-SWEP.SprintPos = Vector(0, 0, 1)
-SWEP.SprintAng = Angle(0, 0, 0)
-
-SWEP.CustomizePos = Vector(9.824, 2, -2.897)
-SWEP.CustomizeAng = Angle(12.149, 30.547, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.AttachmentElements = {
-    ["nors"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-        WMBodygroups = {},
-    },
-    ["nolaser"] = {
-        VMBodygroups = {{ind = 2, bg = 1}},
-        WMBodygroups = {},
-    },
-    ["wepcamo-desert"]		= { VMSkin = 1 },
-    ["wepcamo-arctic"]		= { VMSkin = 2 },
-    ["wepcamo-woodland"]	= { VMSkin = 3 },
-    ["wepcamo-digital"]		= { VMSkin = 4 },
-    ["wepcamo-urban"]		= { VMSkin = 5 },
-    ["wepcamo-bluetiger"]	= { VMSkin = 6 },
-    ["wepcamo-redtiger"]	= { VMSkin = 7 },
-    ["wepcamo-fall"]		= { VMSkin = 8 },
-    ["wepcamo-whiteout"]	= { VMSkin = 9 },
-    ["wepcamo-blackout"]        = { VMSkin = 10 },
-    ["wepcamo-bushdweller"]     = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"]    = { VMSkin = 12 },
-}
-
-SWEP.BarrelLength = 50
-
-SWEP.ExtraSightDist = 5
-SWEP.Bipod_Integral = true
-SWEP.BipodDispersion = 0.5
-SWEP.BipodRecoil = 0.5
-
-SWEP.RejectAttachments = {["go_homemade_auto"] = true, ["go_perk_burst"] = true}
 SWEP.Attachments = {
     {
         PrintName = "Optic",
@@ -153,9 +29,7 @@ SWEP.Attachments = {
             vpos = Vector(4.2, 0, 3),
             vang = Angle(0, 0, 0),
         },
-        Installed = "optic_cheytacscope",
-        VMScale = Vector(1, 1, 1),
-        InstalledEles = {"nors"},
+        Installed = "optic_cheytacscope"
     },
     {
         PrintName = "Muzzle",
@@ -163,33 +37,28 @@ SWEP.Attachments = {
         Slot = "muzzle",
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(33, 0, 1.6),
+            vpos = Vector(39, 0, 1.6),
             vang = Angle(0, 0, 0),
-            wpos = Vector(26.648, 0.782, -8.042),
-            wang = Angle(-9.79, 0, 180)
         },
-		VMScale = Vector(2, 1.25, 1.25)
+        VMScale = Vector(1.75, 1.75, 1.75)
     },
     {
         PrintName = "Tactical",
         Slot = {"tac","mw2_hidelaser"},
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(18, 0, 2.6),
+            vpos = Vector(16.5, -0.15, 2.5),
             vang = Angle(0, 0, 180),
-            wpos = Vector(15.625, -0.253, -6.298),
-            wang = Angle(-8.829, -0.556, 90)
         },
         InstalledEles = {"nolaser"},
     },
     {
         PrintName = "Ammo Type",
-        Slot = "go_ammo",
-        DefaultAttName = "Standard Ammo"
+        Slot = "go_ammo"
     },
     {
         PrintName = "Perk",
-        Slot = "go_perk",
+        Slot = "go_perk"
     },
     {
         PrintName = "Camouflage",
@@ -203,94 +72,26 @@ SWEP.Attachments = {
         FreeSlot = true,
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(4, -0.6, 1),
+            vpos = Vector(2.7, -0.4, -0.95),
             vang = Angle(0, 0, 0),
-            wpos = Vector(9.625, 1.5, -4),
-            wang = Angle(0, 0, 180)
         },
     },
 }
 
-SWEP.Animations = {
-    ["idle"] = {
-        Source = "idle",
-        Time = 101/30
-    },
-    ["enter_sprint"] = {
-        Source = "sprint_in",
-        Time = 20/30
-    },
-    ["idle_sprint"] = {
-        Source = "sprint_loop",
-        Time = 30/40
-    },
-    ["exit_sprint"] = {
-        Source = "sprint_out",
-        Time = 10/30
-    },
-    ["draw"] = {
-        Source = "pullout",
-        Time = 40/30,
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster"] = {
-        Source = "putaway",
-        Time = 36/30,
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["fire"] = {
-        Source = "fire",
-        Time = 10/30,
-		MinProgress = 10/30,
-    },
-    ["cycle"] = {
-        Source = "rechamber",
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltunlock_v1.wav", 	t = 3/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltopen_v1.wav", 		t = 7/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltclose_v1.wav", 	t = 16/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltlock_v1.wav", 		t = 19/30},
-					},
-        ShellEjectAt = 7/30,
-        Time = 29/30,
-    },
-    ["reload"] = {
-        Source = "reload_tac",
-        Time = 69/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_lift_v1.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_clipout_v1.wav", 	t = 18/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_clipin_v1.wav", 	t = 47/30},
-					},
-        Checkpoints = {18, 47},
-        FrameRate = 30,
-        LHIK = false,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        Time = 117/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_lift_v1.wav", 			t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltunlock_v1.wav", 	t = 13/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltopen_v1.wav", 		t = 18/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_clipout_v1.wav", 		t = 54/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_clipin_v1.wav", 		t = 81/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltclose_v1.wav", 	t = 99/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_cheytech_reload_boltlock_v1.wav", 		t = 103/30},
-					},
-        Checkpoints = {18, 54, 81, 99},
-        FrameRate = 30,
-        LHIK = false,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-}
+sound.Add({
+    name = "ArcCW_Horde.Intervention_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/cheytac_mp.wav"
+})
+
+sound.Add({
+    name = "ArcCW_Horde.Intervention_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/sniper_sil.wav"
+})

--- a/gamemodes/horde/entities/weapons/arccw_horde_scarl.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_scarl.lua
@@ -20,21 +20,10 @@ SWEP.WorldModel = "models/weapons/w_rif_galil.mdl"
 SWEP.Damage = 73
 SWEP.DamageMin = 62
 
-SWEP.ShootVol = 75
-
-SWEP.ShootSound = ")weapons/fesiugmw2/fire/scarl.wav"
-SWEP.ShootMechSound = {
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
-}
+SWEP.ShootSound = "ArcCW_Horde.ScarLOS_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.ScarLOS_Fire_Mech"
 SWEP.ShootDrySound = "weapons/arccw/dryfire.wav"
-SWEP.ShootSoundSilenced = ")weapons/fesiugmw2/fire/scarl_sil.wav"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.ScarLOS_Fire_Sil"
 
 SWEP.AttachmentElements = {
     ["grip"] = {
@@ -164,162 +153,38 @@ SWEP.Hook_TranslateAnimation = function(wep, anim)
     end
 end
 
-SWEP.Animations = {
-    ["draw"] = {
-        Source = "pullout",
-        Time = 29/30,
-        SoundTable = {{s = "weapons/fesiugmw2/wpnarm_2.wav", c = CHAN_ITEM, t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["ready"] = {
-        Source = "pullout_first",
-        Time = 38/30,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_chamber_v1.wav", c = CHAN_ITEM, t = 13/30},
-        },
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["reload"] = {
-        Source = "reload",
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magout.wav", c = CHAN_ITEM, t = 10/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magin.wav", c = CHAN_ITEM, t = 40/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-        LHIKEaseOut = 0.3,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magout.wav", c = CHAN_ITEM, t = 10/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magin.wav", c = CHAN_ITEM, t = 40/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/chamber.wav", c = CHAN_ITEM, t = 54/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/chamberforward.wav", c = CHAN_ITEM, t = 62/30},                     
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-        LHIKEaseOut = 0.3,
-    },
-    ["draw_m203"] = {
-        Source = "pullout_m203",
-        Time = 29/30,
-        SoundTable = {{s = "weapons/fesiugmw2/wpnarm_2.wav", c = CHAN_ITEM, t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["ready_m203"] = {
-        Source = "pullout_first_m203",
-        Time = 38/30,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_chamber_v1.wav", c = CHAN_ITEM, t = 13/30},
-        },
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["reload_m203"] = {
-        Source = "reload_m203",
-        Time = 76/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipout_v1.wav", c = CHAN_ITEM, t = 18/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipin_v1.wav", c = CHAN_ITEM, t = 48/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0.7,
-    },
-    ["reload_empty_m203"] = {
-        Source = "reload_empty_m203",
-        Time = 102/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipout_v1.wav", c = CHAN_ITEM, t = 18/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipin_v1.wav", c = CHAN_ITEM, t = 48/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_hit_v1.wav", c = CHAN_ITEM, t = 69/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0.7,
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 79/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", c = CHAN_ITEM, t = 12/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", c = CHAN_ITEM, t = 39/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", c = CHAN_ITEM, t = 60/30},
-        },
-    },
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-}
+sound.Add({
+    name = "ArcCW_Horde.ScarLOS_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/scar.wav"
+})
 
-function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride)
-    local fsound = self.ShootSound
-    local msound = self.ShootMechSound
-    local suppressed = self:GetBuff_Override("Silencer")
-
-    fsound = self:GetBuff_Hook("Hook_GetShootSound", fsound)
-
-    local spv    = self.ShootPitchVariation
-    local volume = self.ShootVol
-    local pitch  = self.ShootPitch * math.Rand(1 - spv, 1 + spv) * self:GetBuff_Mult("Mult_ShootPitch")
-
-    local v = GetConVar("arccw_weakensounds"):GetFloat()
-    volume = volume - v
-
-    volume = volume * self:GetBuff_Mult("Mult_ShootVol")
-
-    volume = math.Clamp(volume, 50, 140)
-    pitch  = math.Clamp(pitch, 0, 255)
-
-    if sndoverride then fsound = sndoverride end
-    if voloverride then volume = voloverride end
-    if pitchoverride then pitch = pitchoverride end
-
-    if suppressed then
-        fsound = self.ShootSoundSilenced
-        pitch = 100
-        msound = nil
-    end
-
-    if fsound then self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON) end
-    if msound then self:MyEmitSound(msound, 45, math.Rand(95, 105), .45, CHAN_AUTO) end
-
-    local data = {
-        sound   = fsound,
-        volume  = volume,
-        pitch   = pitch,
+sound.Add({
+    name = "ArcCW_Horde.ScarLOS_Fire_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {95, 110},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
     }
+})
 
-    self:GetBuff_Hook("Hook_AddShootSound", data)
-end
+sound.Add({
+    name = "ArcCW_Horde.ScarLOS_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/scarl_sil.wav"
+})

--- a/gamemodes/horde/entities/weapons/arccw_horde_striker.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_striker.lua
@@ -3,183 +3,44 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_horde_striker")
     killicon.Add("arccw_horde_striker", "arccw/weaponicons/arccw_horde_striker", Color(0, 0, 0, 255))
 end
-SWEP.Base = "arccw_mw2_abase"
+
+SWEP.Base = "arccw_mw2_striker"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
-SWEP.WeaponCamBone = tag_camera
 
-SWEP.PrintName = "Striker (Horde)"
-SWEP.Trivia_Class = "Shotgun"
-SWEP.Trivia_Desc = "Semi-automatic (single fire)"
-
-SWEP.Trivia_Manufacturer = "Benelli Armi SPA"
-SWEP.Trivia_Calibre = "12 Gauge"
-SWEP.Trivia_Mechanism = "Gas-Operated"
-SWEP.Trivia_Country = "Italy"
-SWEP.Trivia_Year = 1998
-
-SWEP.Slot = 2
-
-SWEP.UseHands = true
+SWEP.PrintName = "Striker"
 
 SWEP.ViewModel = "models/weapons/arccw/fesiugmw2_2/c_striker_1.mdl"
-SWEP.MirrorVMWM = true
-SWEP.WorldModelOffset = {
-    pos = Vector(-3.5, 4, -5),
-    ang = Angle(-10, 0, 180),
-    scale = 1.1
-}
-SWEP.ViewModelFOV = 65
+SWEP.WorldModel = "models/weapons/w_shot_xm1014.mdl"
 
 SWEP.Damage = 43
 SWEP.DamageMin = 25
-SWEP.Range = 1000 * 0.025  -- GAME UNITS * 0.025 = METRES
-SWEP.RangeMin = 500 * 0.025
-SWEP.Penetration = 10
-SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
 
-
-SWEP.ChamberSize = 0
-SWEP.Primary.ClipSize = 12 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 18
-SWEP.ReducedClipSize = 6
-
-SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 2
-SWEP.RecoilSide = 2
-
-SWEP.ShotgunReload = true
-
-SWEP.Delay = 60 / 400 -- 60 / RPM.
-SWEP.Num = 7 -- number of shots per trigger pull.
-SWEP.RunawayBurst = false
-SWEP.Firemodes = {
-    {
-        Mode = 1,
-    },
-    {
-        Mode = 0
-    }
-}
-
-SWEP.NPCWeaponType = "weapon_shotgun"
-SWEP.NPCWeight = 125
-
-SWEP.AccuracyMOA = 90 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 150 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 100
-
-
-SWEP.Primary.Ammo = "buckshot" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =			"weapons/fesiugmw2/fire/shot_stryker.wav"
---SWEP.DistantShootSound =	"weapons/fesiugmw2/fire_distant/shot_m1014.wav"
-SWEP.ShootSoundSilenced =	"weapons/fesiugmw2/fire/shot_sil.wav"
-
-SWEP.MuzzleEffect = "muzzleflash_m3"
-SWEP.ShellModel = "models/shells/shell_12gauge.mdl"
-SWEP.ShellPitch = 100
-SWEP.ShellSounds = ArcCW.ShotgunShellSoundsTable
-SWEP.ShellScale = 1.5
-SWEP.ShellRotateAngle = Angle(0, 90, 0)
-
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-
-SWEP.SpeedMult = 1
-SWEP.SightedSpeedMult = 0.7
-SWEP.SightTime = 0.3
-
-SWEP.BulletBones = { -- the bone that represents bullets in gun/mag
-    -- [0] = "bulletchamber",
-    -- [1] = "bullet1"
-}
-
-SWEP.IronSightStruct = {
-    Pos = Vector(-2.846, -3.5, 0.75),
-    Ang = Angle(-0.2, 0, 0),
-    ViewModelFOV = 65 / 1.18,
-    Magnification = 1.18,
-}
-
-
-
-SWEP.HoldtypeHolstered = "passive"
-SWEP.HoldtypeActive = "smg"
-SWEP.HoldtypeSights = "smg"
-
-SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2
-
-SWEP.ActivePos = Vector(-0.25, -0.5, 0.75)
-SWEP.ActiveAng = Angle(0, 0, 0)
-
-SWEP.CustomizePos = Vector(5.479, -3, 0.321)
-SWEP.CustomizeAng = Angle(6.2, 29.4, 14.8)
-
-SWEP.HolsterPos = Vector(3, 0, 0)
-SWEP.HolsterAng = Angle(-10, 25, 0)
-
-SWEP.SprintPos = Vector(-0.25, -0.5, 0.75)
-SWEP.SprintAng = Angle(0, 0, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.ExtraSightDist = 5
-
-SWEP.AttachmentElements = {
-    ["sight"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-        WMBodygroups = {},
-    },
-    ["grip"] = {
-        VMBodygroups = {{ind = 2, bg = 1}},
-        WMBodygroups = {},
-    },
-    ["wepcamo-desert"]		= { VMSkin = 1 },
-    ["wepcamo-arctic"]		= { VMSkin = 2 },
-    ["wepcamo-woodland"]	= { VMSkin = 3 },
-    ["wepcamo-digital"]		= { VMSkin = 4 },
-    ["wepcamo-urban"]		= { VMSkin = 5 },
-    ["wepcamo-bluetiger"]	= { VMSkin = 6 },
-    ["wepcamo-redtiger"]	= { VMSkin = 7 },
-    ["wepcamo-fall"]		= { VMSkin = 8 },
-    ["wepcamo-whiteout"]	= { VMSkin = 9 },
-    ["wepcamo-blackout"]        = { VMSkin = 10 },
-    ["wepcamo-bushdweller"]     = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"]    = { VMSkin = 12 },
-}
+SWEP.ShootSound = "ArcCW_Horde.Striker_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.Striker_Fire_Sil"
 
 SWEP.Attachments = {
     {
         PrintName = "Optic",
         DefaultAttName = "Iron Sights",
-        Slot = {"optic","optic_lp"},
+        Slot = "optic",
         Bone = "tag_weapon",
         Offset = {
             vpos = Vector(4.4, 0, 2.2),
             vang = Angle(0, 0, 0),
-            wang = Angle(-9.738, 0, 180)
         },
-        GivesFlags = {"optics"},
-        ExcludeFlags = {"tac"},
         InstalledEles = {"sight"},
     },
     {
         PrintName = "Muzzle",
         DefaultAttName = "Standard Muzzle",
-        Slot = {"muzzle_shotgun","muzzle"},
+        Slot = "muzzle_shotgun",
         Bone = "tag_weapon",
         Offset = {
             vpos = Vector(15, 0, 1),
             vang = Angle(0, 0, 0),
-            wpos = Vector(26.648, 0.782, -8.042),
-            wang = Angle(-9.79, 0, 180)
         },
         VMScale = Vector(1.25, 1.25, 1.25),
     },
@@ -190,8 +51,6 @@ SWEP.Attachments = {
         Offset = {
             vpos = Vector(10, 0, 0.34),
             vang = Angle(0, 0, 0),
-            wpos = Vector(14.329, 0.602, -4.453),
-            wang = Angle(-10.216, 0, 180)
         },
         InstalledEles = {"grip"},
     },
@@ -200,17 +59,12 @@ SWEP.Attachments = {
         Slot = "tac",
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(4.4, 0, 2.2),
-            vang = Angle(0, 0, 180),
-            wang = Angle(-9.738, 0, 180)
+            vpos = Vector(10, 0.5, 1),
+            vang = Angle(0, 0, -90),
         },
-        VMScale = Vector(0.8, 0.8, 0.8),
-        GivesFlags = {"tac"},
-        ExcludeFlags = {"optic"},
-        InstalledEles = {"sight"},
         SlideAmount = {
-            vmin = Vector(4.5, 0, 2.2),
-            vmax = Vector(3.2, 0, 2.2),
+            vmin = Vector(7.5, 0.5, 1),
+            vmax = Vector(10, 0.5, 1),
         },
     },
     {
@@ -239,90 +93,26 @@ SWEP.Attachments = {
         FreeSlot = true,
         Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(13, -0.6, 1),
+            vpos = Vector(1, -0.5, 0.8),
             vang = Angle(0, 0, 0),
-            wpos = Vector(9.625, 1.5, -4),
-            wang = Angle(0, 0, 180)
         },
-        VMScale = Vector(0.7, 0.7, 0.7),
     },
 }
 
-SWEP.Animations = {
-    ["idle"] = {
-        Source = "idle",
-        Time = 1 / 100,
-    },
-    ["enter_sprint"] = {
-        Source = "sprint_in",
-        Time = 10 / 30
-    },
-    ["idle_sprint"] = {
-        Source = "sprint_loop",
-        Time = 30 / 40
-    },
-    ["exit_sprint"] = {
-        Source = "sprint_out",
-        Time = 10 / 30
-    },
-    ["draw"] = {
-        Source = "pullout",
-        Time = 26 / 30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.2,
-    },
-    ["holster"] = {
-        Source = "putaway",
-        Time = 25 / 30,
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.3,
-    },
-    ["fire"] = {
-        Source = "fire",
-        Time = 10 / 30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron"] = {
-        Source = "fire_ads",
-        Time = 10 / 30,
-        ShellEjectAt = 0,
-    },
-    ["sgreload_start"] = {
-        Source = "reload_start",
-        Time = 16 / 40,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
-        SoundTable = {
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_lift_v1.wav", 		t = 0},
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_shell_v1.wav", 		t = 20 / 40},
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_button_v1.wav", 		t = 36 / 40},
-                    },
-        RestoreAmmo = 1, -- only used by shotgun empty insert reload
-    },
-    ["sgreload_insert"] = {
-        Source = "reload_loop",
-        Time = 16 / 40,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_SHOTGUN,
-        SoundTable = {
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_shell_v1.wav", 		t = 3 / 40},
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_button_v1.wav", 		t = 19 / 40},
-                    },
-        TPAnimStartTime = 0.3,
-    },
-    ["sgreload_finish"] = {
-        Source = "reload_finish",
-        Time = 16 / 40,
-        SoundTable = {
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_end_v1.wav", 		t = 0.01},
-                    },
-    },
-    ["sgreload_finish_empty"] = {
-        Source = "reload_finish",
-        Time = 16 / 30,
-        SoundTable = {
-                        {s = "weapons/fesiugmw2/foley/wpfoly_striker_reload_end_v1.wav", 		t = 0.01},
-                    },
-    },
-}
+sound.Add({
+    name = "ArcCW_Horde.Striker_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/shot_stryker.wav"
+})
+
+sound.Add({
+    name = "ArcCW_Horde.Striker_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {95, 110},
+    sound = ")weapons/fesiugmw2/fire/shot_sil.wav"
+})


### PR DESCRIPTION
## Dev
- Ported over Intervention, Striker, and M16A4 to use "Sub-base" system.
- F2000 and M16A4 now have an attachment blacklist to block the UBGL and Masterkey devices.

## Changes (Intervention, Striker, M16A4)
- Improved and fixed attachment positions.
- Added ability to attach both an optic and tactical device simultaneously on the Striker.
- Improved sounds.

## Tweaks (F2000, Scar-LOS)
- Now uses sound.Add() for handling shooting sounds.
- Removed unnecessary animation tables.