### PR TITLE
nerf melee range on eschar

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_horde_eschar/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_horde_eschar/init.lua
@@ -14,6 +14,8 @@ ENT.BloodColor = "Red"
 
 ENT.HasMeleeAttack = true
 ENT.AnimTbl_MeleeAttack = { ACT_MELEE_ATTACK1 }
+ENT.MeleeAttackDistance = 32
+ENT.MeleeAttackDamageDistance = 50
 ENT.TimeUntilMeleeAttackDamage = 0.2
 ENT.NextAnyAttackTime_Melee = 0.5
 


### PR DESCRIPTION
nerfed the melee range on the eschar cause it used the default value of 60 defined in npc_vj_creature_base.lua, and it outranged carcass's melee, essentially requiring you to get hit to even get a hit in, if you can land it without the viewpunch from the hit screwing you over