### PR TITLE
GSO QoL & Improvements (Pistols, SMGs, SGs, ARs) + 9mm & SMG-1 Improved + Medic SMGs for Reverend

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_870.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_870.lua
@@ -27,7 +27,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.M870_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.M870_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.M870_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -78,13 +78,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = ")arccw_go/m590_suppressed_fp.wav"
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.M870_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/sawedoff/sawedoff-1-distant.wav"
-
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_9mm.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_9mm.lua
@@ -4,18 +4,19 @@ if CLIENT then
     SWEP.WepSelectIconMat = Material("items/hl2/weapon_pistol.png")
     killicon.AddAlias("arccw_horde_9mm", "weapon_9mm")
 end
+
 SWEP.Base = "arccw_base"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 SWEP.WeaponCamBone = tag_camera
 
-SWEP.PrintName = "9mm (Horde)"
+SWEP.PrintName = "9mm"
 SWEP.Trivia_Class = "Pistol"
 SWEP.Trivia_Desc = "Standard issue pistol."
-
 SWEP.Trivia_Manufacturer = "Combine"
-SWEP.Trivia_Calibre = "9mm"
+SWEP.Trivia_Calibre = "9x19mm Parabellum"
 SWEP.Trivia_Mechanism = "Semi-Auto"
 SWEP.Trivia_Country = "Combine"
 SWEP.Trivia_Year = 2007
@@ -25,31 +26,31 @@ SWEP.Slot = 1
 SWEP.UseHands = true
 
 SWEP.ViewModel = "models/weapons/c_pistol.mdl"
-SWEP.MirrorVMWM = false
+SWEP.MirrorVMWM = true
 SWEP.WorldModel = "models/weapons/w_pistol.mdl"
 SWEP.ViewModelFOV = 65
 
+SWEP.WorldModelOffset = {
+    pos = Vector(-21.5, 7, -3.5),
+    ang = Angle(-10, 0, 180)
+}
+
 SWEP.Damage = 20
 SWEP.DamageMin = 15
-SWEP.RangeMin = 15
 SWEP.Range = 25
 SWEP.Penetration = 2
 SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
+SWEP.ShootEntity = nil
 
+SWEP.ChamberSize = 0
+SWEP.Primary.ClipSize = 18
 
-SWEP.ChamberSize = 1
-SWEP.Primary.ClipSize = 18 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 18
-SWEP.ReducedClipSize = 18
+SWEP.Recoil = 0.2
+SWEP.RecoilSide = 0.12
+SWEP.RecoilPunch = 0
 
-SWEP.Recoil = 0.400
-SWEP.RecoilSide = 0.125
-SWEP.RecoilRise = 0.5
-SWEP.RecoilPunch = 1
-
-SWEP.Delay = 0.08 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
+SWEP.Delay = 0.08
+SWEP.Num = 1
 SWEP.Firemodes = {
     {
         Mode = 1,
@@ -59,37 +60,30 @@ SWEP.Firemodes = {
     }
 }
 
-SWEP.NPCWeaponType = {"weapon_ar2", "weapon_smg1"}
-SWEP.NPCWeight = 150
+SWEP.AccuracyMOA = 5
+SWEP.HipDispersion = 150
+SWEP.MoveDispersion = 200
 
-SWEP.AccuracyMOA = 0 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 50 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 150
+SWEP.Primary.Ammo = "Pistol"
 
-SWEP.Primary.Ammo = "Pistol" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =			")weapons/pistol/pistol_fire2.wav"
-SWEP.DistantShootSound =	"^weapons/pistol/pistol_fire3.wav"
-SWEP.ShootSoundSilenced =	")weapons/usp/usp1.wav"
+SWEP.ShootSound = "ArcCW_Horde.9mm_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.9mm_Fire_Sil"
 
 SWEP.MuzzleEffect = "muzzleflash_pistol"
 SWEP.ShellModel = "models/weapons/shell.mdl"
 SWEP.ShellScale = 0.5
 
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
+SWEP.MuzzleEffectAttachment = 1
+SWEP.CaseEffectAttachment = 2
 
 SWEP.SpeedMult = 1
 SWEP.SightedSpeedMult = 0.8
 SWEP.SightTime = 0.125
 
 SWEP.IronSightStruct = {
-    Pos = Vector(0, 0, 0),
+    Pos = Vector(-1, 0, 2),
     Ang = Angle(0, 0, 0),
-    Magnification = 1.5,
+    Magnification = 1.25,
     SwitchToSound = "", -- sound that plays when switching to this sight
     ViewModelFOV = 40,
     CrosshairInSights = true
@@ -102,17 +96,17 @@ SWEP.HoldtypeSights = "pistol"
 
 SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_PISTOL
 
-SWEP.ActivePos = Vector(0, 0, 1)
+SWEP.ActivePos = Vector(0, -5, 1)
 SWEP.ActiveAng = Angle(0, 0, 0)
 
-SWEP.CustomizePos = Vector(13.92, 1, -1.08)
-SWEP.CustomizeAng = Angle(6.8, 37.7, 10.3)
+SWEP.CustomizePos = Vector(7, -8, 1)
+SWEP.CustomizeAng = Angle(5, 30, 10)
 
-SWEP.HolsterPos = Vector(3, 0, 0)
-SWEP.HolsterAng = Angle(-10, 25, 0)
+SWEP.HolsterPos = Vector(3, -5, 0)
+SWEP.HolsterAng = Angle(-10, 25, -15)
 
-SWEP.SprintPos = Vector(0, 0, 1)
-SWEP.SprintAng = Angle(0, 0, 0)
+SWEP.SprintPos = Vector(0, -5, 1)
+SWEP.SprintAng = Angle(-10, 0, 0)
 
 SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
 SWEP.BarrelOffsetHip = Vector(2, 0, -2)
@@ -187,3 +181,19 @@ function SWEP:DrawWeaponSelection(x, y, w, h, a)
     surface.DrawTexturedRect(x, y, w, w / 2)
 end
 
+sound.Add( {
+    name = "ArcCW_Horde.9mm_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {98, 102},
+    sound = ")weapons/pistol/pistol_fire2.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.9mm_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")weapons/usp/usp1.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_ace.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ace.lua
@@ -3,22 +3,45 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_ace")
     killicon.Add("arccw_horde_ace", "arccw/weaponicons/arccw_go_ace", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_ace"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "ACE 22"
-SWEP.Slot = 2
-
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_ace.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_ace.mdl"
 
 SWEP.Damage = 54
-SWEP.DamageMin = 44  -- damage done at maximum range
+SWEP.DamageMin = 44
 
 SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 700 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.Delay = 60 / 700
+
+SWEP.ShootSound = "ArcCW_Horde.GSO.ACE_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.ACE_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.ACE_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/galilar/galil_01.wav",")arccw_go/galilar/galil_02.wav",")arccw_go/galilar/galil_03.wav",")arccw_go/galilar/galil_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.ACE_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_ak47.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ak47.lua
@@ -3,21 +3,45 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_ak47")
     killicon.Add("arccw_horde_ak47", "arccw/weaponicons/arccw_go_ak47", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_ak47"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "AKM"
-SWEP.Slot = 2
+
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_ak47.mdl"
 SWEP.WorldModel = "models/weapons/w_rif_ak47.mdl"
-SWEP.Damage = 65
-SWEP.DamageMin = 49 -- damage done at maximum range
+
+SWEP.Damage = 68
+SWEP.DamageMin = 50
 
 SWEP.Recoil = 0.45
 SWEP.RecoilSide = 0.35
 SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 600 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.ShootSound = "ArcCW_Horde.GSO.AK47_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.AK47_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.AK47_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = ")arccw_go/ak47/ak47_01.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.AK47_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_ar15.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ar15.lua
@@ -3,22 +3,24 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_ar15")
     killicon.Add("arccw_horde_ar15", "arccw/weaponicons/arccw_go_ar15", Color(0, 0, 0, 255))
 end
-SWEP.Base = "arccw_go_ar15"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
 
+SWEP.Base = "arccw_go_ar15"
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
+
 SWEP.PrintName = "AR-15"
-SWEP.Slot = 2
+
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_car15.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_car15.mdl"
-SWEP.Damage = 42
-SWEP.DamageMin = 32 -- damage done at maximum range
 
+SWEP.Damage = 42
+SWEP.DamageMin = 32
 
 SWEP.RecoilPunch = 0
 
-
+SWEP.Delay = 60 / 725
 SWEP.Firemodes = {
     {
         Mode = 2,
@@ -31,5 +33,27 @@ SWEP.Firemodes = {
     }
 }
 
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.AR15_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.AR15_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.AR15_Fire_Sil"
+SWEP.DistantShootSound = ""
 
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.AR15_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/m4a1/m4a1_us_01.wav",")arccw_go/m4a1/m4a1_us_02.wav",")arccw_go/m4a1/m4a1_us_03.wav",")arccw_go/m4a1/m4a1_us_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.AR15_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_aug.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_aug.lua
@@ -3,21 +3,55 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_aug")
     killicon.Add("arccw_horde_aug", "arccw/weaponicons/arccw_go_aug", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_aug"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "AUG A3"
-SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_aug.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_aug.mdl"
 
-SWEP.Damage = 63
-SWEP.DamageMin = 47 -- damage done at maximum range
+SWEP.Damage = 62
+SWEP.DamageMin = 46
 
+SWEP.Primary.ClipSize = 42
+
+SWEP.Recoil = 0.4
+SWEP.RecoilSide = 0.3
 SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 700 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.AUG_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.AUG_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.AUG_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+SWEP.Attachments = {
+    {},{},{},{},{},
+    {
+        DefaultAttName = "42-Round 5.56mm Poly"
+    },
+}
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.AUG_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/aug/aug_01.wav",")arccw_go/aug/aug_02.wav",")arccw_go/aug/aug_03.wav",")arccw_go/aug/aug_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.AUG_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_bizon.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_bizon.lua
@@ -3,18 +3,48 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_bizon")
     killicon.Add("arccw_horde_bizon", "arccw/weaponicons/arccw_go_bizon", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_bizon"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "PP-19 Bizon-2"
-SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_bizon.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_bizon.mdl"
 
 SWEP.Damage = 45
-SWEP.DamageMin = 32 -- damage done at maximum range
+SWEP.DamageMin = 32
 
-SWEP.Delay = 60 / 750 -- 60 / RPM.
+SWEP.RecoilPunch = 0
+
+SWEP.Delay = 60 / 750
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.Bizon_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.Bizon_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.Bizon_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+SWEP.RejectAttachments = {["go_fore_bipod"] = true, ["go_foregrip"] = true, ["go_foregrip_angled"] = true, ["go_foregrip_ergo"] = true, ["go_foregrip_snatch"] = true, ["go_foregrip_stubby"] = true}
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.Bizon_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/bizon/bizon_01.wav",")arccw_go/bizon/bizon_02.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.Bizon_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_cz75.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_cz75.lua
@@ -20,7 +20,7 @@ SWEP.RecoilPunch = 0
 SWEP.FirstShootSound = "ArcCW_Horde.GSO.CZ75_Fire"
 SWEP.ShootSound = "ArcCW_Horde.GSO.CZ75_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.CZ75_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.CZ75_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -87,12 +87,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.CZ75_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/cz75a/cz75a-1-distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_deagle.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_deagle.lua
@@ -24,7 +24,7 @@ SWEP.Delay = 60 / 200
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.Deagle_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.Deagle_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.Deagle_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -46,12 +46,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = ")arccw_go/mosin_suppressed_fp.wav"
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.Deagle_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/deagle/deagle-1-distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_famas.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_famas.lua
@@ -3,29 +3,25 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_famas")
     killicon.Add("arccw_horde_famas", "arccw/weaponicons/arccw_go_famas", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_famas"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "FAMAS G1"
-
-
-SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_famas.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_famas.mdl"
 
 SWEP.Damage = 50
-SWEP.DamageMin = 40  -- damage done at maximum range
-SWEP.Range = 100 -- in METRES
-
-SWEP.Primary.ClipSize = 25 -- DefaultClip is automatically set.
+SWEP.DamageMin = 40
 
 SWEP.RecoilRise = 0.4
 SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 1000 -- 60 / RPM.
+SWEP.Delay = 60 / 1000
 SWEP.Firemodes = {
     {
         Mode = 2,
@@ -34,223 +30,34 @@ SWEP.Firemodes = {
         Mode = -3,
     },
     {
+        Mode = 1,
+    },
+    {
         Mode = 0
     }
 }
 
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.FAMAS_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.FAMAS_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.FAMAS_Fire_Sil"
+SWEP.DistantShootSound = ""
 
-SWEP.ShootVol = 75 -- volume of shoot sound
-
-SWEP.FirstShootSound = "arccw_go/famas/famas_01.wav"
-SWEP.ShootSound = "arccw_go/famas/famas_04.wav"
-SWEP.ShootSoundSilenced = "arccw_go/m4a1/m4a1_silencer_01.wav"
-SWEP.DistantShootSound = "arccw_go/famas/famas-1-distant.wav"
-
-SWEP.MeleeSwingSound = "arccw_go/m249/m249_draw.wav"
-SWEP.MeleeMissSound = "weapons/iceaxe/iceaxe_swing1.wav"
-SWEP.MeleeHitSound = "arccw_go/knife/knife_hitwall1.wav"
-SWEP.MeleeHitNPCSound = "physics/body/body_medium_break2.wav"
-
-SWEP.MuzzleEffect = "muzzleflash_famas"
-SWEP.ShellModel = "models/shells/shell_556.mdl"
-SWEP.ShellPitch = 95
-SWEP.ShellScale = 1.25
-SWEP.ShellRotateAngle = Angle(0, 180, 0)
-
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-
-SWEP.SpeedMult = 0.95
-SWEP.SightedSpeedMult = 0.75
-SWEP.SightTime = 0.36
-
-SWEP.IronSightStruct = {
-    Pos = Vector(-6.26, -7, 1.2),
-    Ang = Angle(0, -0.1, -2),
-    Magnification = 1.1,
-    SwitchToSound = "", -- sound that plays when switching to this sight
-    CrosshairInSights = false
-}
-
-SWEP.HoldtypeHolstered = "passive"
-SWEP.HoldtypeActive = "ar2"
-SWEP.HoldtypeSights = "rpg"
-
-SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2
-
-SWEP.ActivePos = Vector(-1, 2, -1)
+SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
 
-SWEP.CrouchPos = Vector(-4, 0, -1)
-SWEP.CrouchAng = Angle(0, 0, -10)
-
-SWEP.HolsterPos = Vector(3, 3, 0)
-SWEP.HolsterAng = Angle(-7.036, 30.016, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.CustomizePos = Vector(8, 0, 1)
-SWEP.CustomizeAng = Angle(5, 30, 30)
-
-SWEP.BarrelLength = 24
-
-SWEP.AttachmentElements = {
-    ["rail"] = {
-        VMBodygroups = {{ind = 4, bg = 1}},
-        WMBodygroups = {{ind = 4, bg = 1}},
-    },
-    ["ubrms"] = {
-        VMBodygroups = {{ind = 5, bg = 1}},
-        WMBodygroups = {{ind = 5, bg = 1}},
-    },
-    ["tacms"] = {
-        VMBodygroups = {{ind = 6, bg = 1}},
-        WMBodygroups = {{ind = 6, bg = 1}},
-    },
-    ["fh_none"] = {
-        VMBodygroups = {{ind = 2, bg = 3}},
-        WMBodygroups = {{ind = 2, bg = 3}},
-    },
-    ["go_famas_barrel_short"] = {
-        VMBodygroups = {
-            {ind = 1, bg = 1},
-            {ind = 2, bg = 1},
-        },
-        WMBodygroups = {
-            {ind = 1, bg = 1},
-            {ind = 2, bg = 1},
-        },
-        AttPosMods = {
-            [5] = {
-                vpos = Vector(0, -2.85, 13.4),
-            }
-        }
-    },
-    ["go_famas_barrel_long"] = {
-        VMBodygroups = {
-            {ind = 1, bg = 2},
-            {ind = 2, bg = 2},
-        },
-        WMBodygroups = {
-            {ind = 1, bg = 2},
-            {ind = 2, bg = 2},
-        },
-        AttPosMods = {
-            [5] = {
-                vpos = Vector(0, -2.85, 20.5),
-            }
-        }
-    },
-    ["go_famas_mag_25"] = {
-        VMBodygroups = {
-            {ind = 3, bg = 1},
-        },
-        WMBodygroups = {
-            {ind = 3, bg = 1},
-        },
-    },
-    ["go_556_ammo_60round"] = {
-        VMBodygroups = {
-            {ind = 3, bg = 2},
-        },
-        WMBodygroups = {
-            {ind = 3, bg = 2},
-        },
-    }
-}
-
-SWEP.ExtraSightDist = 10
-SWEP.GuaranteeLaser = true
-
-SWEP.WorldModelOffset = {
-    pos = Vector(-15, 7, -5),
-    ang = Angle(-10, 0, 180)
-}
-
-SWEP.MirrorVMWM = true
-
-SWEP.Attachments = {
-    {
-        PrintName = "Optic",
-        Slot = {"optic_lp", "optic"},
-        Bone = "v_weapon.famas_Parent",
-        DefaultAttName = "Iron Sights",
-        Offset = {
-            vpos = Vector(0, -7.25, 4),
-            vang = Angle(90, 0, -90),
-            wpos = Vector(22, 1, -7),
-            wang = Angle(-9.79, 0, 180)
-        },
-        InstalledEles = {"rail"},
-        CorrectiveAng = Angle(0.25, 0, 0)
-    },
-    {
-        PrintName = "Underbarrel",
-        Slot = {"foregrip", "ubgl"},
-        Bone = "v_weapon.famas_Parent",
-        Offset = {
-            vpos = Vector(0, -0.9, 12),
-            vang = Angle(90, 0, -90),
-            wpos = Vector(22, 1, -7),
-            wang = Angle(-9.79, 0, 180)
-        },
-        InstalledEles = {"ubrms"},
-    },
-    {
-        PrintName = "Tactical",
-        Slot = "tac",
-        Bone = "v_weapon.famas_Parent",
-        Offset = {
-            vpos = Vector(0.9, -6.7, 4.5),
-            vang = Angle(90, 0, 0),
-            wpos = Vector(22, 1, -7),
-            wang = Angle(-9.79, 0, 180)
-        },
-        InstalledEles = {"tacms"},
-    },
-    {
-        PrintName = "Barrel",
-        Slot = "go_famas_barrel",
-        DefaultAttName = "490mm Standard Barrel"
-    },
-    {
-        PrintName = "Muzzle",
-        DefaultAttName = "Standard Muzzle",
-        Slot = "muzzle",
-        Bone = "v_weapon.famas_Parent",
-        Offset = {
-            vpos = Vector(0, -2.9, 16.5),
-            vang = Angle(90, 0, -90),
-            wpos = Vector(22, 1, -7),
-            wang = Angle(-9.79, 0, 180)
-        },
-        InstalledEles = {"fh_none"},
-    },
-    {
-        PrintName = "Magazine",
-        Slot = {"go_ammo_556_60"},
-        DefaultAttName = "25-Round 5.56mm FR"
-    },
-    {
-        PrintName = "Ammo Type",
-        Slot = "go_ammo",
-        DefaultAttName = "Standard Ammo"
-    },
-    {
-        PrintName = "Perk",
-        Slot = "go_perk"
-    },
-    {
-        PrintName = "Charm",
-        Slot = "charm",
-        FreeSlot = true,
-        Bone = "v_weapon.famas_Parent", -- relevant bone any attachments will be mostly referring to
-        Offset = {
-            vpos = Vector(0.5, -6.2, -2), -- offset that the attachment will be relative to the bone
-            vang = Angle(90, 0, -90),
-            wpos = Vector(6.099, 1.1, -3.301),
-            wang = Angle(171.817, 180-1.17, 0),
-        },
-    },
-}
+sound.Add( {
+    name = "ArcCW_Horde.GSO.FAMAS_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/famas/famas_01.wav",")arccw_go/famas/famas_02.wav",")arccw_go/famas/famas_03.wav",")arccw_go/famas/famas_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.FAMAS_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_fiveseven.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_fiveseven.lua
@@ -17,12 +17,13 @@ SWEP.WorldModel = "models/weapons/arccw_go/v_pist_fiveseven.mdl"
 
 SWEP.Damage = 34
 SWEP.DamageMin = 27
+SWEP.Penetration = 10
 
 SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.FiveSeven_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.FiveSeven_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.FiveSeven_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -44,12 +45,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.FiveSeven_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = {99, 101},
-    sound = "arccw_go/fiveseven/fiveseven-1-distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_glock.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_glock.lua
@@ -20,7 +20,7 @@ SWEP.RecoilPunch = 0
 SWEP.FirstShootSound = "ArcCW_Horde.GSO.Glock_Fire"
 SWEP.ShootSound = "ArcCW_Horde.GSO.Glock_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.Glock_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.Glock_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -52,12 +52,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.Glock_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/glock18/glock18-1-distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_m1014.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m1014.lua
@@ -37,7 +37,7 @@ SWEP.Firemodes = {
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.M1014_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.M1014_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.M1014_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -71,13 +71,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = ")arccw_go/m590_suppressed_fp.wav"
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.M1014_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/xm1014/xm1014-1-distant.wav"
-
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m16m203.lua
@@ -18,6 +18,19 @@ SWEP.WorldModel = "models/weapons/w_rif_m4a1.mdl"
 SWEP.Damage = 47
 SWEP.DamageMin = 39
 
+SWEP.Firemodes = {
+    {
+        Mode = 2,
+    },
+    {
+        Mode = 1,
+    },
+    {
+        Mode = 0
+    }
+}
+
+
 SWEP.ShootSound = "ArcCW_Horde.MW2.M16_Fire"
 SWEP.ShootMechSound = "ArcCW_Horde.MW2.M16_Mech"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.MW2.M16_Fire_Sil"

--- a/gamemodes/horde/entities/weapons/arccw_horde_m4.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m4.lua
@@ -3,24 +3,48 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_m4")
     killicon.Add("arccw_horde_m4", "arccw/weaponicons/arccw_go_m4", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_m4"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "M4A1"
-
-
-SWEP.Slot = 2
-
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_m4a1.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_m4a1.mdl"
 
 SWEP.Damage = 60
-SWEP.DamageMin = 45 -- damage done at maximum range
-SWEP.Range = 3000 * 0.025 -- in METRES
+SWEP.DamageMin = 45
+
+SWEP.Recoil = 0.3
+SWEP.RecoilSide = 0.25
 SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 800 --725 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.Delay = 60 / 800
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.M4_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.M4_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.M4_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.M4_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/m4a1/m4a1_01.wav",")arccw_go/m4a1/m4a1_02.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.M4_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_m9.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m9.lua
@@ -20,7 +20,7 @@ SWEP.RecoilPunch = 0
 SWEP.FirstShootSound = "ArcCW_Horde.GSO.Elite_Fire"
 SWEP.ShootSound = "ArcCW_Horde.GSO.Elite_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.Elite_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.Elite_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -52,12 +52,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.Elite_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/elite/elite-1-distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_mac10.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mac10.lua
@@ -3,19 +3,44 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_mac10")
     killicon.Add("arccw_horde_mac10", "arccw/weaponicons/arccw_go_mac10", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_mac10"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "MAC-10"
 
-SWEP.Slot = 2
-
-
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_mac10.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_mac10.mdl"
 
-SWEP.Damage = 35
-SWEP.DamageMin = 20 -- damage done at maximum range
+SWEP.Damage = 32
+SWEP.DamageMin = 20
+
 SWEP.RecoilPunch = 0
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.MAC10_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.MAC10_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.MAC10_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MAC10_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/mac10/mac10_01.wav",")arccw_go/mac10/mac10_02.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MAC10_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_mag7.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mag7.lua
@@ -27,7 +27,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.MAG7_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.MAG7_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.MAG7_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -92,13 +92,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = ")arccw_go/m590_suppressed_fp.wav"
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.MAG7_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = {")arccw_go/mag7/mag7_distant_01.wav","arccw_go/mag7/mag7_distant_02.wav"}
-
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_medic_9mm.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_medic_9mm.lua
@@ -2,9 +2,11 @@ if not ArcCWInstalled then return end
 if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("items/hl2/weapon_pistol.png")
     SWEP.WepSelectIconMat = Material("items/hl2/weapon_pistol.png")
-    killicon.AddAlias("arccw_horde_medic_9mm", "weapon_9mm")
+    killicon.AddAlias("arccw_horde_9mm", "weapon_9mm")
 end
+
 SWEP.Base = "arccw_base"
+
 SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
@@ -13,9 +15,8 @@ SWEP.WeaponCamBone = tag_camera
 SWEP.PrintName = "Medic 9mm"
 SWEP.Trivia_Class = "Pistol"
 SWEP.Trivia_Desc = "Standard issue pistol."
-
 SWEP.Trivia_Manufacturer = "Combine"
-SWEP.Trivia_Calibre = "9mm"
+SWEP.Trivia_Calibre = "9x19mm Parabellum"
 SWEP.Trivia_Mechanism = "Semi-Auto"
 SWEP.Trivia_Country = "Combine"
 SWEP.Trivia_Year = 2007
@@ -25,68 +26,61 @@ SWEP.Slot = 1
 SWEP.UseHands = true
 
 SWEP.ViewModel = "models/weapons/c_pistol.mdl"
-SWEP.MirrorVMWM = false
+SWEP.MirrorVMWM = true
 SWEP.WorldModel = "models/weapons/w_pistol.mdl"
 SWEP.ViewModelFOV = 65
 
+SWEP.WorldModelOffset = {
+    pos = Vector(-21.5, 7, -3.5),
+    ang = Angle(-10, 0, 180)
+}
+
 SWEP.Damage = 20
 SWEP.DamageMin = 15
-SWEP.RangeMin = 15
 SWEP.Range = 25
 SWEP.Penetration = 2
 SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
+SWEP.ShootEntity = nil
 
+SWEP.ChamberSize = 0
+SWEP.Primary.ClipSize = 18
 
-SWEP.ChamberSize = 1
-SWEP.Primary.ClipSize = 18 -- DefaultClip is automatically set.
-SWEP.ExtendedClipSize = 18
-SWEP.ReducedClipSize = 18
+SWEP.Recoil = 0.2
+SWEP.RecoilSide = 0.12
+SWEP.RecoilPunch = 0
 
-SWEP.Recoil = 0.400
-SWEP.RecoilSide = 0.125
-SWEP.RecoilRise = 0.5
-SWEP.RecoilPunch = 1
-
-SWEP.Delay = 0.08 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
+SWEP.Delay = 0.08
+SWEP.Num = 1
 SWEP.Firemodes = {
     {
         Mode = 1,
     }
 }
 
-SWEP.NPCWeaponType = {"weapon_ar2", "weapon_smg1"}
-SWEP.NPCWeight = 150
+SWEP.AccuracyMOA = 5
+SWEP.HipDispersion = 150
+SWEP.MoveDispersion = 200
 
-SWEP.AccuracyMOA = 0 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 50 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 150
+SWEP.Primary.Ammo = "Pistol"
 
-SWEP.Primary.Ammo = "Pistol" -- what ammo type the gun uses
-
-SWEP.ShootVol = 75 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound =           ")weapons/pistol/pistol_fire2.wav"
-SWEP.DistantShootSound =    "^weapons/pistol/pistol_fire3.wav"
-SWEP.ShootSoundSilenced =   ")weapons/usp/usp1.wav"
+SWEP.ShootSound = "ArcCW_Horde.9mm_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.9mm_Fire_Sil"
 
 SWEP.MuzzleEffect = "muzzleflash_pistol"
 SWEP.ShellModel = "models/weapons/shell.mdl"
 SWEP.ShellScale = 0.5
 
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
+SWEP.MuzzleEffectAttachment = 1
+SWEP.CaseEffectAttachment = 2
 
 SWEP.SpeedMult = 1
 SWEP.SightedSpeedMult = 0.8
 SWEP.SightTime = 0.125
 
 SWEP.IronSightStruct = {
-    Pos = Vector(0, 0, 0),
+    Pos = Vector(-1, 0, 2),
     Ang = Angle(0, 0, 0),
-    Magnification = 1.5,
+    Magnification = 1.25,
     SwitchToSound = "", -- sound that plays when switching to this sight
     ViewModelFOV = 40,
     CrosshairInSights = true
@@ -99,17 +93,17 @@ SWEP.HoldtypeSights = "pistol"
 
 SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_PISTOL
 
-SWEP.ActivePos = Vector(0, 0, 1)
+SWEP.ActivePos = Vector(0, -5, 1)
 SWEP.ActiveAng = Angle(0, 0, 0)
 
-SWEP.CustomizePos = Vector(13.92, 1, -1.08)
-SWEP.CustomizeAng = Angle(6.8, 37.7, 10.3)
+SWEP.CustomizePos = Vector(7, -8, 1)
+SWEP.CustomizeAng = Angle(5, 30, 10)
 
-SWEP.HolsterPos = Vector(3, 0, 0)
-SWEP.HolsterAng = Angle(-10, 25, 0)
+SWEP.HolsterPos = Vector(3, -5, 0)
+SWEP.HolsterAng = Angle(-10, 25, -15)
 
-SWEP.SprintPos = Vector(0, 0, 1)
-SWEP.SprintAng = Angle(0, 0, 0)
+SWEP.SprintPos = Vector(0, -5, 1)
+SWEP.SprintAng = Angle(-10, 0, 0)
 
 SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
 SWEP.BarrelOffsetHip = Vector(2, 0, -2)
@@ -262,3 +256,20 @@ function SWEP:Hook_DrawHUD()
         pos.x - 15, pos.y - 15, Color(50, 200, 50), TEXT_ALIGN_LEFT)
     end
 end
+
+sound.Add( {
+    name = "ArcCW_Horde.Medic_9mm_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {98, 102},
+    sound = ")weapons/pistol/pistol_fire2.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.Medic_9mm_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")weapons/usp/usp1.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_mp5.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mp5.lua
@@ -3,15 +3,41 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_mp5")
     killicon.Add("arccw_horde_mp5", "arccw/weaponicons/arccw_go_mp5", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_mp5"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "MP5A3"
-SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_mp5.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_mp5.mdl"
 
 SWEP.RecoilPunch = 0
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.MP5_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.MP5_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.MP5_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MP5_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = {107, 113},
+    sound = ")arccw_go/mp5/mp5_unsil.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MP5_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_mp7m.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mp7m.lua
@@ -3,18 +3,19 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_mp7")
     killicon.Add("arccw_horde_mp7m", "arccw/weaponicons/arccw_go_mp7", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_mp7"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
-SWEP.PrintName = "MP7A1 Medic PDW"
-SWEP.Slot = 2
+SWEP.PrintName = "Medic MP7A1"
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_mp7.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_mp7.mdl"
 
-SWEP.Primary.ClipSize = 35 -- DefaultClip is automatically set.
+SWEP.RecoilPunch = 0
 
 SWEP.Firemodes = {
     {
@@ -22,7 +23,30 @@ SWEP.Firemodes = {
     }
 }
 
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.MP7_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.MP7_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.MP7_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MP7_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/mp7/mp7_01.wav",")arccw_go/mp7/mp7_02.wav",")arccw_go/mp7/mp7_03.wav",")arccw_go/mp7/mp7_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MP7_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )
 
 function SWEP:ChangeFiremode(pred)
     if self:GetNextSecondaryFire() > CurTime() then return end
@@ -63,7 +87,7 @@ function SWEP:ChangeFiremode(pred)
         end
     end
 
-    ply:EmitSound("horde/weapons/mp7m/heal.ogg", 125, 100, 1, CHAN_AUTO)
+    ply:EmitSound("horde/weapons/mp7m/heal.ogg", 75, 100, 1, CHAN_WEAPON)
 
     self:SetNextSecondaryFire(CurTime() + 1)
     self:SetNextPrimaryFire(CurTime() + 0.25)
@@ -97,8 +121,6 @@ function SWEP:Hook_DrawHUD()
         local pos = nv_center(self.Horde_HealTarget):ToScreen()
         surface.SetDrawColor(Color(50, 200, 50))
         surface.DrawCircle(pos.x, pos.y, 30)
-        --surface.DrawLine(pos.x, 0, pos.x, ScrH())
-        --surface.DrawLine(0, pos.y, ScrW(), pos.y)
         draw.DrawText(self.Horde_HealTarget:Health(), "Trebuchet24",
         pos.x - 15, pos.y - 15, Color(50, 200, 50), TEXT_ALIGN_LEFT)
     end

--- a/gamemodes/horde/entities/weapons/arccw_horde_mp9m.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mp9m.lua
@@ -3,14 +3,19 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_mp9")
     killicon.Add("arccw_horde_mp9m", "arccw/weaponicons/arccw_go_mp9", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_mp9"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
-SWEP.PrintName = "MP9N Medic PDW"
-SWEP.Trivia_Class = "PDW"
-SWEP.Slot = 2
+SWEP.PrintName = "Medic MP9N"
+
+SWEP.ViewModel = "models/weapons/arccw_go/v_smg_mp9.mdl"
+SWEP.WorldModel = "models/weapons/arccw_go/v_smg_mp9.mdl"
+
+SWEP.RecoilPunch = 0
 
 SWEP.Firemodes = {
     {
@@ -18,13 +23,32 @@ SWEP.Firemodes = {
     }
 }
 
-SWEP.ViewModel = "models/weapons/arccw_go/v_smg_mp9.mdl"
-SWEP.WorldModel = "models/weapons/arccw_go/v_smg_mp9.mdl"
+SWEP.Delay = 60 / 900
 
-SWEP.DamageMin = 13 -- damage done at maximum range
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.MP9_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.MP9_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.MP9_Fire_Sil"
+SWEP.DistantShootSound = ""
 
-SWEP.Delay = 60 / 900 -- 60 / RPM.
-SWEP.ShootVol = 75 -- volume of shoot sound
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MP9_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/mp9/mp9_01.wav",")arccw_go/mp9/mp9_02.wav",")arccw_go/mp9/mp9_03.wav",")arccw_go/mp9/mp9_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.MP9_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )
 
 function SWEP:ChangeFiremode(pred)
     if self:GetNextSecondaryFire() > CurTime() then return end
@@ -65,7 +89,7 @@ function SWEP:ChangeFiremode(pred)
         end
     end
 
-    ply:EmitSound("horde/weapons/mp7m/heal.ogg", 125, 100, 1, CHAN_AUTO)
+    ply:EmitSound("horde/weapons/mp7m/heal.ogg", 75, 100, 1, CHAN_WEAPON)
 
     self:SetNextSecondaryFire(CurTime() + 1)
     self:SetNextPrimaryFire(CurTime() + 0.25)
@@ -99,8 +123,6 @@ function SWEP:Hook_DrawHUD()
         local pos = nv_center(self.Horde_HealTarget):ToScreen()
         surface.SetDrawColor(Color(50, 200, 50))
         surface.DrawCircle(pos.x, pos.y, 30)
-        --surface.DrawLine(pos.x, 0, pos.x, ScrH())
-        --surface.DrawLine(0, pos.y, ScrW(), pos.y)
         draw.DrawText(self.Horde_HealTarget:Health(), "Trebuchet24",
         pos.x - 15, pos.y - 15, Color(50, 200, 50), TEXT_ALIGN_LEFT)
     end

--- a/gamemodes/horde/entities/weapons/arccw_horde_mp9m.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_mp9m.lua
@@ -10,7 +10,7 @@ SWEP.Spawnable = true
 SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
-SWEP.PrintName = "Medic MP9N"
+SWEP.PrintName = "Medic MP9-N"
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_mp9.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_mp9.mdl"

--- a/gamemodes/horde/entities/weapons/arccw_horde_nova.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_nova.lua
@@ -27,7 +27,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.Nova_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.Nova_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.Nova_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -69,13 +69,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = ")arccw_go/m590_suppressed_fp.wav"
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.Nova_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/nova/nova-1-distant.wav"
-
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_p2000.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_p2000.lua
@@ -19,7 +19,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.P2000_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.P2000_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.P2000_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -41,12 +41,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.P2000_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = {98, 101},
-    sound = "arccw_go/hkp2000/hkp2000-1-distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_p250.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_p250.lua
@@ -19,7 +19,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.P250_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.P250_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.P250_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -41,12 +41,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.P250_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = {98, 101},
-    sound = "arccw_go/p250/p250_distant_01.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_p90.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_p90.lua
@@ -3,9 +3,11 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_p90")
     killicon.Add("arccw_horde_p90", "arccw/weaponicons/arccw_go_p90", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_p90"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "P90 TR"
@@ -14,6 +16,33 @@ SWEP.Slot = 2
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_p90.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_p90.mdl"
 
-SWEP.Damage = 41
-SWEP.DamageMin = 30 -- damage done at maximum range
+SWEP.Damage = 42
+SWEP.DamageMin = 30
+SWEP.Penetration = 12
+
 SWEP.RecoilPunch = 0
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.P90_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.P90_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.P90_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.P90_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/p90/p90_01.wav",")arccw_go/p90/p90_02.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.P90_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_r8.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_r8.lua
@@ -22,7 +22,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.R8_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.R8_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.R8_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -62,12 +62,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = ")arccw_go/mosin_suppressed_fp.wav"
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.R8_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/revolver/revolver-1_distant.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_sg556.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_sg556.lua
@@ -3,18 +3,46 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_sg556")
     killicon.Add("arccw_horde_sg556", "arccw/weaponicons/arccw_go_sg556", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_sg556"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "SIG SG556"
-SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_rif_sg556.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_rif_sg556.mdl"
 
 SWEP.Damage = 64
-SWEP.DamageMin = 48  -- damage done at maximum range
+SWEP.DamageMin = 48
+
 SWEP.RecoilPunch = 0
-SWEP.ShootVol = 75 -- volume of shoot sound
+
+SWEP.Delay = 60 / 650
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.SG556_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.SG556_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.SG556_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.SG556_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = {")arccw_go/sg556/sg556_01.wav",")arccw_go/sg556/sg556_02.wav",")arccw_go/sg556/sg556_03.wav",")arccw_go/sg556/sg556_04.wav"}
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.SG556_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/m4a1/m4a1_silencer_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_smg1.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_smg1.lua
@@ -4,10 +4,13 @@ if CLIENT then
     SWEP.WepSelectIconMat = Material("items/hl2/weapon_smg1.png")
     killicon.AddAlias("arccw_horde_smg1", "weapon_smg1")
 end
+
 SWEP.Base = "arccw_base"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
+SWEP.WeaponCamBone = tag_camera
 
 SWEP.PrintName = "SMG-1"
 SWEP.Trivia_Class = "Submachine Gun"
@@ -35,25 +38,23 @@ SWEP.WorldModelOffset = {
 SWEP.DefaultBodygroups = "000000000000"
 
 SWEP.Damage = 25
-SWEP.DamageMin = 10 -- damage done at maximum range
-SWEP.Range = 50 -- in METRES
-SWEP.Penetration = 1
+SWEP.DamageMin = 10
+SWEP.Range = 50
+SWEP.Penetration = 4
 SWEP.DamageType = DMG_BULLET
-SWEP.ShootEntity = nil -- entity to fire, if any
-SWEP.MuzzleVelocity = 1000 -- projectile or phys bullet muzzle velocity
--- IN M/S
-SWEP.ChamberSize = 1 -- how many rounds can be chambered.
-SWEP.Primary.ClipSize = 45 -- DefaultClip is automatically set.
+SWEP.ShootEntity = nil
+
+SWEP.ChamberSize = 0
+SWEP.Primary.ClipSize = 45
 
 SWEP.PhysBulletMuzzleVelocity = 400
 
 SWEP.Recoil = 0.15
-SWEP.RecoilSide = 0.105
-SWEP.RecoilRise = 0.05
-SWEP.RecoilPunch = 1.5
+SWEP.RecoilSide = 0.1
+SWEP.RecoilPunch = 0
 
-SWEP.Delay = 60 / 600 -- 60 / RPM.
-SWEP.Num = 1 -- number of shots per trigger pull.
+SWEP.Delay = 0.08
+SWEP.Num = 1
 SWEP.Firemodes = {
     {
         Mode = 2,
@@ -66,26 +67,14 @@ SWEP.Firemodes = {
     }
 }
 
-SWEP.NPCWeaponType = "weapon_smg1"
-SWEP.NPCWeight = 100
+SWEP.AccuracyMOA = 10
+SWEP.HipDispersion = 300
+SWEP.MoveDispersion = 250
 
-SWEP.AccuracyMOA = -12 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
-SWEP.HipDispersion = 250 -- inaccuracy added by hip firing.
-SWEP.MoveDispersion = 75
+SWEP.Primary.Ammo = "Pistol"
 
-SWEP.Primary.Ammo = "Pistol" -- what ammo type the gun uses
-
-SWEP.ShootVol = 80 -- volume of shoot sound
-SWEP.ShootPitch = 100 -- pitch of shoot sound
-
-SWEP.ShootSound = ")weapons/smg1/smg1_fire1.wav"
-SWEP.DistantShootSound = "^weapons/smg1/npc_smg1_fire1.wav"
-SWEP.ShootSoundSilenced = ")weapons/tmp/tmp-1.wav"
-
-SWEP.MeleeSwingSound = "arccw_go/m249/m249_draw.wav"
-SWEP.MeleeMissSound = "weapons/iceaxe/iceaxe_swing1.wav"
-SWEP.MeleeHitSound = "arccw_go/knife/knife_hitwall1.wav"
-SWEP.MeleeHitNPCSound = "physics/body/body_medium_break2.wav"
+SWEP.ShootSound = "ArcCW_Horde.SMG1_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.SMG1_Fire_Sil"
 
 SWEP.MuzzleEffect = "muzzleflash_smg"
 SWEP.ShellModel = "models/weapons/rifleshell.mdl"
@@ -93,17 +82,17 @@ SWEP.ShellPitch = 100
 SWEP.ShellScale = 0.5
 SWEP.ShellRotateAngle = Angle(0, 180, 0)
 
-SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
-SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
+SWEP.MuzzleEffectAttachment = 1
+SWEP.CaseEffectAttachment = 2
 
 SWEP.SpeedMult = 1
 SWEP.SightedSpeedMult = 0.75
 SWEP.SightTime = 0.275
 
 SWEP.IronSightStruct = {
-    Pos = Vector(0, 0, 0),
+    Pos = Vector(-1, 0, 0.5),
     Ang = Angle(0, 0, 0),
-    Magnification = 1.5,
+    Magnification = 1.25,
     SwitchToSound = "", -- sound that plays when switching to this sight
     ViewModelFOV = 40,
     CrosshairInSights = true
@@ -111,43 +100,23 @@ SWEP.IronSightStruct = {
 
 SWEP.HoldtypeHolstered = "passive"
 SWEP.HoldtypeActive = "smg"
-SWEP.HoldtypeSights = "smg"
+SWEP.HoldtypeSights = "rpg"
 
 SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_SMG1
 
-SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActivePos = Vector(0, -2, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
 
-SWEP.CrouchPos = Vector(-4, 0, -1)
-SWEP.CrouchAng = Angle(0, 0, -10)
+SWEP.HolsterPos = Vector(3, -3, -1)
+SWEP.HolsterAng = Angle(-7, 30, -10)
 
-SWEP.HolsterPos = Vector(3, 3, 0)
-SWEP.HolsterAng = Angle(-7.036, 30.016, 0)
-
-SWEP.BarrelOffsetSighted = Vector(0, 0, -1)
-SWEP.BarrelOffsetHip = Vector(2, 0, -2)
-
-SWEP.CustomizePos = Vector(8, 0, 1)
+SWEP.CustomizePos = Vector(8, -3, 1)
 SWEP.CustomizeAng = Angle(5, 30, 30)
 
 SWEP.BarrelLength = 24
 
-SWEP.AttachmentElements = {
-    ["rail"] = {
-        VMBodygroups = {{ind = 5, bg = 1}},
-        WMBodygroups = {{ind = 5, bg = 1}},
-    },
-}
-
 SWEP.ExtraSightDist = 10
 SWEP.GuaranteeLaser = true
-
-SWEP.WorldModelOffset = {
-    pos = Vector(-14, 6, -4),
-    ang = Angle(-10, 0, 180)
-}
-
-SWEP.MirrorVMWM = false
 
 SWEP.Attachments = {
     {
@@ -214,3 +183,20 @@ function SWEP:DrawWeaponSelection(x, y, w, h, a)
 
     surface.DrawTexturedRect(x, y, w, w / 2)
 end
+
+sound.Add( {
+    name = "ArcCW_Horde.SMG1_Fire",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 90,
+    pitch = {95, 105},
+    sound = ")weapons/smg1/smg1_fire1.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.SMG1_Fire_Sil",
+    channel = CHAN_WEAPON,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")weapons/tmp/tmp-1.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_tec9.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_tec9.lua
@@ -22,7 +22,7 @@ SWEP.RecoilPunch = 0
 
 SWEP.ShootSound = "ArcCW_Horde.GSO.Tec9_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.Tec9_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.Tec9_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -64,12 +64,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.Tec9_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/tec9/tec9_distant_01.wav"
 } )

--- a/gamemodes/horde/entities/weapons/arccw_horde_ump.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_ump.lua
@@ -3,17 +3,44 @@ if CLIENT then
     SWEP.WepSelectIcon = surface.GetTextureID("arccw/weaponicons/arccw_go_ump")
     killicon.Add("arccw_horde_ump", "arccw/weaponicons/arccw_go_ump", Color(0, 0, 0, 255))
 end
+
 SWEP.Base = "arccw_go_ump"
-SWEP.Spawnable = true -- this obviously has to be set to true
-SWEP.Category = "ArcCW - Horde" -- edit this if you like
+
+SWEP.Spawnable = true
+SWEP.Category = "ArcCW - Horde"
 SWEP.AdminOnly = false
 
 SWEP.PrintName = "UMP-45"
-SWEP.Slot = 2
 
 SWEP.ViewModel = "models/weapons/arccw_go/v_smg_ump45.mdl"
 SWEP.WorldModel = "models/weapons/arccw_go/v_smg_ump45.mdl"
 
 SWEP.Damage = 38
-SWEP.DamageMin = 27 -- damage done at maximum range
+SWEP.DamageMin = 28
+
 SWEP.RecoilPunch = 0
+
+SWEP.FirstShootSound = "ArcCW_Horde.GSO.UMP_Fire"
+SWEP.ShootSound = "ArcCW_Horde.GSO.UMP_Fire"
+SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.UMP_Fire_Sil"
+SWEP.DistantShootSound = ""
+
+SWEP.ActivePos = Vector(0, 0, 0)
+SWEP.ActiveAng = Angle(0, 0, 0)
+
+sound.Add( {
+    name = "ArcCW_Horde.GSO.UMP_Fire",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 90,
+    pitch = 100,
+    sound = ")arccw_go/ump45/ump45_02.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.UMP_Fire_Sil",
+    channel = CHAN_STATIC,
+    volume = 1.0,
+    level = 75,
+    pitch = 100,
+    sound = ")arccw_go/mp5/mp5_01.wav"
+} )

--- a/gamemodes/horde/entities/weapons/arccw_horde_usp.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_usp.lua
@@ -20,7 +20,7 @@ SWEP.RecoilPunch = 0
 SWEP.FirstShootSound = "ArcCW_Horde.GSO.USP_Fire"
 SWEP.ShootSound = "ArcCW_Horde.GSO.USP_Fire"
 SWEP.ShootSoundSilenced = "ArcCW_Horde.GSO.USP_Fire_Sil"
-SWEP.DistantShootSound = "ArcCW_Horde.GSO.USP_Fire_Dist"
+SWEP.DistantShootSound = ""
 
 SWEP.ActivePos = Vector(0, 0, 0)
 SWEP.ActiveAng = Angle(0, 0, 0)
@@ -42,12 +42,4 @@ sound.Add( {
     level = 75,
     pitch = 100,
     sound = {")arccw_go/usp/usp_01.wav",")arccw_go/usp/usp_02.wav",")arccw_go/usp/usp_03.wav"}
-} )
-sound.Add( {
-    name = "ArcCW_Horde.GSO.USP_Fire_Dist",
-    channel = CHAN_WEAPON,
-    volume = 0.25,
-    level = 140,
-    pitch = 100,
-    sound = "arccw_go/usp/usp_unsil-1-distant.wav"
 } )

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -564,13 +564,13 @@ function HORDE:GetDefaultItemsData()
         "MP5K-PDW.\nA more compact MP5 equipped with a healing dart launcher.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 0.8 second cooldown.",
         { Medic = true, Hatcher = true },
         8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
-    HORDE:CreateItem( "SMG", "MP9 Medic PDW", "arccw_horde_mp9m", 2500, 4,
+    HORDE:CreateItem( "SMG", "Medic MP9-N", "arccw_horde_mp9m", 2500, 4,
         "Brügger & Thomet MP9.\nManufactured in Switzerland,\nthe MP9 is favored by private security firms world-wide.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
-        { Medic = true, Hatcher = true },
+        { Reverend = true, Medic = true, Hatcher = true },
         8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
-    HORDE:CreateItem( "SMG", "MP7A1 Medic PDW", "arccw_horde_mp7m", 2500, 4,
+    HORDE:CreateItem( "SMG", "Medic MP7A1", "arccw_horde_mp7m", 2500, 4,
         "A modified version of the MP7A1 for medical purposes.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 10 health and has a 1 second cooldown.",
-        { Medic = true, Hatcher = true },
+        { Reverend = true, Medic = true, Hatcher = true },
         8, -1, nil, nil, nil, nil, { HORDE.DMG_BALLISTIC, HORDE.DMG_POISON } )
     HORDE:CreateItem( "SMG", "Vector Medic PDW", "arccw_horde_vector", 3000, 5,
         "KRISS Vector Gen I equipped with a medical dart launcher.\nUses an unconventional blowback system that provides a high firerate with low recoil.\n\nPress B or ZOOM to fire healing darts.\nHealing dart heals 20 health and has a 1.5 second cooldown.",


### PR DESCRIPTION
## Changes (SMGs, ARs, SMG-1, 9mm)
- Removed recoil punch for SMGs that still had it.
- Improved SMG-1 and 9mm functionality.
- Improved sounds.
- Removed most bulk within certain weapon files.
- Improved viewmodel positions.
- Fixed floating SMG-1.
- Removed the ability to attach foregrips to the Bizon.
- Increased penetration values for the Five-Seven and P90.

## Reverend.
- Added Medic MP7A1 and MP9-N to Reverend subclass.

Per results of the "Should Medic SMGs be added to Reverend?" (9/14/2025) poll hosted by JessiPepsi.

## General
- Removed distant sounds from playing.

This is because due to how Source networks sounds in multiplayer, it ends up being that player made sounds far away do not play, for this reason I removed the distant sounds from the recently updated GSO weapons to remove bulk.