### PR TITLE
added taser

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_taser.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_taser.lua
@@ -1,0 +1,207 @@
+if not ArcCWInstalled then return end
+if CLIENT then
+    SWEP.WepSelectIcon = surface.GetTextureID( "arccw/weaponicons/arccw_go_taser" )
+    killicon.Add( "arccw_horde_taser", "arccw/weaponicons/arccw_go_taser", Color( 0, 0, 0, 255 ) )
+end
+
+SWEP.Base = "arccw_go_taser"
+SWEP.Spawnable = true -- this obviously has to be set to true
+SWEP.Category = "ArcCW - Horde"
+SWEP.AdminOnly = false
+
+SWEP.PrintName = "M26 Stunner"
+SWEP.Trivia_Class = "Stun Gun"
+SWEP.Trivia_Desc = "Less-lethal weapon designed to incapacitate attackers with a high voltage electric shock. Pissed off bank robbers and cool helmet not included.\nRecharges after each shot, if the battery is completely discharged, it'll be unable to fire until it fully charges."
+SWEP.Trivia_Manufacturer = "klAxon"
+SWEP.Trivia_Calibre = "Taser Cartridge M26"
+SWEP.Trivia_Mechanism = "Compressed CO2"
+SWEP.Trivia_Country = "USA"
+SWEP.Trivia_Year = 1999
+
+SWEP.Slot = 1
+
+SWEP.UseHands = true
+
+SWEP.ViewModel = "models/weapons/arccw_go/v_eq_taser.mdl"
+SWEP.WorldModel = "models/weapons/arccw_go/v_eq_taser.mdl"
+SWEP.ViewModelFOV = 60
+
+SWEP.DefaultBodygroups = "000000000000"
+
+SWEP.Damage = 10
+SWEP.DamageMin = 0 -- damage done at maximum range
+SWEP.RangeMin = 6
+SWEP.Range = 6 -- in METRES
+SWEP.Penetration = 0
+SWEP.DamageType = DMG_SHOCK
+
+SWEP.Primary.ClipSize = 100 -- DefaultClip is automatically set.
+SWEP.Primary.MaxAmmo = -1
+SWEP.ForceDefaultAmmo = -1
+SWEP.RegenerationTimer = CurTime()
+SWEP.AmmoRegenAmount = 1
+SWEP.AmmoPerShot = 50
+SWEP.AlwaysPhysBullet = false
+SWEP.TracerNum = 0
+
+SWEP.Recoil = 1.5
+SWEP.RecoilSide = 0.1
+SWEP.RecoilRise = 0.1
+SWEP.RecoilPunch = 0
+
+SWEP.Delay = 60 / 80 -- 60 / RPM.
+SWEP.Num = 1 -- number of shots per trigger pull.
+SWEP.Firemodes = {
+    {
+        Mode = 1,
+        PrintName = "SNGL"
+    },
+    {
+        Mode = 0
+    }
+}
+
+SWEP.AccuracyMOA = 1 -- accuracy in Minutes of Angle. There are 60 MOA in a degree.
+SWEP.HipDispersion = 1 -- inaccuracy added by hip firing.
+SWEP.MoveDispersion = 1
+
+SWEP.Primary.Ammo = "XBowBoltHL1"
+
+SWEP.Disposable = false -- when all ammo is expended, the gun will remove itself when holstered
+SWEP.DoNotEquipmentAmmo = true
+SWEP.AutoReload = true
+
+SWEP.ShootSound = "arccw_go/taser/taser_shoot.wav"
+
+SWEP.MeleeSwingSound = "arccw_go/m249/m249_draw.wav"
+SWEP.MeleeMissSound = "weapons/iceaxe/iceaxe_swing1.wav"
+SWEP.MeleeHitSound = "arccw_go/knife/knife_hitwall1.wav"
+SWEP.MeleeHitNPCSound = "physics/body/body_medium_break2.wav"
+
+SWEP.SpeedMult = 1
+SWEP.SightedSpeedMult = 0.75
+SWEP.SightTime = 0.2
+SWEP.ShootWhileSprint = true
+SWEP.AnimShoot = ACT_HL2MP_GESTURE_RANGE_ATTACK_PISTOL
+
+SWEP.ActivePos = Vector(-1, 2, -1)
+SWEP.ActiveAng = Angle(0, 0, 0)
+SWEP.RejectAttachments = {["go_perk_fastreload"] = true, ["go_perk_cowboy"] = true}
+SWEP.Discharged = false
+
+if SERVER then
+    SWEP.Hook_BulletHit = function( wep, data )
+        local att = data.att
+        local tr = data.tr
+        local entHit = tr.Entity
+        local bulletDmg = data.damage
+
+        if HORDE:IsEnemy( entHit ) then
+            entHit:Horde_AddDebuffBuildup( HORDE.Status_Stun, bulletDmg * 10, att )
+            if bulletDmg >= 1 then
+            entHit:EmitSound("ArcCW_Horde.GSO.TASER.Hit")
+            end
+        end
+    end
+end
+
+SWEP.Hook_OnDeploy = function( wep )
+
+    if not wep.Discharged then
+        wep.RegenerationTimer = CurTime() + 0.1
+    end
+
+    if wep.HolsterTime then
+        local ammoCount = math.floor( ( CurTime() - wep.HolsterTime ) * wep.AmmoRegenAmount )
+        wep:SetClip1( math.min( wep:Clip1() + ammoCount, wep.Primary.ClipSize ) )
+    end
+end
+
+SWEP.Hook_OnHolster = function( wep )
+    if not wep.Discharged then
+        wep.RegenerationTimer = CurTime()
+    end
+    wep.HolsterTime = CurTime()
+end
+
+SWEP.Hook_Think = function( wep )
+
+    if wep.RegenerationTimer <= CurTime() and wep:Clip1() < wep.Primary.ClipSize then
+        wep:SetClip1( wep:Clip1() + wep.AmmoRegenAmount )
+        wep.RegenerationTimer = CurTime() + 0.1
+    end
+
+    if wep:Clip1() > wep.Primary.ClipSize then
+        wep:SetClip1( wep.Primary.ClipSize )
+    end
+
+    if wep:Clip1() <= 15 and not wep.Discharged then
+        wep.Discharged = true
+        wep:EmitSound( "ArcCW_Horde.GSO.TASER.Discharged" )
+        wep.RegenerationTimer = CurTime() + 3
+    end
+
+    if wep:Clip1() >= 100 and wep.Discharged then
+        wep.Discharged = false
+         wep:EmitSound( "ArcCW_Horde.GSO.TASER.Recharged" )
+    end
+end
+
+SWEP.Hook_PostFireBullets = function( wep )
+    wep.RegenerationTimer = CurTime() + 0.1
+end
+
+SWEP.Hook_ShouldNotSight = function( wep )
+    local notSprinting
+
+    if  wep:GetState() == ArcCW.STATE_SPRINT then
+        notSprinting = true
+    elseif wep:GetState() ~= ArcCW.STATE_SPRINT then
+        notSprinting = false
+    end
+    return notSprinting
+end
+
+SWEP.Hook_ShouldNotFire = function( wep )
+    local canFire
+
+    if wep.Discharged then
+        canFire = true
+    elseif not wep.Discharged then
+        canFire = false
+    end
+    return canFire
+end
+
+
+
+sound.Add({
+    name = "ARCCW_GO_TASER.Draw",
+    channel = 16,
+    volume = 1.0,
+    sound = "arccw_go/glock18/glock_draw.wav"
+})
+sound.Add( {
+    name = "ArcCW_Horde.GSO.TASER.Discharged",
+    channel = CHAN_STATIC,
+    volume = 1.5,
+    level = 70,
+    pitch = {100, 100},
+    sound = ")arccw_go/sensorgrenade/sensor_arm.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.TASER.Recharged",
+    channel = CHAN_STATIC,
+    volume = 1.5,
+    level = 70,
+    pitch = {98, 101},
+    sound = ")arccw_go/sensorgrenade/sensor_detect.wav"
+} )
+sound.Add( {
+    name = "ArcCW_Horde.GSO.TASER.Hit",
+    channel = CHAN_STATIC,
+    volume = 1.2,
+    level = 80,
+    pitch = {74, 76},
+    sound = ")arccw_go/taser/taser_hit.wav"
+} )

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -1142,7 +1142,7 @@ Hysteria lasts for 5 seconds and falls off sequentially.]],
     HORDE:CreateItem( "Equipment", "M26 Stunner", "arccw_horde_taser", 1500, 0,
         "A Taser that stuns a single target for 3 seconds.\nStun cooldown is 10 seconds. \nRecharges after each shot, if the battery is completely discharged,\nit'll be unable to fire until it fully recharges.",
        { Assault = true, Engineer = true, Hatcher = true, Ghost = true, SpecOps = true, Reverend = true, Warden = true },
-        100, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_SHOCK } )
 
     HORDE:GetDefaultGadgets()
     HORDE:GetDefaultItemInfusions()

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -1139,6 +1139,11 @@ Hysteria lasts for 5 seconds and falls off sequentially.]],
         "Distinguished Cremator armor.\n\nFills up 100% of your armor bar.\nProvides 8% increased Fire damage resistance.",
         { Cremator = true },
         10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_cremator.png", { Cremator = 30 }, 1 )
+    HORDE:CreateItem( "Equipment", "M26 Stunner", "arccw_horde_taser", 1500, 0,
+        "A Taser that stuns a single target for 3 seconds.\nStun cooldown is 10 seconds. \nRecharges after each shot, if the battery is completely discharged,\nit'll be unable to fire until it fully recharges.",
+       -- { Assault = true, Engineer = true, Hatcher = true, Ghost = true, SpecOps = true, Reverend = true, }, --intended recipiants so far
+             { Survivor = true, Psycho = true, Prototype = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Overlord = true, Cremator = true, Carcass = true, Warlock = true, Artificer = true, Necromancer = true }, -- temporary nuclear approach suggested by Jessi
+        100, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
 
     HORDE:GetDefaultGadgets()
     HORDE:GetDefaultItemInfusions()

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -1141,8 +1141,7 @@ Hysteria lasts for 5 seconds and falls off sequentially.]],
         10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_cremator.png", { Cremator = 30 }, 1 )
     HORDE:CreateItem( "Equipment", "M26 Stunner", "arccw_horde_taser", 1500, 0,
         "A Taser that stuns a single target for 3 seconds.\nStun cooldown is 10 seconds. \nRecharges after each shot, if the battery is completely discharged,\nit'll be unable to fire until it fully recharges.",
-       -- { Assault = true, Engineer = true, Hatcher = true, Ghost = true, SpecOps = true, Reverend = true, }, --intended recipiants so far
-             { Survivor = true, Psycho = true, Prototype = true, Assault = true, SpecOps = true, Reverend = true, Heavy = true, Juggernaut = true, Medic = true, Hatcher = true, Demolition = true, Ghost = true, Gunslinger = true, Engineer = true, Berserker = true, Samurai = true, ["Cyborg Ninja"] = true, Warden = true, Overlord = true, Cremator = true, Carcass = true, Warlock = true, Artificer = true, Necromancer = true }, -- temporary nuclear approach suggested by Jessi
+       { Assault = true, Engineer = true, Hatcher = true, Ghost = true, SpecOps = true, Reverend = true, },
         100, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
 
     HORDE:GetDefaultGadgets()

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -1141,7 +1141,7 @@ Hysteria lasts for 5 seconds and falls off sequentially.]],
         10, -1, { type = HORDE.ENTITY_PROPERTY_ARMOR, armor = 100 }, "items/armor_cremator.png", { Cremator = 30 }, 1 )
     HORDE:CreateItem( "Equipment", "M26 Stunner", "arccw_horde_taser", 1500, 0,
         "A Taser that stuns a single target for 3 seconds.\nStun cooldown is 10 seconds. \nRecharges after each shot, if the battery is completely discharged,\nit'll be unable to fire until it fully recharges.",
-       { Assault = true, Engineer = true, Hatcher = true, Ghost = true, SpecOps = true, Reverend = true, },
+       { Assault = true, Engineer = true, Hatcher = true, Ghost = true, SpecOps = true, Reverend = true, Warden = true },
         100, -1, nil, nil, nil, nil, { HORDE.DMG_BLAST } )
 
     HORDE:GetDefaultGadgets()


### PR DESCRIPTION
M26 Stunner
• Equipment tab, costs $1,500 and its weight is 0
• deals 10 damage within 6 meters
• can stun a single target within 6 meters
• has a battery size of 100%, each shot uses 50%, if the battery goes below 15% the taser can't be fired until it recharges to 100% 
• 80 rpm
• can be fired while sprinting but can't ads while sprinting (not that it really matters) • plays a sound when a target is hit and dealt damage
• plays a sound when the battery is discharged (15% and below) and plays a sound when it recharges to 100% after being discharged

• temporarily available for all classes until field data is gathered (yes, even casters, its quite a nuclear approach but Jessi suggested it so we'll see what happens), there's a commented out list of classes that are intended to be able to access it so far, but it'll prolly change (or not) after we open pandora's stun gun