### PR TITLE
Cremator & Arti changes

### DIFF
--- a/gamemodes/horde/entities/entities/projectile_horde_floating_chaos/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_floating_chaos/shared.lua
@@ -43,7 +43,7 @@ function ENT:Initialize()
 
     self:SetCollisionGroup(COLLISION_GROUP_WORLD)
 
-    self.ExplodeTimer = CurTime() + 3 * ( self.Horde_Spell_Level + 1 )
+    self.ExplodeTimer = CurTime() + 3 + ( self.Horde_Spell_Level * 2 )
 
     self.Owner.Horde_Floating_Chaos = self
 

--- a/gamemodes/horde/entities/entities/projectile_horde_floating_chaos/shared.lua
+++ b/gamemodes/horde/entities/entities/projectile_horde_floating_chaos/shared.lua
@@ -43,7 +43,7 @@ function ENT:Initialize()
 
     self:SetCollisionGroup(COLLISION_GROUP_WORLD)
 
-    self.ExplodeTimer = CurTime() + 3 + self.Horde_Spell_Level
+    self.ExplodeTimer = CurTime() + 3 * ( self.Horde_Spell_Level + 1 )
 
     self.Owner.Horde_Floating_Chaos = self
 

--- a/gamemodes/horde/entities/weapons/horde_gluon.lua
+++ b/gamemodes/horde/entities/weapons/horde_gluon.lua
@@ -160,7 +160,7 @@ function SWEP:PrimaryAttack()
     bullet.Force = self.Primary.Force
     bullet.Damage = self.Primary.Damage
     bullet.AmmoType = self.Primary.Ammo
-    bullet.Distance = 1000
+    bullet.Distance = 2500
     bullet.Callback = function (ent, tr, dmginfo)
         dmginfo:SetDamageType(DMG_BURN)
         local dmg = DamageInfo()

--- a/gamemodes/horde/gamemode/languages/english.lua
+++ b/gamemodes/horde/gamemode/languages/english.lua
@@ -356,7 +356,7 @@ Complexity: EASY
 
 {8} increased Fire damage resistance and immune to Ignite.
 Attacks have {5} chance to Ignite enemies.
-Regenerate a Molotov every 45 seconds.
+Regenerate a Molotov every 30 seconds.
 {1} increased Ignite damage. ({3} per level, up to {4}).
 
 Ignite base duration is {6} and deals damage over time based on hit damage.
@@ -1048,16 +1048,12 @@ LANGUAGE["Item_F2000"] = [[F2000]]
 LANGUAGE["Item_Desc_F2000"] = [[
 FN F2000.
 An ambidextrous bullpup rifle developed by FN.
-Equipped with an M203 underbarrel incendiary grenade launcher.
-Press USE+RELOAD to equip M203.
 ]]
 
 LANGUAGE["Item_Tavor"] = [[Tavor]]
 LANGUAGE["Item_Desc_Tavor"] = [[
 IWI Tavor-21.
 Designed to maximize reliability, durability, and simplicity.
-Equipped with an M203 underbarrel shock grenade launcher.
-Press USE+RELOAD to equip M203.
 ]]
 
 

--- a/gamemodes/horde/gamemode/perks/cremator/cremator_base.lua
+++ b/gamemodes/horde/gamemode/perks/cremator/cremator_base.lua
@@ -4,7 +4,7 @@ The Cremator builds its offense and defense around Fire damage.
 Complexity: EASY
 
 {8} increased Fire damage resistance and immune to Ignite.
-Regenerate a Molotov every 45 seconds.
+Regenerate a Molotov every 30 seconds.
 Attacks have {5} chance to Ignite enemies.
 {1} increased Ignite damage. ({3} per level, up to {4}).
 
@@ -26,7 +26,7 @@ PERK.Hooks = {}
 PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if SERVER and perk == "cremator_base" then
         ply:Horde_SetApplyIgniteChance(ply:Horde_GetApplyIgniteChance() + 0.25)
-        timer.Create("Horde_CrematorBase" .. ply:SteamID(), 45, 0, function ()
+        timer.Create("Horde_CrematorBase" .. ply:SteamID(), 30, 0, function ()
             if not ply:IsValid() or not ply:Alive() then return end
             if HORDE.items["arccw_thr_horde_molotov"] then
                 if not ply:HasWeapon("arccw_thr_horde_molotov") then

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -656,17 +656,17 @@ function HORDE:GetDefaultItemsData()
         { Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "F2000", "arccw_horde_f2000", 3250, 7,
-        "FN F2000.\nAn ambidextrous bullpup rifle developed by FN. \nEquipped with an M203 underbarrel incendiary grenade launcher.\nPress USE+RELOAD to equip M203.",
+        "FN F2000.\nAn ambidextrous bullpup rifle developed by FN.",
         { Assault = true, SpecOps = true, Reverend = true, Cremator = true },
-        10, 10, nil, nil, { Assault = 2, Cremator = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_FIRE } )
+        10, 10, nil, nil, { Assault = 2, Cremator = 2 }, nil, { HORDE.DMG_FIRE } )
     HORDE:CreateItem( "Rifle", "Tavor", "arccw_horde_tavor", 3250, 7,
-        "IWI Tavor-21.\nDesigned to maximize reliability, durability, and simplicity. \nEquipped with an M203 underbarrel shock grenade launcher.\nPress USE+RELOAD to equip M203.",
+        "IWI Tavor-21.\nDesigned to maximize reliability, durability, and simplicity.",
         { Assault = true, SpecOps = true, Reverend = true, Warden = true },
-        10, 10, nil, nil, { Assault = 2, Warden = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING } )
+        10, 10, nil, nil, { Assault = 2, Warden = 2 }, nil, { HORDE.DMG_LIGHTNING } )
     HORDE:CreateItem( "Rifle", "SCAR-L", "arccw_horde_scarl", 3500, 8,
-        "FN SCAR-L.\nAn assault rifle developed by Belgian manufacturer FN Herstal.\nLight version, chambered in 5.56x45mm NATO. \nEquipped with an M203 underbarrel cryo grenade launcher.\nPress USE+RELOAD to equip M203.",
+        "FN SCAR-L.\nAn assault rifle developed by Belgian manufacturer FN Herstal.\nLight version, chambered in 5.56x45mm NATO.",
         { Assault = true, SpecOps = true, Reverend = true, Ghost = true, Gunslinger = true },
-        15, 10, nil, nil, { Assault = 2, Ghost = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_COLD } )
+        15, 10, nil, nil, { Assault = 2, Ghost = 2 }, nil, { HORDE.DMG_COLD } )
     HORDE:CreateItem( "Rifle", "OSIPR", "arccw_horde_ar2", 3500, 9, "Overwatch Standard Issue Pulse Rifle.\n\nPress ZOOM or B to change firemode.\nFires regular ballistic ammo or energy balls that deal Lightning damage and builds up Shock.",
         { Assault = true, SpecOps = true, Reverend = true, Warden = true },
         15, -1, nil, "items/hl2/weapon_ar2.png", { Assault = 5 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_LIGHTNING } )
@@ -741,7 +741,7 @@ function HORDE:GetDefaultItemsData()
     HORDE:CreateItem( "Rifle", "M16 M203", "arccw_horde_m16m203", 2250, 7,
         "M16A4 equipped with an M203 underbarrel grenade launcher.\nPress USE+RELOAD to equip M203.",
         { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Demolition = true },
-        10, 10, nil, nil, { Assault = 2, Demolition = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST } )
+        10, 10, nil, nil, { Assault = 2, Demolition = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST, HORDE.DMG_FIRE, HORDE.DMG_COLD, HORDE.DMG_LIGHTNING } )
 
     HORDE:CreateItem( "MG", "AUG HBAR", "arccw_horde_aug_hbar", 2000, 9,
         "Steyr AUG HBAR.\nA light-support machine gun variant of the AUG assault rifle.",

--- a/gamemodes/horde/gamemode/spells/dark_orb.lua
+++ b/gamemodes/horde/gamemode/spells/dark_orb.lua
@@ -20,7 +20,7 @@ SPELL.Fire           = function ( ply, wpn, charge_stage )
 
         local level = ply:Horde_GetSpellUpgrade( "dark_orb" )
         ent:SetSpellLevel( level )
-        ent:SetSpellBaseDamages( { math.floor( 25 + math.pow( level, 1.1 ) * 5.5 ), math.floor( 10 + math.pow( level, 1.1 ) * 7 ) } )
+        ent:SetSpellBaseDamages( { math.floor( 25 + ( level ^ 1.1 ) * 5.5 ), math.floor( 10 + ( level ^ 1.1 ) * 7 ) } )
         ent:SetPos( pos )
         ent:SetAngles( angles )
         hook.Run( "Horde_OnDraconicCheck", ply, ent )
@@ -30,7 +30,7 @@ SPELL.Fire           = function ( ply, wpn, charge_stage )
         if ( not IsValid( phys ) ) then ent:Remove() return end
         local velocity = dir
         velocity:Normalize()
-        velocity = velocity * 750
+        velocity = velocity * 2000
         if charge_stage == 4 then
             velocity = velocity * 1.25
         end

--- a/gamemodes/horde/gamemode/spells/dark_orb.lua
+++ b/gamemodes/horde/gamemode/spells/dark_orb.lua
@@ -71,4 +71,4 @@ SPELL.Upgrade_Description        = "Increases damage."
 SPELL.Upgrade_Prices             = function ( upgrade_level )
     return 550 + 50 * upgrade_level
 end
-SPELL.Levels          = { Artificer = 5 }
+SPELL.Levels          = { Artificer = 3 }

--- a/gamemodes/horde/gamemode/spells/solar_orb.lua
+++ b/gamemodes/horde/gamemode/spells/solar_orb.lua
@@ -17,7 +17,7 @@ SPELL.Fire           = function (ply, wpn, charge_stage)
         ent:SetCharged(charge_stage - 1)
         local level = ply:Horde_GetSpellUpgrade("solar_orb")
         ent:SetSpellLevel(level)
-        ent:SetSpellBaseDamages({math.floor(25 + math.pow(level, 1.1) * 5.5), math.floor(10 + math.pow(level, 1.1) * 7)})
+        ent:SetSpellBaseDamages({math.floor(25 + (level ^ 1.1) * 5.5), math.floor(10 + (level ^ 1.1) * 7)})
         ent:SetPos( pos )
         ent:SetAngles( angles )
         hook.Run("Horde_OnDraconicCheck", ply, ent)
@@ -27,7 +27,7 @@ SPELL.Fire           = function (ply, wpn, charge_stage)
         if (!IsValid( phys )) then ent:Remove() return end
         local velocity = dir
         velocity:Normalize()
-        velocity = velocity * 1000
+        velocity = velocity * 2000
         if charge_stage == 4 then
             velocity = velocity * 1.25
         end


### PR DESCRIPTION
**Artificer** 
- Buffed the duration of Floating Chaos
- Reduced the requirement for Dark Orb
- Increased the velocity of Dark & Solar orb to make the trajectory more favorable in longer hallways

**Cremator**
- Reduced the timing between Molotov regen to be in line with Demo's grenades
- Buffed the range on the gluon gun, to have roughly the same range as the heat crossbow and heat blaster

**Misc.**
- Updated some weapon description to remove mentions of their grenade launcher and added the proper damage types