### PR TITLE
UBGL Rifle Changes & Extra Weapon Selection

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_f2000.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_f2000.lua
@@ -17,93 +17,31 @@ SWEP.WorldModel = "models/weapons/w_rif_famas.mdl"
 
 SWEP.Damage = 67
 SWEP.DamageMin = 57
+SWEP.DamageType = DMG_BURN
 
 SWEP.Recoil = 0.42
 SWEP.RecoilSide = 0.35
 
-SWEP.ShootVol = 75
+SWEP.ShootSound = "ArcCW_Horde.MW2.F2000_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.MW2.F2000_Mech"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.MW2.F2000_Fire_Sil"
 
-SWEP.ShootSound = ")weapons/fesiugmw2/fire/f2000.wav"
-SWEP.ShootMechSound = {
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
-}
-SWEP.ShootSoundSilenced = ")weapons/fesiugmw2/fire/m4_sil.wav"
-
-SWEP.AttachmentElements = {
-    ["wepcamo-desert"]      = { VMSkin = 1 },
-    ["wepcamo-arctic"]      = { VMSkin = 2 },
-    ["wepcamo-woodland"]    = { VMSkin = 3 },
-    ["wepcamo-digital"]     = { VMSkin = 4 },
-    ["wepcamo-urban"]       = { VMSkin = 5 },
-    ["wepcamo-bluetiger"]   = { VMSkin = 6 },
-    ["wepcamo-redtiger"]    = { VMSkin = 7 },
-    ["wepcamo-fall"]        = { VMSkin = 8 },
-    ["wepcamo-whiteout"]    = { VMSkin = 9 },
-    ["wepcamo-blackout"]        = { VMSkin = 10 },
-    ["wepcamo-bushdweller"]     = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"]    = { VMSkin = 12 },
-    ["nors"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-        WMBodygroups = {},
-    },
-    ["nocover"] = {
-        VMBodygroups = {{ind = 2, bg = 3}},
-        WMBodygroups = {},
-    },
-    ["horde_ubgl_incendiary"] = {
-        VMBodygroups = {{ind = 2, bg = 1}},
-    },
-}
+SWEP.RejectAttachments = {["mw2_ubgl_masterkey"] = true, ["mw2_ubgl_m203"] = true}
 
 SWEP.Attachments = {
     {
-        PrintName = "Optic",
-        DefaultAttName = "Iron Sights",
-        Slot = { "optic" },
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(5.8, -0.025, 3.2),
             vang = Angle(0, 0, 0),
         },
-        InstalledEles = {"nors"},
     },
     {
-        PrintName = "Muzzle",
-        DefaultAttName = "Standard Muzzle",
-        Slot = "muzzle",
-        Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(16, 0, 1.55),
+            vpos = Vector(15, 0, 1.55),
             vang = Angle(0, 0, 0),
         },
-        VMScale = Vector(1.15, 1.15, 1.15),
-    },
+    },{},
     {
-        PrintName = "Underbarrel",
-        Slot = {"foregrip", "horde_ubgl_incendiary", "", ""},
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(10, 0, -1.04),
-            vang = Angle(0, 0, 0),
-        },
-        SlideAmount = {
-            vmin = Vector(8, 0, 0),
-            vmax = Vector(11, 0, 0.8),
-        },
-        InstalledEles = {"nocover"},
-        Installed = "horde_ubgl_incendiary",
-    },
-    {
-        PrintName = "Tactical",
-        Slot = "tac",
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(5, -1.235, 1.25),
             vang = Angle(0, 0, 90),
@@ -112,31 +50,14 @@ SWEP.Attachments = {
             vmin = Vector(6.5, -1.235, 1.25),
             vmax = Vector(4, -1.235, 1.25),
         },
-    },
+    },{},
     {
-        PrintName = "Fire Group",
-        Slot = "fcg",
-        DefaultAttName = "Standard FCG"
-    },
-    {
-        PrintName = "Ammo Type",
         Slot = "go_ammo"
     },
     {
-        PrintName = "Perk",
         Slot = "go_perk"
-    },
+    },{},
     {
-        PrintName = "Camouflage",
-        DefaultAttName = "None",
-        Slot = "mw2_wepcamo",
-        FreeSlot = true,
-    },
-    {
-        PrintName = "Charm",
-        Slot = "charm",
-        FreeSlot = true,
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(-1.5, -0.85, 0.8),
             vang = Angle(0, 0, 0),
@@ -144,139 +65,36 @@ SWEP.Attachments = {
     },
 }
 
-SWEP.Hook_TranslateAnimation = function(wep, anim)
-    local attached = wep.Attachments[3].Installed
-    local attthing
-        if attached == "horde_ubgl_incendiary" then attthing = 1
-        elseif attached then attthing = 3
-        else attthing = 0
-    end
-    if anim == "enter_ubgl" then
-        if attthing == 1 then
-            return "switch2_alt_m203"
-        end
-    elseif anim == "exit_ubgl" then
-        if attthing == 1 then
-            return "switch2_gun_m203"
-        end
-    end
-    if attthing == 1 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_m203"
-    elseif attthing == 3 then
-        return anim .. "_fgrip"
-    end
-end
-
-SWEP.Animations = {
-    ["draw"] = {
-        Source = "pullout",
-        Time = 33/30,
-        SoundTable = {{s = "weapons/fesiugmw2/wpnarm_2.wav", c = CHAN_ITEM, t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["ready"] = {
-        Source = "pullout_first",
-        Time = 35/30,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_first_lift_v1.wav", c = CHAN_ITEM, t = 0/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_first_chamber_v1.wav", c = CHAN_ITEM, t = 13/30},
-        },
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["reload"] = {
-        Source = "reload",
-        Time = 90/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipout_v1.wav", c = CHAN_ITEM, t = 16/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipin_v1.wav", c = CHAN_ITEM, t = 60/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        Time = 103/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipout_v1.wav", c = CHAN_ITEM, t = 15/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_clipin_v1.wav", c = CHAN_ITEM, t = 61/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_fn2000_reload_chamber_v1.wav", c = CHAN_ITEM, t = 76/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 79/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", c = CHAN_ITEM, t = 12/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", c = CHAN_ITEM, t = 39/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", c = CHAN_ITEM, t = 60/30},
-        },
-    },
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-}
-function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride)
-    local fsound = self.ShootSound
-    local msound = self.ShootMechSound
-    local suppressed = self:GetBuff_Override("Silencer")
-
-    fsound = self:GetBuff_Hook("Hook_GetShootSound", fsound)
-
-    local spv    = self.ShootPitchVariation
-    local volume = self.ShootVol
-    local pitch  = self.ShootPitch * math.Rand(1 - spv, 1 + spv) * self:GetBuff_Mult("Mult_ShootPitch")
-
-    local v = GetConVar("arccw_weakensounds"):GetFloat()
-    volume = volume - v
-
-    volume = volume * self:GetBuff_Mult("Mult_ShootVol")
-
-    volume = math.Clamp(volume, 50, 140)
-    pitch  = math.Clamp(pitch, 0, 255)
-
-    if sndoverride then fsound = sndoverride end
-    if voloverride then volume = voloverride end
-    if pitchoverride then pitch = pitchoverride end
-
-    if suppressed then
-        fsound = self.ShootSoundSilenced
-        pitch = 100
-        msound = nil
-    end
-
-    if fsound then self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON) end
-    if msound then self:MyEmitSound(msound, 45, math.Rand(95, 105), .45, CHAN_AUTO) end
-
-    local data = {
-        sound   = fsound,
-        volume  = volume,
-        pitch   = pitch,
+sound.Add( {
+    name = "ArcCW_Horde.MW2.F2000_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/f2000.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.F2000_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {90, 105},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
     }
-
-    self:GetBuff_Hook("Hook_AddShootSound", data)
-end
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.F2000_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/m4_sil.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
@@ -3,241 +3,60 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_mw2_m4")
     killicon.Add("arccw_horde_m16m203", "arccw/weaponicons/arccw_mw2_m4", Color(0, 0, 0, 255))
 end
-SWEP.Base = "arccw_mw2_abase"
+
+SWEP.Base = "arccw_mw2_m16"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
---SWEP.CamAttachment = 3
 
 SWEP.PrintName = "M16A4"
-SWEP.Trivia_Class = "Assault Rifle"
-SWEP.Trivia_Desc = "3 round burst."
-
-SWEP.Slot = 2
-
-SWEP.UseHands = true
 
 SWEP.ViewModel = "models/weapons/arccw/fesiugmw2_2/c_m16.mdl"
-SWEP.MirrorVMWM = true
-SWEP.WorldModelOffset = {
-    pos = Vector(-5, 3, -5),
-    ang = Angle(-10, 0, 180),
-    scale = 1.25
-}
 SWEP.WorldModel = "models/weapons/w_rif_m4a1.mdl"
-SWEP.ViewModelFOV = 65
 
 SWEP.Damage = 47
-SWEP.DamageMin = 36
-SWEP.RangeMin = 1500 * 0.025  -- GAME UNITS * 0.025 = METRES
-SWEP.Range = 2000 * 0.025  -- GAME UNITS * 0.025 = METRES
-SWEP.Penetration = 7
-SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
+SWEP.DamageMin = 39
 
-
-SWEP.ChamberSize = 0
-SWEP.Primary.ClipSize = 30 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 45
-SWEP.ReducedClipSize = 15
-
-SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 0.5
-SWEP.RecoilSide = 0.4
-SWEP.RecoilRise = 0.1
-
-SWEP.Delay = 0.064 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
-SWEP.Firemodes = {
-    {
-        Mode = -3,
-		RunawayBurst = true,
-        PostBurstDelay = 0.2,
-    },
-    {
-        Mode = 1,
-    },
-    {
-        Mode = 0
-    }
-}
-
-SWEP.NPCWeaponType = {"weapon_ar2", "weapon_smg1"}
-SWEP.NPCWeight = 100
-
-SWEP.AccuracyMOA = 2.5 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 500 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 150
-
-SWEP.Primary.Ammo = "smg1" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =			"weapons/fesiugmw2/fire/m4.wav"
-SWEP.ShootMechSound =       ArcCW_MW2_Mech
---SWEP.DistantShootSound =	"weapons/fesiugmw2/fire_distant/m4_mp.wav"
-SWEP.ShootSoundSilenced =	"weapons/fesiugmw2/fire/m4_sil.wav"
-
-SWEP.MuzzleEffect = "muzzleflash_4"
-SWEP.ShellModel = "models/shells/shell_556.mdl"
-SWEP.ShellPitch = 95
-SWEP.ShellScale = 1
-
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-
-SWEP.SpeedMult = 0.95
-SWEP.SightedSpeedMult = 0.38
-SWEP.SightTime = 0.25
-SWEP.ShellRotateAngle = Angle(0, 90, 0)
-
-SWEP.BulletBones = { -- the bone that represents bullets in gun/mag
-    -- [0] = "bulletchamber",
-    -- [1] = "bullet1"
-}
-
-SWEP.IronSightStruct = {
-    Pos = Vector(-2.595, -3.512, -0.1), --
-    Ang = Angle(0.8, 0, 0),
-    ViewModelFOV = 65 / 1.3,
-    Magnification = 1.3,
-}
-
-SWEP.HoldtypeHolstered = "passive"
-SWEP.HoldtypeActive = "ar2"
-SWEP.HoldtypeSights = "rpg"
-
-SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2
-
-SWEP.ActivePos = Vector(0, 0, 1)
-SWEP.ActiveAng = Angle(0, 0, 0)
-
-SWEP.CustomizePos = Vector(10.479, 0, -1.321)
-SWEP.CustomizeAng = Angle(18.2, 39.4, 14.8)
-
-SWEP.HolsterPos = Vector(1, 0, 1)
-SWEP.HolsterAng = Angle(-10, 12, 0)
-
-SWEP.SprintPos = Vector(0, 0, 1)
-SWEP.SprintAng = Angle(0, 0, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.BarrelLength = 27
+SWEP.ShootSound = "ArcCW_Horde.MW2.M16_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.MW2.M16_Mech"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.MW2.M16_Fire_Sil"
 
 SWEP.AttachmentElements = {
-    ["nors"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-        WMBodygroups = {},
+    ["horde_ubgl_cryo"] = {
+        VMBodygroups = {{ind = 2, bg = 1}},
     },
-    ["grip"] = {
-        VMBodygroups = {{ind = 2, bg = 3}},
+    ["horde_ubgl_incendiary"] = {
+        VMBodygroups = {{ind = 2, bg = 1}},
     },
-    ["wepcamo-desert"]		= { VMSkin = 1 },
-    ["wepcamo-arctic"]		= { VMSkin = 2 },
-    ["wepcamo-woodland"]	= { VMSkin = 3 },
-    ["wepcamo-digital"]		= { VMSkin = 4 },
-    ["wepcamo-urban"]		= { VMSkin = 5 },
-    ["wepcamo-bluetiger"]	= { VMSkin = 6 },
-    ["wepcamo-redtiger"]	= { VMSkin = 7 },
-    ["wepcamo-fall"]		= { VMSkin = 8 },
-    ["wepcamo-whiteout"]	= { VMSkin = 9 },
-    ["wepcamo-blackout"]        = { VMSkin = 10 },
-    ["wepcamo-bushdweller"]     = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"]    = { VMSkin = 12 },
-            ["horde_ubgl_m203"] = {
-                VMBodygroups = {{ind = 2, bg = 1}},
-            },
-            ["mw2_ubgl_masterkey"] = {
-                VMBodygroups = {{ind = 2, bg = 2}},
-            },
+    ["horde_ubgl_m203"] = {
+        VMBodygroups = {{ind = 2, bg = 1}},
+    },
+    ["horde_ubgl_shock"] = {
+        VMBodygroups = {{ind = 2, bg = 1}},
+    },
 }
 
-SWEP.ExtraSightDist = 5
+SWEP.RejectAttachments = {["mw2_ubgl_masterkey"] = true, ["mw2_ubgl_m203"] = true}
 
 SWEP.Attachments = {
+    {},{},
     {
-        PrintName = "Optic",
-        DefaultAttName = "Iron Sights",
-        Slot = "optic",
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(6.972, 0, 4.018),
-            vang = Angle(0, 0, 0),
-            wang = Angle(-9.738, 0, 180)
-        },
-        SlideAmount = {
-            vmin = Vector(0.5, 0, 2.95),
-            vmax = Vector(4, 0, 2.95),
-            wmin = Vector(5.36, 0.739, -5.401),
-            wmax = Vector(5.36, 0.739, -5.401),
-        },
-        InstalledEles = {"nors"},
+        Slot = {"foregrip", "horde_ubgl_cryo", "horde_ubgl_incendiary", "horde_ubgl_m203", "horde_ubgl_shock"},
     },
     {
-        PrintName = "Muzzle",
-        DefaultAttName = "Standard Muzzle",
-        Slot = "muzzle",
-        Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(21.7, 0, 2),
-            vang = Angle(0, 0, 0),
-            wpos = Vector(33.719, -2.122, -5.573),
-            wang = Angle(0, 6.034, 180)
-        },
-		WMScale = Vector(1, 1, 1),
-    },
-    {
-        PrintName = "Underbarrel",
-        Slot = {"foregrip", "bipod",--[[] "foregrip_mw2exclusive",]] "horde_ubgl_m203"},
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(18.427, 0, -1.04),
-            vang = Angle(0, 0, 0),
-            wpos = Vector(14.329, 0.602, -4.453),
-            wang = Angle(-2.461, -6.525, 176.662)
-        },
-        SlideAmount = {
-            vmin = Vector(6.748, 0, 1.04),
-            vmax = Vector(12.427, 0, 1.04),
-            wmin = Vector(20.996, -0.991, -3.837),
-            wmax = Vector(13.661, -0.078, -3.837),
-        },
-        Installed = "horde_ubgl_m203",
-    },
-    {
-        PrintName = "Tactical",
-        Slot = "tac",
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(12.5, -1, 2.25),
+            vpos = Vector(12.5, -1.15, 1.95),
             vang = Angle(0, 0, 90),
-            wpos = Vector(15.625, -0.253, -6.298),
-            wang = Angle(-8.829, -0.556, 90)
         },
-    },
+    },{},
     {
-        PrintName = "Fire Group",
-        Slot = "fcg",
-        DefaultAttName = "Standard FCG"
-    },
-    {
-        PrintName = "Ammo Type",
         Slot = "go_ammo"
     },
     {
-        PrintName = "Perk",
         Slot = "go_perk"
-    },
+    },{},
     {
-        PrintName = "Camouflage",
-        DefaultAttName = "None",
-        Slot = "mw2_wepcamo",
-        FreeSlot = true,
-    },
-	{
         PrintName = "Charm",
         Slot = "charm",
         FreeSlot = true,
@@ -251,390 +70,58 @@ SWEP.Attachments = {
     },
 }
 
-
-
 SWEP.Hook_TranslateAnimation = function(wep, anim)
-	local attached = wep.Attachments[3].Installed
-
-	-- m203 is 1, masterkey is 2, fgrip is 3
-	local attthing
-		if 		attached == "horde_ubgl_m203" 		then attthing = 1
-		elseif 	attached == "mw2_ubgl_masterkey" 	then attthing = 2
-		else 											 attthing = 0
-	end
-
-	-- when entering ubgl
-	if anim == "enter_ubgl" then
-		if attthing == 1 then
-			return "switch2_alt_m203"
-		elseif attthing == 2 then
-			return "switch2_alt_masterkey"
-		end
-	elseif anim == "exit_ubgl" then
-		if attthing == 1 then
-			return "switch2_gun_m203"
-		elseif attthing == 2 then
-			return "switch2_gun_masterkey"
-		end
-	end
-
+    local attached = wep.Attachments[3].Installed
+    local attthing
+        if attached == "horde_ubgl_cryo" or attached == "horde_ubgl_incendiary" or attached == "horde_ubgl_m203" or attached == "horde_ubgl_shock" then attthing = 1
+        else attthing = 0
+    end
+    if anim == "enter_ubgl" then
+        if attthing == 1 then
+            return "switch2_alt_m203"
+        end
+    elseif anim == "exit_ubgl" then
+        if attthing == 1 then
+            return "switch2_gun_m203"
+        end
+    end
     if attthing == 1 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_m203"
-		elseif attthing == 1 then
-			return anim .. "_m203"
-
-	elseif attthing == 2 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_masterkey"
-		elseif attthing == 2 then
-			return anim .. "_masterkey"
-
+    return "alt_" .. anim .. "_m203"
+    elseif attthing == 1 then
+        return anim .. "_m203"
     end
 end
 
-SWEP.Animations = {
-		["enter_ubgl"] = {
-			Source = "idle",
-			Time = 1/60
-		},
-		["exit_ubgl"] = {
-			Source = "idle",
-			Time = 1/60
-		}, 						-- Fuck you.
-    ["idle"] = {
-        Source = "idle",
-        Time = 0--100/30
-    },
-    ["enter_sprint"] = {
-        Source = "sprint_in",
-        Time = 10/30
-    },
-    ["idle_sprint"] = {
-        Source = "sprint_loop",
-        Time = 30/40
-    },
-    ["exit_sprint"] = {
-        Source = "sprint_out",
-        Time = 10/30
-    },
-    ["draw"] = {
-        Source = "pullout",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster"] = {
-        Source = "putaway",
-        Time = 20/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire"] = {
-        Source = "fire",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron"] = {
-        Source = "fire_ads",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["reload"] = {
-        Source = "reload",
-        Time = 61/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        Time = 70/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_chamber_v10.wav",		t = 52/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies M203 ANIMATIONS ... AWESOME ---
-------------------------------------------------
-    ["idle_m203"] = {
-        Source = "idle_m203",
-        Time = 0--100/30
-    },
-    ["enter_sprint_m203"] = {
-        Source = "sprint_in_m203",
-        Time = 10/30
-    },
-    ["idle_sprint_m203"] = {
-        Source = "sprint_loop_m203",
-        Time = 30/40
-    },
-    ["exit_sprint_m203"] = {
-        Source = "sprint_out_m203",
-        Time = 10/30
-    },
-    ["draw_m203"] = {
-        Source = "pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster_m203"] = {
-        Source = "putaway_m203",
-        Time = 20/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire_m203"] = {
-        Source = "fire_m203",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron_m203"] = {
-        Source = "fire_ads_m203",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["reload_m203"] = {
-        Source = "reload_m203",
-        Time = 61/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty_m203"] = {
-        Source = "reload_empty_m203",
-        Time = 70/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_chamber_v10.wav",		t = 52/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies M203 IN THE ANIMATIONS........... ... AWESOME ---
-------------------------------------------------
-    ["alt_idle_m203"] = {
-        Source = "alt_idle_m203",
-        Time = 0--100/30
-    },
-    ["alt_enter_sprint_m203"] = {
-        Source = "alt_sprint_in_m203",
-        Time = 10/30
-    },
-    ["alt_idle_sprint_m203"] = {
-        Source = "alt_sprint_loop_m203",
-        Time = 30/40
-    },
-    ["alt_exit_sprint_m203"] = {
-        Source = "alt_sprint_out_m203",
-        Time = 10/30
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["alt_holster_m203"] = {
-        Source = "alt_putaway_m203",
-        Time = 20/30,
-    },
-    ["alt_fire_m203"] = {
-        Source = "alt_fire_m203",
-        Time = 10/30,
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 78/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", 		t = 12/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", 	t = 39/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", 	t = 60/30},
-					},
-    },
-------------------------------------------------
------- Here lies MASTERKEY ANIMATIONS ... AWESOME ---
-------------------------------------------------
-    ["idle_masterkey"] = {
-        Source = "idle_masterkey",
-        Time = 0--100/30
-    },
-    ["enter_sprint_masterkey"] = {
-        Source = "sprint_in_masterkey",
-        Time = 10/30
-    },
-    ["idle_sprint_masterkey"] = {
-        Source = "sprint_loop_masterkey",
-        Time = 30/40
-    },
-    ["exit_sprint_masterkey"] = {
-        Source = "sprint_out_masterkey",
-        Time = 10/30
-    },
-    ["draw_masterkey"] = {
-        Source = "pullout_masterkey",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["holster_masterkey"] = {
-        Source = "putaway_masterkey",
-        Time = 20/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire_masterkey"] = {
-        Source = "fire_masterkey",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron_masterkey"] = {
-        Source = "fire_ads_masterkey",
-        Time = 5/30,
-        ShellEjectAt = 0,
-    },
-    ["reload_masterkey"] = {
-        Source = "reload_masterkey",
-        Time = 61/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty_masterkey"] = {
-        Source = "reload_empty_masterkey",
-        Time = 70/30,
-        MinProgress = 1.1,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_lift_v10.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipout_v10.wav", 	t = 11/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_clipin_v10.wav", 	    t = 37/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m4reload_chamber_v10.wav",		t = 52/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies MASTERKEY IN THE ANIMATIONS........... ... AWESOME ---
-------------------------------------------------
-    ["alt_idle_masterkey"] = {
-        Source = "alt_idle_masterkey",
-        Time = 0--100/30
-    },
-    ["alt_enter_sprint_masterkey"] = {
-        Source = "alt_sprint_in_masterkey",
-        Time = 10/30
-    },
-    ["alt_idle_sprint_masterkey"] = {
-        Source = "alt_sprint_loop_masterkey",
-        Time = 30/40
-    },
-    ["alt_exit_sprint_masterkey"] = {
-        Source = "alt_sprint_out_masterkey",
-        Time = 10/30
-    },
-    ["alt_draw_masterkey"] = {
-        Source = "alt_pullout_masterkey",
-        Time = 25/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["alt_holster_masterkey"] = {
-        Source = "alt_putaway_masterkey",
-        Time = 20/30,
-    },
-    ["alt_fire_masterkey"] = {
-        Source = "alt_fire_masterkey",
-        Time = 10/24,
-    },
-    ["alt_cycle_masterkey"] = {
-        Source = "alt_cycle_masterkey",
-        SoundTable = {{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 		t = 3/30}},
-        Time = 15/30,
-    },
-    ["alt_reload_start_masterkey"] = {
-        Source = "alt_reload_start_masterkey",
-        Time = 35/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_lift_v1.wav", 		t = 0/30},
-						{s = "MW2Common.Masterkey_Load", 		t = 35/30},
-					},
-    },
-    ["alt_reload_loop_masterkey"] = {
-        Source = "alt_reload_loop_masterkey",
-        Time = 33/40,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "MW2Common.Masterkey_Load", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_end_v1.wav", 	t = 33/30},
-					},
-    },
-    ["alt_reload_finish_masterkey"] = {
-        Source = "alt_reload_finish_masterkey",
-        Time = 50/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_end_v1.wav", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 	t = 22/30},
-					},
-    },
------------------------------------------------------
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 24/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 24/30
-    },
-    ["switch2_gun_masterkey"] = {
-        Source = "switch2_gun_masterkey",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 22/30
-    },
-    ["switch2_alt_masterkey"] = {
-        Source = "switch2_alt_masterkey",
-        SoundTable = {
-						{s = "MW2Common.Underbarrel", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 		t = 14/30},
-					},
-        Time = 25/30
-    },
-}
+sound.Add( {
+    name = "ArcCW_Horde.MW2.M16_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {80, 95},
+    sound = ")weapons/fesiugmw2/fire/m4.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.M16_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {90, 105},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
+    }
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.M16_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/m4_sil.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_scarl.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_scarl.lua
@@ -19,56 +19,14 @@ SWEP.WorldModel = "models/weapons/w_rif_galil.mdl"
 
 SWEP.Damage = 73
 SWEP.DamageMin = 62
+SWEP.DamageType = DMG_REMOVENORAGDOLL
 
-SWEP.ShootVol = 75
-
-SWEP.ShootSound = ")weapons/fesiugmw2/fire/scarl.wav"
-SWEP.ShootMechSound = {
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
-    ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
-}
-SWEP.ShootDrySound = "weapons/arccw/dryfire.wav"
-SWEP.ShootSoundSilenced = ")weapons/fesiugmw2/fire/scarl_sil.wav"
-
-SWEP.AttachmentElements = {
-    ["grip"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-    },
-    ["nors"] = {
-        VMBodygroups = {{ind = 2, bg = 1}},
-    },
-    ["nomuzzle"] = {
-        VMBodygroups = {{ind = 4, bg = 1}},
-    },
-    ["horde_ubgl_cryo"] = {
-        VMBodygroups = {{ind = 3, bg = 1}},
-    },
-    ["wepcamo-desert"] = { VMSkin = 1 },
-    ["wepcamo-arctic"] = { VMSkin = 2 },
-    ["wepcamo-woodland"] = { VMSkin = 3 },
-    ["wepcamo-digital"] = { VMSkin = 4 },
-    ["wepcamo-urban"] = { VMSkin = 5 },
-    ["wepcamo-bluetiger"] = { VMSkin = 6 },
-    ["wepcamo-redtiger"] = { VMSkin = 7 },
-    ["wepcamo-fall"] = { VMSkin = 8 },
-    ["wepcamo-whiteout"] = { VMSkin = 9 },
-    ["wepcamo-blackout"] = { VMSkin = 10 },
-    ["wepcamo-bushdweller"] = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"] = { VMSkin = 12 },
-}
+SWEP.ShootSound = "ArcCW_Horde.MW2.SCARLOS_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.MW2.SCARLOS_Mech"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.MW2.SCARLOS_Fire_Sil"
 
 SWEP.Attachments = {
     {
-        PrintName = "Optic",
-        DefaultAttName = "Iron Sights",
-        Slot = "optic",
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(6.972, 0, 2.9),
             vang = Angle(0, 0, 0),
@@ -77,23 +35,8 @@ SWEP.Attachments = {
             vmin = Vector(2, 0, 2.9),
             vmax = Vector(6, 0, 2.9),
         },
-        InstalledEles = {"nors"},
-    },
+    },{},
     {
-        PrintName = "Muzzle",
-        DefaultAttName = "Standard Muzzle",
-        Slot = "muzzle",
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(15, 0, 1.25),
-            vang = Angle(0, 0, 0),
-        },
-        InstalledEles = {"nomuzzle"},
-    },
-    {
-        PrintName = "Underbarrel",
-        Slot = {"foregrip", "horde_ubgl_cryo", "bipod"},
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(18.427, 0, -1.04),
             vang = Angle(0, 0, 0),
@@ -102,41 +45,20 @@ SWEP.Attachments = {
             vmin = Vector(8, 0, 0.4),
             vmax = Vector(11, 0, 0.4),
         },
-        Installed = "horde_ubgl_cryo",
     },
     {
-        PrintName = "Tactical",
-        Slot = "tac",
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(11.5, 0.75, 1.45),
             vang = Angle(0, 0, -90),
         },
-    },
+    },{},
     {
-        PrintName = "Fire Group",
-        Slot = "fcg",
-        DefaultAttName = "Standard FCG"
-    },
-    {
-        PrintName = "Ammo Type",
         Slot = "go_ammo"
     },
     {
-        PrintName = "Perk",
         Slot = "go_perk"
-    },
+    },{},
     {
-        PrintName = "Camouflage",
-        DefaultAttName = "None",
-        Slot = "mw2_wepcamo",
-        FreeSlot = true,
-    },
-    {
-        PrintName = "Charm",
-        Slot = "charm",
-        FreeSlot = true,
-        Bone = "tag_weapon",
         Offset = {
             vpos = Vector(4, -0.6, 0.75),
             vang = Angle(0, 0, 0),
@@ -144,182 +66,47 @@ SWEP.Attachments = {
     },
 }
 
-SWEP.Hook_TranslateAnimation = function(wep, anim)
-    local attached = wep.Attachments[3].Installed
-    local attthing
-        if attached == "horde_ubgl_cryo" then attthing = 1
-        else attthing = 0
-    end
-    if anim == "enter_ubgl" then
-        if attthing == 1 then
-            return "switch2_alt_m203"
+if SERVER then
+    SWEP.Hook_BulletHit = function(wep, data)
+        local att = data.att
+        local entHit = data.tr.Entity
+
+        if HORDE:IsEnemy(entHit) then
+            entHit:Horde_AddDebuffBuildup(HORDE.Status_Frostbite, 4, att)
         end
-    elseif anim == "exit_ubgl" then
-        if attthing == 1 then
-            return "switch2_gun_m203"
-        end
-    end
-    if attthing == 1 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_m203"
     end
 end
 
-SWEP.Animations = {
-    ["draw"] = {
-        Source = "pullout",
-        Time = 29/30,
-        SoundTable = {{s = "weapons/fesiugmw2/wpnarm_2.wav", c = CHAN_ITEM, t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["ready"] = {
-        Source = "pullout_first",
-        Time = 38/30,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_chamber_v1.wav", c = CHAN_ITEM, t = 13/30},
-        },
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["reload"] = {
-        Source = "reload",
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magout.wav", c = CHAN_ITEM, t = 10/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magin.wav", c = CHAN_ITEM, t = 40/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-        LHIKEaseOut = 0.3,
-    },
-    ["reload_empty"] = {
-        Source = "reload_empty",
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magout.wav", c = CHAN_ITEM, t = 10/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/magin.wav", c = CHAN_ITEM, t = 40/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/chamber.wav", c = CHAN_ITEM, t = 54/30},
-            {s = "weapons/fesiugmw2/unofficial/scarl/chamberforward.wav", c = CHAN_ITEM, t = 62/30},                     
-        },
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-        LHIKEaseOut = 0.3,
-    },
-    ["draw_m203"] = {
-        Source = "pullout_m203",
-        Time = 29/30,
-        SoundTable = {{s = "weapons/fesiugmw2/wpnarm_2.wav", c = CHAN_ITEM, t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["ready_m203"] = {
-        Source = "pullout_first_m203",
-        Time = 38/30,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_chamber_v1.wav", c = CHAN_ITEM, t = 13/30},
-        },
-        LHIK = true,
-        LHIKIn = 0,
-        LHIKOut = 0.25,
-    },
-    ["reload_m203"] = {
-        Source = "reload_m203",
-        Time = 76/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipout_v1.wav", c = CHAN_ITEM, t = 18/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipin_v1.wav", c = CHAN_ITEM, t = 48/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0.7,
-    },
-    ["reload_empty_m203"] = {
-        Source = "reload_empty_m203",
-        Time = 102/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_lift_v1.wav", c = CHAN_ITEM, t = 0},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipout_v1.wav", c = CHAN_ITEM, t = 18/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_clipin_v1.wav", c = CHAN_ITEM, t = 48/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_scar_reload_hit_v1.wav", c = CHAN_ITEM, t = 69/30},
-        },
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0.7,
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 79/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", c = CHAN_ITEM, t = 12/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", c = CHAN_ITEM, t = 39/30},
-            {s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", c = CHAN_ITEM, t = 60/30},
-        },
-    },
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "weapons/fesiugmw2/pu_weapon01.wav", c = CHAN_ITEM, t = 0}},
-        Time = 25/30
-    },
-}
-
-function SWEP:DoShootSound(sndoverride, dsndoverride, voloverride, pitchoverride)
-    local fsound = self.ShootSound
-    local msound = self.ShootMechSound
-    local suppressed = self:GetBuff_Override("Silencer")
-
-    fsound = self:GetBuff_Hook("Hook_GetShootSound", fsound)
-
-    local spv    = self.ShootPitchVariation
-    local volume = self.ShootVol
-    local pitch  = self.ShootPitch * math.Rand(1 - spv, 1 + spv) * self:GetBuff_Mult("Mult_ShootPitch")
-
-    local v = GetConVar("arccw_weakensounds"):GetFloat()
-    volume = volume - v
-
-    volume = volume * self:GetBuff_Mult("Mult_ShootVol")
-
-    volume = math.Clamp(volume, 50, 140)
-    pitch  = math.Clamp(pitch, 0, 255)
-
-    if sndoverride then fsound = sndoverride end
-    if voloverride then volume = voloverride end
-    if pitchoverride then pitch = pitchoverride end
-
-    if suppressed then
-        fsound = self.ShootSoundSilenced
-        pitch = 100
-        msound = nil
-    end
-
-    if fsound then self:MyEmitSound(fsound, volume, pitch, 1, CHAN_WEAPON) end
-    if msound then self:MyEmitSound(msound, 45, math.Rand(95, 105), .45, CHAN_AUTO) end
-
-    local data = {
-        sound   = fsound,
-        volume  = volume,
-        pitch   = pitch,
+sound.Add( {
+    name = "ArcCW_Horde.MW2.SCARLOS_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/scarl.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.SCARLOS_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {90, 105},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
     }
-
-    self:GetBuff_Hook("Hook_AddShootSound", data)
-end
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.SCARLOS_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/scarl_sil.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_tavor.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_tavor.lua
@@ -3,584 +3,98 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_mw2_tavor")
     killicon.Add("arccw_horde_tavor", "arccw/weaponicons/arccw_mw2_tavor", Color(0, 0, 0, 255))
 end
-SWEP.Base = "arccw_mw2_abase"
+
+SWEP.Base = "arccw_mw2_tavor"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
-SWEP.WeaponCamBone = tag_camera
 
 SWEP.PrintName = "TAR-21"
-SWEP.Trivia_Class = "Assault Rifle"
-SWEP.Trivia_Desc = "Fully automatic, all purpose weapon."
-
-if CLIENT then
-SWEP.Trivia_Manufacturer = "Israel Weapon Industries"
-SWEP.Trivia_Calibre = "5.56x45mm NATO"
-SWEP.Trivia_Mechanism = "Gas-Operated"
-SWEP.Trivia_Country = "Israel"
-SWEP.Trivia_Year = 2001
-end
-
-SWEP.Slot = 2
-
-SWEP.UseHands = true
 
 SWEP.ViewModel = "models/weapons/arccw/fesiugmw2_2/c_tavor_1.mdl"
-SWEP.MirrorVMWM = true
-SWEP.WorldModelOffset = {
-    pos = Vector(-5, 3, -5),
-    ang = Angle(-10, 0, 180),
-    scale = 1.25
-}
-SWEP.ViewModelFOV = 65
+SWEP.WorldModel = "models/weapons/w_rif_ak47.mdl"
 
 SWEP.Damage = 69
 SWEP.DamageMin = 59
-SWEP.Range = 1500 * 0.025  -- GAME UNITS * 0.025 = METRES
-SWEP.Penetration = 7
-SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
+SWEP.DamageType = DMG_SHOCK
 
+SWEP.ShootSound = "ArcCW_Horde.MW2.Tavor_Fire"
+SWEP.ShootMechSound = "ArcCW_Horde.MW2.Tavor_Mech"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.MW2.Tavor_Fire_Sil"
 
-SWEP.ChamberSize = 0
-SWEP.Primary.ClipSize = 30 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 45
-SWEP.ReducedClipSize = 15
-
-SWEP.VisualRecoilMult = 0
-SWEP.Recoil = 0.4
-SWEP.RecoilSide = 0.3
-SWEP.RecoilRise = 0.3
---SWEP.RecoilPunch = 2.5
-
-SWEP.Delay = 60 / 750 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
-SWEP.Firemodes = {
-    {
-        Mode = 2,
-    },
-    {
-        Mode = 1,
-    },
-    {
-        Mode = 0
-    }
-}
-
-SWEP.NPCWeaponType = {"weapon_ar2", "weapon_smg1"}
-SWEP.NPCWeight = 150
-
-SWEP.AccuracyMOA = 5 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 500 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 200
-
-SWEP.Primary.Ammo = "smg1" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =			"weapons/fesiugmw2/fire/tar21.wav"
-SWEP.ShootMechSound =       ArcCW_MW2_Mech
---SWEP.DistantShootSound =	"weapons/fesiugmw2/fire_distant/tar21.wav"
-SWEP.ShootSoundSilenced =	"weapons/fesiugmw2/fire/m4_sil.wav"
-
-SWEP.MuzzleEffect = "muzzleflash_4"
-SWEP.ShellModel = "models/shells/shell_556.mdl"
-SWEP.ShellPitch = 95
-SWEP.ShellScale = 1.5
-
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-
-SWEP.SpeedMult = 0.95
-SWEP.SightedSpeedMult = 0.38
-SWEP.SightTime = 0.25
-SWEP.ShellRotateAngle = Angle(0, 90, 0)
-
-SWEP.BulletBones = { -- the bone that represents bullets in gun/mag
-    -- [0] = "bulletchamber",
-    -- [1] = "bullet1"
-}
-
-SWEP.IronSightStruct = {
-    Pos = Vector(-2.816, -5.49, 0.56),
-    Ang = Angle(0, 0, 0),
-    ViewModelFOV = 65 / 1.3,
-    Magnification = 1.3,
-}
-
-SWEP.HoldtypeHolstered = "passive"
-SWEP.HoldtypeActive = "ar2"
-SWEP.HoldtypeSights = "rpg"
-
-SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2
-
-SWEP.ActivePos = Vector(0, 0, 1)
-SWEP.ActiveAng = Angle(0, 0, 0)
-
-SWEP.CustomizePos = Vector(10.479, 0, -1.321)
-SWEP.CustomizeAng = Angle(18.2, 39.4, 14.8)
-
-SWEP.HolsterPos = Vector(3, 0, 0)
-SWEP.HolsterAng = Angle(-10, 25, 0)
-
-SWEP.SprintPos = Vector(0, 0, 1)
-SWEP.SprintAng = Angle(0, 0, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.BarrelLength = 27
-
-SWEP.AttachmentElements = {
-    ["nors"] = {
-        VMBodygroups = {{ind = 1, bg = 1}},
-        WMBodygroups = {},
-    },
-    ["wepcamo-desert"]		= { VMSkin = 1 },
-    ["wepcamo-arctic"]		= { VMSkin = 2 },
-    ["wepcamo-woodland"]	= { VMSkin = 3 },
-    ["wepcamo-digital"]		= { VMSkin = 4 },
-    ["wepcamo-urban"]		= { VMSkin = 5 },
-    ["wepcamo-bluetiger"]	= { VMSkin = 6 },
-    ["wepcamo-redtiger"]	= { VMSkin = 7 },
-    ["wepcamo-fall"]		= { VMSkin = 8 },
-    ["wepcamo-whiteout"]	= { VMSkin = 9 },
-    ["wepcamo-blackout"]        = { VMSkin = 10 },
-    ["wepcamo-bushdweller"]     = { VMSkin = 11 },
-    ["wepcamo-thunderstorm"]    = { VMSkin = 12 },
-            ["horde_ubgl_shock"] = {
-                VMBodygroups = {{ind = 2, bg = 1}},
-            },
-            ["mw2_ubgl_masterkey"] = {
-                VMBodygroups = {{ind = 2, bg = 2}},
-            },
-}
-
-SWEP.ExtraSightDist = 5
+SWEP.RejectAttachments = {["mw2_ubgl_masterkey"] = true, ["mw2_ubgl_m203"] = true}
 
 SWEP.Attachments = {
+    {},
     {
-        PrintName = "Optic",
-        DefaultAttName = "Iron Sights",
-        Slot = "optic",
-        Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(-2.6, 0, 2.8),
+            vpos = Vector(9.5, 0, 0.8),
             vang = Angle(0, 0, 0),
         },
-        InstalledEles = {"nors"},
-    },
+        VMScale = Vector(1, 1, 1),
+    },{},
     {
-        PrintName = "Muzzle",
-        DefaultAttName = "Standard Muzzle",
-        Slot = "muzzle",
-        Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(9.2, 0, 0.75),
-            vang = Angle(0, 0, 0),
+            vpos = Vector(3.5, 0.6, 0.8),
+            vang = Angle(0, 0, -90),
         },
-		WMScale = Vector(1, 1, 1),
-        InstalledEles = {"nomuzzle"},
+    },{},
+    {
+        Slot = "go_ammo"
     },
     {
-        PrintName = "Underbarrel",
-        Slot = {"foregrip", "bipod", "horde_ubgl_shock"},
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(3.748, 0, -1),
-            vang = Angle(0, 0, 0),
-        },
-        Installed = "horde_ubgl_shock",
-    },
-    {
-        PrintName = "Tactical",
-        Slot = "tac",
-        Bone = "tag_weapon",
-        Offset = {
-            vpos = Vector(-4.5, -0.7, 1.25),
-            vang = Angle(0, 0, 90),
-            wpos = Vector(15.625, -0.253, -6.298),
-            wang = Angle(-8.829, -0.556, 90)
-        },
-    },
-    {
-        PrintName = "Fire Group",
-        Slot = "fcg",
-        DefaultAttName = "Standard FCG"
-    },
-    {
-        PrintName = "Ammo Type",
-        Slot = "go_ammo",
-        DefaultAttName = "Standard Ammo"
-    },
-    {
-        PrintName = "Perk",
         Slot = "go_perk"
-    },
+    },{},
     {
-        PrintName = "Camouflage",
-        DefaultAttName = "None",
-        Slot = "mw2_wepcamo",
-        FreeSlot = true,
-    },
-	{
-        PrintName = "Charm",
-        Slot = "charm",
-        FreeSlot = true,
-        Bone = "tag_weapon",
         Offset = {
-            vpos = Vector(-0.5, -0.45, 0.75),
+            vpos = Vector(-5, -0.45, 1.2),
             vang = Angle(0, 0, 0),
-            wpos = Vector(9.625, 1.5, -4),
-            wang = Angle(0, 0, 180)
         },
     },
 }
 
+if SERVER then
+    SWEP.Hook_BulletHit = function(wep, data)
+        local att = data.att
+        local entHit = data.tr.Entity
 
-
-SWEP.Hook_TranslateAnimation = function(wep, anim)
-	local attached = wep.Attachments[3].Installed
-
-	-- m203 is 1, masterkey is 2, fgrip is 3
-	local attthing
-		if 		attached == "horde_ubgl_shock" 		then attthing = 1
-		elseif 	attached == "mw2_ubgl_masterkey" 	then attthing = 2
-		else 											 attthing = 0
-	end
-
-	-- when entering ubgl
-	if anim == "enter_ubgl" then
-		if attthing == 1 then
-			return "switch2_alt_m203"
-		elseif attthing == 2 then
-			return "switch2_alt_masterkey"
-		end
-	elseif anim == "exit_ubgl" then
-		if attthing == 1 then
-			return "switch2_gun_m203"
-		elseif attthing == 2 then
-			return "switch2_gun_masterkey"
-		end
-	end
-
-    if attthing == 1 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_m203"
-		elseif attthing == 1 then
-			return anim .. "_masterkey"
-
-	elseif attthing == 2 and wep:GetInUBGL() then
-        return "alt_" .. anim .. "_masterkey"
-		elseif attthing == 2 then
-			return anim .. "_masterkey"
-
+        if HORDE:IsEnemy(entHit) then
+            entHit:Horde_AddDebuffBuildup(HORDE.Status_Shock, 4, att)
+        end
     end
 end
 
-SWEP.Animations = {
-		["enter_ubgl"] = {
-			Source = "idle",
-			Time = 0/30
-		},
-		["exit_ubgl"] = {
-			Source = "idle",
-			Time = 0/30
-		}, 						-- Fuck you.
-    ["idle"] = {
-        Source = "idle",
-        Time = 1/30
-    },
-    ["enter_sprint"] = {
-        Source = "sprint_in",
-        Time = 10/30
-    },
-    ["idle_sprint"] = {
-        Source = "sprint_loop",
-        Time = 30/40
-    },
-    ["exit_sprint"] = {
-        Source = "sprint_out",
-        Time = 10/30
-    },
-    ["ready"] = {
-        Source = "pullout_first",
-        Time = 33/30,
-        SoundTable = {
-                        {s = "MW2Common.Deploy", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_chamber_v1.wav",		t = 11/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["draw"] = {
-        Source = "pullout",
-        Time = 29/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["holster"] = {
-        Source = "putaway",
-        Time = 25/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire"] = {
-        Source = "fire",
-        Time = 6/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron"] = {
-        Source = "fire_ads",
-        Time = 6/30,
-        ShellEjectAt = 0,
-    },
-    ["reload"] = {
-        Source = "reload",
-        Time = 71/30,
-        MinProgress = 1.7,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_lift_v1.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipout_v1.wav", 	    t = 12/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipin_v1.wav", 	    t = 47/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty"] = {
-        Source = {"reload_empty","reload_empty2"},
-        Time = 87/30,
-        MinProgress = 1.7,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_lift_v1.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipout_v1.wav", 	    t = 13/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipin_v1.wav", 	    t = 46/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_chamber_v1.wav",		t = 66/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies MASTERKEY ANIMATIONS ... AWESOME ---
-------------------------------------------------
-    ["idle_masterkey"] = {
-        Source = "idle_masterkey",
-        Time = 1/30
-    },
-    ["enter_sprint_masterkey"] = {
-        Source = "sprint_in_masterkey",
-        Time = 10/30
-    },
-    ["idle_sprint_masterkey"] = {
-        Source = "sprint_loop_masterkey",
-        Time = 30/40
-    },
-    ["exit_sprint_masterkey"] = {
-        Source = "sprint_out_masterkey",
-        Time = 10/30
-    },
-    ["ready_masterkey"] = {
-        Source = "pullout_first_masterkey",
-        Time = 33/30,
-        SoundTable = {
-                        {s = "MW2Common.Deploy", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_chamber_v1.wav",		t = 11/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["draw_masterkey"] = {
-        Source = "pullout_masterkey",
-        Time = 29/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["holster_masterkey"] = {
-        Source = "putaway_masterkey",
-        Time = 25/30,
-        LHIK = true,
-        LHIKIn = 0.3,
-        LHIKOut = 0,
-    },
-    ["fire_masterkey"] = {
-        Source = "fire_masterkey",
-        Time = 6/30,
-        ShellEjectAt = 0,
-    },
-    ["fire_iron_masterkey"] = {
-        Source = "fire_ads_masterkey",
-        Time = 6/30,
-        ShellEjectAt = 0,
-    },
-    ["reload_masterkey"] = {
-        Source = "reload_masterkey",
-        Time = 71/30,
-        MinProgress = 1.7,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_lift_v1.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipout_v1.wav", 	    t = 12/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipin_v1.wav", 	    t = 47/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.5,
-    },
-    ["reload_empty_masterkey"] = {
-        Source = "reload_empty_masterkey",
-        Time = 87/30,
-        MinProgress = 1.7,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_lift_v1.wav", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipout_v1.wav", 	    t = 13/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_clipin_v1.wav", 	    t = 46/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_tavor_reload_chamber_v1.wav",		t = 66/30},
-					},
-        LHIK = true,
-        LHIKIn = 0.5,
-        LHIKOut = 0.6,
-    },
-------------------------------------------------
------- Here lies M203 IN THE ANIMATIONS........... ... AWESOME ---
-------------------------------------------------
-    ["alt_idle_m203"] = {
-        Source = "alt_idle_m203",
-        Time = 1/30
-    },
-    ["alt_enter_sprint_m203"] = {
-        Source = "alt_sprint_in_m203",
-        Time = 10/30
-    },
-    ["alt_idle_sprint_m203"] = {
-        Source = "alt_sprint_loop_m203",
-        Time = 30/40
-    },
-    ["alt_exit_sprint_m203"] = {
-        Source = "alt_sprint_out_m203",
-        Time = 10/30
-    },
-    ["alt_draw_m203"] = {
-        Source = "alt_pullout_m203",
-        Time = 33/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["alt_holster_m203"] = {
-        Source = "alt_putaway_m203",
-        Time = 20/30,
-    },
-    ["alt_fire_m203"] = {
-        Source = "alt_fire_m203",
-        Time = 10/30,
-    },
-    ["alt_reload_m203"] = {
-        Source = "alt_reload_m203",
-        Time = 78/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_open_v12.wav", 		t = 12/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_load_v12.wav", 	t = 40/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_m203_chamber_close_v12.wav", 	t = 61/30},
-					},
-    },
-------------------------------------------------
------- Here lies MASTERKEY IN THE ANIMATIONS........... ... AWESOME ---
-------------------------------------------------
-    ["alt_idle_masterkey"] = {
-        Source = "alt_idle_masterkey",
-        Time = 1/30
-    },
-    ["alt_enter_sprint_masterkey"] = {
-        Source = "alt_sprint_in_masterkey",
-        Time = 10/30
-    },
-    ["alt_idle_sprint_masterkey"] = {
-        Source = "alt_sprint_loop_masterkey",
-        Time = 30/40
-    },
-    ["alt_exit_sprint_masterkey"] = {
-        Source = "alt_sprint_out_masterkey",
-        Time = 10/30
-    },
-    ["alt_draw_masterkey"] = {
-        Source = "alt_pullout_masterkey",
-        Time = 25/30,
-        SoundTable = {{s = "MW2Common.Deploy", 		t = 0}},
-    },
-    ["alt_holster_masterkey"] = {
-        Source = "alt_putaway_masterkey",
-        Time = 25/30,
-    },
-    ["alt_fire_masterkey"] = {
-        Source = "alt_fire_masterkey",
-        Time = 10/30,
-    },
-    ["alt_cycle_masterkey"] = {
-        Source = "alt_cycle_masterkey",
-        SoundTable = {{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 		t = 3/30}},
-        Time = 15/30,
-    },
-    ["alt_reload_start_masterkey"] = {
-        Source = "alt_reload_start_masterkey",
-        Time = 35/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_lift_v1.wav", 		t = 0/30},
-						{s = "MW2Common.Masterkey_Load", 		t = 26/30},
-					},
-    },
-    ["alt_reload_loop_masterkey"] = {
-        Source = "alt_reload_loop_masterkey",
-        Time = 33/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						{s = "MW2Common.Masterkey_Load", 	t = 24/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_end_v1.wav", 	t = 33/30}, -- end
-					},
-    },
-    ["alt_reload_finish_masterkey"] = {
-        Source = "alt_reload_finish_masterkey",
-        Time = 50/30,
-        TPAnim = ACT_HL2MP_GESTURE_RELOAD_AR2,
-        SoundTable = {
-						--{s = "MW2Common.Masterkey_Load", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_shotattach_reload_end_v1.wav", 	t = 0/30},
-						{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 	t = 22/30},
-					},
-    },
------------------------------------------------------
-    ["switch2_gun_m203"] = {
-        Source = "switch2_gun_m203",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 24/30
-    },
-    ["switch2_alt_m203"] = {
-        Source = "switch2_alt_m203",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 24/30
-    },
-    ["switch2_gun_masterkey"] = {
-        Source = "switch2_gun_masterkey",
-        SoundTable = {{s = "MW2Common.Underbarrel", 		t = 0}},
-        Time = 22/30
-    },
-    ["switch2_alt_masterkey"] = {
-        Source = "switch2_alt_masterkey",
-        SoundTable = {
-						{s = "MW2Common.Underbarrel", 		t = 0},
-						{s = "weapons/fesiugmw2/foley/wpfoly_winchester_reload_pump_v1.wav", 		t = 14/30},
-					},
-        Time = 25/30
-    },
-}
+sound.Add( {
+    name = "ArcCW_Horde.MW2.Tavor_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/tar21.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.Tavor_Mech",
+    channel = CHAN_AUTO,
+    volume = 1.0,
+    level = 45,
+    pitch = {90, 105},
+    sound = {
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c1.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c2.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c3.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c4.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c5.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c6.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c7.wav",
+        ")weapons/fesiugmw2/mechanism/weap_mech_layer_c8.wav"
+    }
+} )
+sound.Add( {
+    name = "ArcCW_Horde.MW2.Tavor_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = {90, 105},
+    sound = ")weapons/fesiugmw2/fire/m4_sil.wav"
+} )

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -649,7 +649,7 @@ function HORDE:GetDefaultItemsData()
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "SG556", "arccw_horde_sg556", 3000, 7,
         "SIG SG 556.\nAn assault rifle manufactured by Sig Sauer AG.",
-        { Assault = true, SpecOps = true, Reverend = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "AUG", "arccw_horde_aug", 3000, 7,
         "Steyr AUG.\nAn Austrian bullpup assault rifle.",

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -732,7 +732,7 @@ function HORDE:GetDefaultItemsData()
 
     HORDE:CreateItem( "Rifle", "SSG08 Medic SR", "arccw_horde_medic_rifle", 1500, 6,
         "A medic sniper rifle that shoots healing darts.\nDamages enemies and heals players.",
-        { Assault = true, SpecOps = true, Reverend = true, Medic = true, Hatcher = true, Ghost = true, Gunslinger = true },
+        { Medic = true, Hatcher = true, Ghost = true, Gunslinger = true },
         10, -1, nil, nil, { Medic = 2 }, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "ACR Medic AR", "arccw_horde_medic_acr", 3000, 8,
         "Remington Adaptive Combat Rifle.\nEquipped with healing dart and medic grenade launcher.\n\nPress USE+RELOAD to equip medic grenade launcher.\nPress B or ZOOM to fire healing dart.\nHealing dart heals 20 health and has a 1.5 second cooldown.",

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -649,11 +649,11 @@ function HORDE:GetDefaultItemsData()
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "SG556", "arccw_horde_sg556", 3000, 7,
         "SIG SG 556.\nAn assault rifle manufactured by Sig Sauer AG.",
-        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
+        { Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "AUG", "arccw_horde_aug", 3000, 7,
         "Steyr AUG.\nAn Austrian bullpup assault rifle.",
-        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
+        { Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "F2000", "arccw_horde_f2000", 3250, 7,
         "FN F2000.\nAn ambidextrous bullpup rifle developed by FN. \nEquipped with an M203 underbarrel incendiary grenade launcher.\nPress USE+RELOAD to equip M203.",

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -641,19 +641,19 @@ function HORDE:GetDefaultItemsData()
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "AK47", "arccw_horde_ak47", 3000, 7,
         "Avtomat Kalashnikova.\nA gas-operated, 7.62x39mm assault rifle developed in the Soviet Union.",
-        { Assault = true, SpecOps = true, Reverend = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "M4A1", "arccw_horde_m4", 3000, 7,
         "Colt M4.\nA 5.56x45mm NATO, air-cooled, gas-operated, select fire carbine.",
-        { Assault = true, SpecOps = true, Reverend = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "SG556", "arccw_horde_sg556", 3000, 7,
         "SIG SG 556.\nAn assault rifle manufactured by Sig Sauer AG.",
-        { Assault = true, SpecOps = true, Reverend = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "AUG", "arccw_horde_aug", 3000, 7,
         "Steyr AUG.\nAn Austrian bullpup assault rifle.",
-        { Assault = true, SpecOps = true, Reverend = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "F2000", "arccw_horde_f2000", 3250, 7,
         "FN F2000.\nAn ambidextrous bullpup rifle developed by FN. \nEquipped with an M203 underbarrel incendiary grenade launcher.\nPress USE+RELOAD to equip M203.",
@@ -673,7 +673,7 @@ function HORDE:GetDefaultItemsData()
 
     HORDE:CreateItem( "Rifle", "Springfield M14", "arccw_horde_m14", 1250, 4,
         "Springfield semi-auto rifle.\nClassic, affordable, zombie-killing machine.",
-        { Survivor = true, Psycho = true, Ghost = true, Gunslinger = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Ghost = true, Gunslinger = true },
         10, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "Winchester LAR", "arccw_horde_winchester", 1000, 4,
         "Winchester Lever Action Rifle.\nAn all-time classic.",
@@ -732,7 +732,7 @@ function HORDE:GetDefaultItemsData()
 
     HORDE:CreateItem( "Rifle", "SSG08 Medic SR", "arccw_horde_medic_rifle", 1500, 6,
         "A medic sniper rifle that shoots healing darts.\nDamages enemies and heals players.",
-        { Medic = true, Hatcher = true, Ghost = true, Gunslinger = true },
+        { Assault = true, SpecOps = true, Reverend = true, Medic = true, Hatcher = true, Ghost = true, Gunslinger = true },
         10, -1, nil, nil, { Medic = 2 }, nil, { HORDE.DMG_BALLISTIC } )
     HORDE:CreateItem( "Rifle", "ACR Medic AR", "arccw_horde_medic_acr", 3000, 8,
         "Remington Adaptive Combat Rifle.\nEquipped with healing dart and medic grenade launcher.\n\nPress USE+RELOAD to equip medic grenade launcher.\nPress B or ZOOM to fire healing dart.\nHealing dart heals 20 health and has a 1.5 second cooldown.",
@@ -740,7 +740,7 @@ function HORDE:GetDefaultItemsData()
         10, 10, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
     HORDE:CreateItem( "Rifle", "M16 M203", "arccw_horde_m16m203", 2250, 7,
         "M16A4 equipped with an M203 underbarrel grenade launcher.\nPress USE+RELOAD to equip M203.",
-        { Assault = true, SpecOps = true, Reverend = true, Demolition = true },
+        { Survivor = true, Psycho = true, Assault = true, SpecOps = true, Reverend = true, Demolition = true },
         10, 10, nil, nil, { Assault = 2, Demolition = 2 }, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_BLAST } )
 
     HORDE:CreateItem( "MG", "AUG HBAR", "arccw_horde_aug_hbar", 2000, 9,


### PR DESCRIPTION
## UBGL Rifle Changes (Scar-LOS, F2000, Tar-21, M16A4)
- Ported Tar-21 and M16A4 to "Sub-base" system.
- Scar-LOS, F2000, and Tar-21 now deal buildup and damage type from their respective UBGL type.
- Scar-LOS, F2000, and Tar-21 have had UBGL attachments removed.
- M16A4 has been given all unique UBGL variants. (Excluding Medic UBGL.)
- Improved various aspects of the Scar-LOS and F2000.

## Extra Weapon Selection
- M16A4, AK47, M4A1 and SG556 have been given to Survivor class.
- M14 has been given to Assault class.

Note: M14 has returned to the Assault class for one main reason, the overwhelmingly negative feedback from Horde playerbase upon the initial removal of the M14 from Assault (6/18/2025).