### PR TITLE
Necromancer, Healing Beam changes & Flash reduction

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_shadow_hulk/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_shadow_hulk/init.lua
@@ -54,6 +54,16 @@ ENT.EntitiesToNoCollide = {
 	"npc_manhack"
 }
 
+ENT.Horde_Immune_Status = {
+	[HORDE.Status_Bleeding] = true,
+	[HORDE.Status_Frostbite] = true,
+	[HORDE.Status_Ignite] = false,
+	[HORDE.Status_Break] = true,
+	[HORDE.Status_Necrosis] = true,
+	[HORDE.Status_Hemorrhage] = true,
+}
+ENT.Immune_AcidPoisonRadiation = true
+
 ENT.GeneralSoundPitch1 = 75
 ENT.GeneralSoundPitch2 = 75
 ENT.HasAllies = true

--- a/gamemodes/horde/entities/entities/npc_vj_horde_spectre/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_spectre/init.lua
@@ -75,6 +75,16 @@ ENT.EntitiesToNoCollide = {
 	"npc_manhack"
 }
 
+ENT.Horde_Immune_Status = {
+	[HORDE.Status_Bleeding] = true,
+	[HORDE.Status_Frostbite] = true,
+	[HORDE.Status_Ignite] = false,
+	[HORDE.Status_Break] = true,
+	[HORDE.Status_Necrosis] = true,
+	[HORDE.Status_Hemorrhage] = true,
+}
+ENT.Immune_AcidPoisonRadiation = true
+
 ENT.HasWorldShakeOnMove = false -- Should the world shake when it's moving?
 ENT.WorldShakeOnMoveAmplitude = 5 -- How much the screen will shake | From 1 to 16, 1 = really low 16 = really high
 ENT.WorldShakeOnMoveRadius = 200 -- How far the screen shake goes, in world units

--- a/gamemodes/horde/gamemode/gadgets/gadget_healing_beam.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_healing_beam.lua
@@ -107,7 +107,7 @@ GADGET.Hooks.Horde_OnSetGadget = function (ply, gadget)
             local healinfo = HealInfo:New({amount=1, healer=ply})
             HORDE:OnPlayerHeal(ply, healinfo)
         else
-            local healinfo = HealInfo:New({amount=2, healer=ply})
+            local healinfo = HealInfo:New({amount=3, healer=ply})
             if ply.Horde_Healing_Target:GetClass() == "npc_vj_horde_antlion" then
                 HORDE:OnAntlionHeal(ply.Horde_Healing_Target, healinfo)
             else

--- a/gamemodes/horde/gamemode/perks/necromancer/necromancer_eldritch_protection.lua
+++ b/gamemodes/horde/gamemode/perks/necromancer/necromancer_eldritch_protection.lua
@@ -60,10 +60,10 @@ PERK.Hooks.Horde_OnPlayerDamageTaken = function(ply, dmginfo, bonus)
         dmg:SetAttacker(ply)
         dmg:SetInflictor(ply)
         dmg:SetDamageType(DMG_REMOVENORAGDOLL)
-        dmg:SetDamage(math.min(dmginfo:GetDamage() * 2, 300))
-        util.BlastDamageInfo(dmg, ply:GetPos(), 200)
+        dmg:SetDamage(math.min(dmginfo:GetDamage() * 4, 300))
+        util.BlastDamageInfo(dmg, ply:GetPos(), 300)
 
-        ply:Horde_SetMind( math.min( ply:Horde_GetMaxMind(), math.min( 15, dmginfo:GetDamage() / 5 ) + ply:Horde_GetMind() ) )
+        ply:Horde_SetMind( math.min( ply:Horde_GetMaxMind(), math.floor( dmginfo:GetDamage() ) + ply:Horde_GetMind() ) )
 
         local effectdata = EffectData()
         effectdata:SetOrigin(ply:GetPos())

--- a/gamemodes/horde/gamemode/perks/necromancer/necromancer_eldritch_protection.lua
+++ b/gamemodes/horde/gamemode/perks/necromancer/necromancer_eldritch_protection.lua
@@ -47,6 +47,7 @@ PERK.Hooks.Horde_OnPlayerDamageTaken = function(ply, dmginfo, bonus)
     if not ply:Horde_GetPerk("necromancer_eldritch_protection") then return end
     local attacker = dmginfo:GetAttacker()
     if HORDE:IsPlayerOrMinion(attacker) or dmginfo:GetDamage() <= 0 or not ply:Alive() then return end
+
     if (not ply.Horde_Eldritch_Shield_Cooldown) or (ply.Horde_Eldritch_Shield_Cooldown <= CurTime()) then
         ply:EmitSound("physics/glass/glass_cup_break2.wav")
         bonus.resistance = bonus.resistance + 0.4
@@ -59,8 +60,10 @@ PERK.Hooks.Horde_OnPlayerDamageTaken = function(ply, dmginfo, bonus)
         dmg:SetAttacker(ply)
         dmg:SetInflictor(ply)
         dmg:SetDamageType(DMG_REMOVENORAGDOLL)
-        dmg:SetDamage(150)
+        dmg:SetDamage(math.min(dmginfo:GetDamage() * 2, 300))
         util.BlastDamageInfo(dmg, ply:GetPos(), 200)
+
+        ply:Horde_SetMind( math.min( ply:Horde_GetMaxMind(), math.min( 15, dmginfo:GetDamage() / 5 ) + ply:Horde_GetMind() ) )
 
         local effectdata = EffectData()
         effectdata:SetOrigin(ply:GetPos())

--- a/gamemodes/horde/gamemode/perks/psycho/psycho_base.lua
+++ b/gamemodes/horde/gamemode/perks/psycho/psycho_base.lua
@@ -57,7 +57,7 @@ PERK.Hooks.PlayerSwitchFlashlight = function (ply, switchOn)
         net.Send(ply)
         ply.Horde_In_Frenzy_Mode = true
         ply.Horde_HealthDegenCurTime = CurTime()
-        ply:ScreenFade(SCREENFADE.STAYOUT, Color(200, 112, 121, 50), 0.2, 5)
+        ply:ScreenFade(SCREENFADE.STAYOUT, Color(200, 112, 121, 20), 0.2, 5)
     else
         -- Disable Frenzy mode
         net.Start("Horde_SyncStatus")

--- a/gamemodes/horde/gamemode/sv_heal.lua
+++ b/gamemodes/horde/gamemode/sv_heal.lua
@@ -99,7 +99,7 @@ function HORDE:OnPlayerHeal(ply, healinfo, silent)
         return
     end
 	if ply:GetInfoNum("horde_heal_flash", 1) == 1 then
-	    ply:ScreenFade(SCREENFADE.IN, Color(50, 200, 50, 10), 0.3, 0)
+	    ply:ScreenFade(SCREENFADE.IN, Color(50, 200, 50, 5), 0.15, 0)
 	end
 end
 


### PR DESCRIPTION
Necromancer
- Gave minions status immunity to everything except fire
- changed the damage calculation for eldritch protection
- added mind regen on taking damage while eldritch protection is up

Psycho
- Reduced intensity of frenzy screen effect

Healing beam gadget
- Slight increase in heals per tick, from 2 to 3

Healing in general
- Reduced the intensity of flashing caused by being healed 