### PR TITLE
Gives perks 1 wave earlier

### DIFF
--- a/gamemodes/horde/gamemode/sh_horde.lua
+++ b/gamemodes/horde/gamemode/sh_horde.lua
@@ -33,7 +33,7 @@ CreateConVar("horde_disable_difficulty_voting", 0, nil, "Disable difficulty voti
 CreateConVar("horde_endless", 0, FCVAR_ARCHIVE, "Endless.")
 CreateConVar("horde_total_enemies_scaling", 0, nil, "Forces the gamemode to multiply maximum enemy count by this.")
 
-CreateConVar("horde_perk_start_wave", 1, FCVAR_REPLICATED, "The wave when Tier 1 perks are active.")
+CreateConVar("horde_perk_start_wave", 0, FCVAR_REPLICATED, "The wave when Tier 1 perks are active.")
 CreateConVar("horde_perk_scaling", 2, FCVAR_REPLICATED, "The multiplier to the level for which wave it is unlocked. e.g. at 1.5, perk level 4 is unlocked at start_wave + 6.", 0)
 
 CreateConVar("horde_enable_starter", 1, FCVAR_ARCHIVE + FCVAR_REPLICATED, "Enables starter weapons.")


### PR DESCRIPTION
Incredibly simple number change so people get their perks one wave earlier than before as requested.
players now start with their first set of perks unlocked.

Perk waves before 2, 4, 6, 8
Perk waves now 1, 3, 4, 7