### PR TITLE
carcass buffs and tweaks

### DIFF
--- a/gamemodes/horde/entities/effects/horde_twin_heart.lua
+++ b/gamemodes/horde/entities/effects/horde_twin_heart.lua
@@ -1,0 +1,49 @@
+function EFFECT:Init(data)
+    local radius = data:GetRadius()
+
+    local emitter = ParticleEmitter(data:GetOrigin())
+    local emitter2 = ParticleEmitter(data:GetOrigin(), true)
+    emitter2:SetNearClip(24, 32)
+    for i = 1,10 do
+        local smoke = emitter:Add("particles/smokey", data:GetOrigin())
+        smoke:SetGravity(Vector(0,0,-800))
+        smoke:SetDieTime(radius / 225)
+        smoke:SetStartAlpha(120)
+        smoke:SetEndAlpha(0)
+        smoke:SetStartSize(4)
+        smoke:SetEndSize(radius * math.random(0.5,1))
+        smoke:SetRoll( math.Rand(-180, 180) )
+        smoke:SetRollDelta( math.Rand(-0.2,0.2) )
+        smoke:SetColor(200, 50, 50)
+        smoke:SetAirResistance(0)
+        local p = VectorRand() * 50
+        p.z = 0
+        smoke:SetPos( data:GetOrigin() + p)
+        smoke:SetLighting( false )
+        smoke:SetCollide(true)
+        smoke:SetBounce(0)
+    end
+    emitter:Finish()
+
+    local normal = Vector(0,0,1)
+    local ringstart = data:GetOrigin() + normal * 10
+    local particle
+    for i = 1, 2 do
+        particle = emitter2:Add("effects/select_ring", ringstart)
+        particle:SetDieTime(0.5 + i * 0.2)
+        particle:SetColor(200, 50, 50)
+        particle:SetStartAlpha(255)
+        particle:SetEndAlpha(0)
+        particle:SetStartSize(0)
+        particle:SetEndSize(radius)
+        particle:SetAngles(normal:Angle())
+    end
+    emitter2:Finish()
+end
+
+function EFFECT:Think()
+return false
+end
+
+function EFFECT:Render()
+end

--- a/gamemodes/horde/entities/entities/horde_aas_perfume/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_aas_perfume/shared.lua
@@ -24,9 +24,6 @@ AddCSLuaFile()
 function ENT:Initialize()
     if SERVER then
         self:SetModel( self.Model )
-        self:SetMoveType( MOVETYPE_VPHYSICS )
-        self:SetSolid( SOLID_VPHYSICS )
-        self:PhysicsInit(SOLID_VPHYSICS)
         self:DrawShadow( false )
         self:SetCollisionBounds(Vector(-150,-150,-100), Vector(150,150,100))
         self:SetTrigger(true)
@@ -42,17 +39,10 @@ function ENT:Initialize()
         self:Detonate()
 
         self.FireTime = math.Rand(4.5, 5.5)
-
-        timer.Simple(0.1, function()
-            if !IsValid(self) then return end
-            self:SetCollisionGroup(COLLISION_GROUP_PROJECTILE)
+        timer.Simple(0, function()
+            if not IsValid(self) then return end
+            self:SetCollisionGroup(COLLISION_GROUP_PLAYER_MOVEMENT)
         end)
-    end
-
-    local owner = self:GetOwner()
-    self.has_burner = nil
-    if owner and owner:Horde_GetGadget() == "gadget_hydrogen_burner" then
-        self.has_burner = true
     end
 end
 
@@ -68,13 +58,13 @@ local function GetFireParticle()
 end
 
 function ENT:Think()
-    if !self.SpawnTime then self.SpawnTime = CurTime() end
+    if not self.SpawnTime then self.SpawnTime = CurTime() end
 
     if CLIENT then
         local emitter = ParticleEmitter(self:GetPos())
 
-        if !self:IsValid() or self:WaterLevel() > 2 then return end
-        if !IsValid(emitter) then return end
+        if not self:IsValid() or self:WaterLevel() > 2 then return end
+        if not IsValid(emitter) then return end
 
         for i = 1,10 do
             local fire = emitter:Add(GetFireParticle(), self:GetPos() + (VectorRand() * 30))
@@ -97,7 +87,7 @@ function ENT:Think()
             fire:SetBounce(0.75)
             fire:SetNextThink( CurTime() + FrameTime() )
             fire:SetThinkFunction( function(pa)
-                if !pa then return end
+                if not pa then return end
                 local col1 = Color(255,105,180, 255)
                 local col2 = Color(255,255,255, 0)
 
@@ -118,19 +108,19 @@ function ENT:Think()
         self.Ticks = self.Ticks + 1
     else
 
-        if self:GetVelocity():LengthSqr() <= 32 then
-            self:SetMoveType( MOVETYPE_NONE )
-        end
-
         if self.NextDamageTick > CurTime() then return end
+        local ply = self:GetOwner()
         for _, ent in pairs(ents.FindInSphere(self:GetPos(), 200)) do
             if ent:IsPlayer() then
                 ent:Horde_AddHypertrophyStack(true)
             end
+            if IsValid( ent ) and HORDE:IsEnemy( ent ) then
+            ent:Horde_AddWeaken(ply, ply:Horde_GetApplyDebuffDuration(), ply:Horde_GetApplyDebuffMore())
+            end
         end
 
         local dmg = DamageInfo()
-        dmg:SetAttacker(self.Owner)
+        dmg:SetAttacker(ply)
         dmg:SetInflictor(self)
         dmg:SetDamageType(DMG_NERVEGAS)
         dmg:SetDamage(50)
@@ -146,7 +136,7 @@ function ENT:Think()
 end
 
 function ENT:OnRemove()
-    if !self.FireSound then return end
+    if not self.FireSound then return end
     self.FireSound:Stop()
 
     if SERVER then
@@ -157,33 +147,26 @@ function ENT:OnRemove()
 end
 
 function ENT:Detonate()
-    if !self:IsValid() then return end
-
+    if not self:IsValid() then return end
+        timer.Simple(0.01, function()
+            if not IsValid(self) then return end
+                self:SetMoveType(MOVETYPE_NONE)
+        end)
     self.Armed = true
 
     if self.Order and self.Order != 1 then return end
 
-    --self.FireSound = CreateSound(self, "arccw_go/Perfume/fire_loop_1.wav")
-    --self.FireSound:Play()
-
-    --self.FireSound:ChangePitch(80, self.FireTime)
-
     timer.Simple(self.FireTime - 1, function()
-        if !IsValid(self) then return end
+        if not IsValid(self) then return end
 
-        --self.FireSound:ChangeVolume(0, 1)
     end)
 
     timer.Simple(self.FireTime, function()
-        if !IsValid(self) then return end
+        if not IsValid(self) then return end
 
         self:Remove()
     end)
 end
 
 function ENT:Draw()
-    -- cam.Start3D() -- Start the 3D function so we can draw onto the screen.
-    --     render.SetMaterial( GetFireParticle() ) -- Tell render what material we want, in this case the flash from the gravgun
-    --     render.DrawSprite( self:GetPos(), math.random(200, 250), math.random(200, 250), Color(255, 255, 255) ) -- Draw the sprite in the middle of the map, at 16x16 in it's original colour with full alpha.
-    -- cam.End3D()
 end

--- a/gamemodes/horde/entities/weapons/horde_carcass.lua
+++ b/gamemodes/horde/entities/weapons/horde_carcass.lua
@@ -1,7 +1,7 @@
 
 AddCSLuaFile()
 if CLIENT then
-    killicon.Add("horde_carcass", "vgui/hud/punch", Color(0, 0, 0, 255))
+	killicon.Add("horde_carcass", "vgui/hud/punch", Color(0, 0, 0, 255))
 end
 
 SWEP.PrintName = "Carcass Biosystem"
@@ -30,7 +30,7 @@ SWEP.Secondary.Ammo = "none"
 
 SWEP.DrawAmmo = false
 
-SWEP.HitDistance = 90
+SWEP.HitDistance = 100
 
 SWEP.Charging = 0
 SWEP.ChargingTimer = 0
@@ -39,17 +39,18 @@ SWEP.Charged = 0
 SWEP.Delay = 0.4
 SWEP.DrainInterval = 0.1
 SWEP.LastDrain = CurTime()
-SWEP.BaseDamage = 20
+SWEP.BaseDamage = 35
 SWEP.TransferInterval = 0.1
 SWEP.LastTransfer = CurTime()
+SWEP.LastPulse = CurTime()
 SWEP.ToggleInterval = 0.5
 SWEP.LastToggle = CurTime()
 SWEP.ThrustInterval = 1
 SWEP.LastThrust = CurTime()
+SWEP.Grapper = CurTime()
 
-local sndPowerUp		= Sound("horde/player/carcass/intestine_throw.ogg")
-local sndPowerDown		= Sound("horde/player/carcass/intestine_throw.ogg")
-local sndTooFar			= Sound("buttons/button10.wav")
+local sndPowerUp = Sound("horde/player/carcass/intestine_throw.ogg")
+local sndTooFar	= Sound("buttons/button10.wav")
 local SwingSound = Sound( "WeaponFrag.Throw" )
 local HitSound = Sound( "Flesh.ImpactHard" )
 local pull = false
@@ -71,26 +72,24 @@ function SWEP:SetupDataTables()
 end
 
 function SWEP:SecondaryAttack()
-
 end
 
 function SWEP:UpdateNextIdle()
 
-	local vm = self.Owner:GetViewModel()
+	local vm = self:GetOwner():GetViewModel()
 	self:SetNextIdle( CurTime() + vm:SequenceDuration() / vm:GetPlaybackRate() )
 
 end
 
 function SWEP:PrimaryAttack()
 	self:SetNextPrimaryFire( CurTime() + self.Delay )
-
 	self.Charging = 1
 	self.ChargingTimer = CurTime() + 0.5
+
 end
 
 function SWEP:Punch(charged)
 	self.Charged = charged
-	self.Owner:SetAnimation( PLAYER_ATTACK1 )
 
 	local anim = "fists_left"
 	local right = math.random(0,1)
@@ -103,7 +102,7 @@ function SWEP:Punch(charged)
 		anim = "fists_uppercut"
 	end
 
-	local vm = self.Owner:GetViewModel()
+	local vm = self:GetOwner():GetViewModel()
 	vm:SendViewModelMatchingSequence( vm:LookupSequence( anim ) )
 
 	self:EmitSound( SwingSound )
@@ -121,7 +120,7 @@ function SWEP:DealDamage()
 
 	if SERVER then
 		local level = owner:Horde_GetUpgrade("horde_carcass")
-		self.BaseDamage = 25 + 8 * level
+		self.BaseDamage = 35 + (9 * level)
 	end
 
 	local anim = self:GetSequenceName(owner:GetViewModel():GetSequence())
@@ -135,7 +134,7 @@ function SWEP:DealDamage()
 		mask = MASK_SHOT_HULL
 	} )
 
-	if ( !IsValid( tr.Entity ) ) then
+	if ( not IsValid( tr.Entity ) ) then
 		tr = util.TraceHull( {
 			start = owner:GetShootPos(),
 			endpos = owner:GetShootPos() + owner:GetAimVector() * self.HitDistance,
@@ -149,7 +148,7 @@ function SWEP:DealDamage()
 	local hitent = tr.Entity
 
 	-- We need the second part for single player because SWEP:Think is ran shared in SP
-	if ( tr.Hit && !( game.SinglePlayer() && CLIENT ) ) then
+	if ( tr.Hit and not ( game.SinglePlayer() and CLIENT ) ) then
 		self:EmitSound( HitSound )
 	end
 
@@ -161,9 +160,9 @@ function SWEP:DealDamage()
 	local hit = false
 	local scale = phys_pushscale:GetFloat()
 
-	if ( SERVER && IsValid( hitent ) && ( hitent:IsNPC() || hitent:IsPlayer() || hitent:Health() > 0 ) ) then
+	if ( SERVER and IsValid( hitent ) and ( hitent:IsNPC() or hitent:IsPlayer() or hitent:Health() > 0 ) ) then
 		local attacker = owner
-		if ( !IsValid( attacker ) ) then attacker = self end
+		if ( not IsValid( attacker ) ) then attacker = self end
 
 		local dmginfo = DamageInfo()
 		dmginfo:SetDamage(self.BaseDamage)
@@ -176,17 +175,25 @@ function SWEP:DealDamage()
 		if self.Charged == 1 then
 			dmginfo:ScaleDamage(2)
 		end
-		if owner:Horde_GetPerk("carcass_reinforced_arms") then
-			bonus.more = bonus.more * math.max(1, owner:GetVelocity():Length() / 180)
-		end
 		if owner.Horde_Bio_Thruster_Stack and owner.Horde_Bio_Thruster_Stack > 0 then
 			bonus.increase = bonus.increase + owner.Horde_Bio_Thruster_Stack * 0.1
+		end
+
+		local grappendix = owner:Horde_GetPerk("carcass_grappendix")
+		local vel = owner:GetVelocity():Length()
+		if grappendix and vel >= 400 and owner:Horde_GetGadget() ~= "gadget_exoskeleton" then
+			bonus.more = bonus.more * math.min(20, vel / 100)
+		elseif grappendix and vel >= 400 and ((vel < 1000) or (vel > 1020 )) and owner:Horde_GetGadget() == "gadget_exoskeleton" then
+			bonus.more = bonus.more * math.min(20, owner:GetVelocity():Length() / 100)
+		elseif owner:GetVelocity():Length() >= 350 then
+			bonus.more = bonus.more * math.max(1, owner:GetVelocity():Length() / 180)
 		end
 
 		dmginfo:ScaleDamage((1 + bonus.increase) * bonus.more)
 
 		local uppercut = false
 		local reinforced = owner:Horde_GetPerk("carcass_reinforced_arms")
+		local lvl = owner:Horde_GetUpgrade("horde_carcass")
 		local vmult = math.max(1, owner:GetVelocity():Length() / 180)
 		if anim == "fists_left" then
 			dmginfo:SetDamageForce(owner:GetRight() * 4912 * scale + owner:GetForward() * 9998 * scale) -- Yes we need those specific numbers
@@ -204,7 +211,7 @@ function SWEP:DealDamage()
 
 		if uppercut then
 			local pos, damage = dmginfo:GetDamagePosition(), dmginfo:GetDamage() / 2
-
+			local lvlmult = 5 * lvl
 			local dmg = DamageInfo()
 			dmg:SetAttacker(attacker)
 			dmg:SetInflictor(hitent)
@@ -214,7 +221,7 @@ function SWEP:DealDamage()
 			dmg:SetDamagePosition(pos)
 			dmg:SetDamageCustom(HORDE.DMG_SPLASH)
 
-			util.BlastDamageInfo(dmg, pos, 140 * (reinforced and vmult or 1))
+			util.BlastDamageInfo(dmg, pos, (( 140 or ( reinforced and 200 )) + lvlmult) * ( vmult or 1 ))
 		end
 
 		SuppressHostEvents( NULL ) -- Let the breakable gibs spawn in multiplayer on client
@@ -232,7 +239,7 @@ function SWEP:DealDamage()
 	end
 
 	if ( SERVER ) then
-		if ( hit && anim != "fists_uppercut" ) then
+		if ( hit and anim ~= "fists_uppercut" ) then
 			self:SetCombo( self:GetCombo() + 1 )
 		else
 			self:SetCombo( 0 )
@@ -244,79 +251,77 @@ function SWEP:DealDamage()
 end
 
 function SWEP:OnDrop()
-
 	self:Remove() -- You can't drop fists
-
 end
 
 function SWEP:Reload()
 	if CLIENT then return end
-	HORDE:UsePerkSkill(self.Owner)
+	HORDE:UsePerkSkill(self:GetOwner())
 end
 
 function SWEP:TwinHeart()
 	if self.LastToggle > CurTime() then return end
 	self.LastToggle = CurTime() + self.ToggleInterval
-	local ply = self.Owner
+	local ply = self:GetOwner()
 	if ply.Horde_TwinHeartStack <= 0 then
 		ply.TwinHeartToggleOn = false
 		return
 	end
 
 	if ply.TwinHeartToggleOn then
-	ply:EmitSound("items/suitchargeno1.wav")
+		ply:EmitSound("items/suitchargeno1.wav")
 	else
-	ply:EmitSound("buttons/combine_button5.wav")
+		ply:EmitSound("buttons/combine_button5.wav")
 	end
 
-	ply.TwinHeartToggleOn = !ply.TwinHeartToggleOn
+	ply.TwinHeartToggleOn = not ply.TwinHeartToggleOn
 end
 
 function SWEP:AAS_Perfume()
-	local ply = self.Owner
+	local ply = self:GetOwner()
 	local rocket = ents.Create("projectile_horde_aas_perfume")
-    local vel = 2000
-    local ang = ply:EyeAngles()
+	local vel = 2000
+	local ang = ply:EyeAngles()
 
-    local src = ply:GetPos() + Vector(0,0,50) + ply:GetEyeTrace().Normal * 5
+	local src = ply:GetPos() + Vector(0,0,50) + ply:GetEyeTrace().Normal * 5
 
-    if !rocket:IsValid() then print("!!! INVALID ROUND " .. rocket) return end
+	if not rocket:IsValid() then print("!!! Invalid Projectile: " .. rocket) return end
 
-    local rocketAng = Angle(ang.p, ang.y, ang.r)
+	local rocketAng = Angle(ang.p, ang.y, ang.r)
 
-    rocket:SetAngles(rocketAng)
-    rocket:SetPos(src)
+	rocket:SetAngles(rocketAng)
+	rocket:SetPos(src)
 
-    rocket:SetOwner(ply)
-    rocket.Owner = ply
-    rocket.Inflictor = rocket
+	rocket:SetOwner(ply)
+	rocket.Owner = ply
+	rocket.Inflictor = rocket
 
-    rocket.Damage = 100
-    rocket.BlastRadius = 150
+	rocket.Damage = 100
+	rocket.BlastRadius = 150
 
-    local RealVelocity = (ply:GetAbsVelocity() or Vector(0, 0, 0)) + ang:Forward() * vel / 0.0254
-    rocket.CurVel = RealVelocity -- for non-physical projectiles that move themselves
+	local RealVelocity = (ply:GetAbsVelocity() or Vector(0, 0, 0)) + ang:Forward() * vel / 0.0254
+	rocket.CurVel = RealVelocity -- for non-physical projectiles that move themselves
 
-    rocket:Spawn()
-    rocket:Activate()
-    if !rocket.NoPhys and rocket:GetPhysicsObject():IsValid() then
-        rocket:SetCollisionGroup(rocket.CollisionGroup or COLLISION_GROUP_DEBRIS)
-        rocket:GetPhysicsObject():SetVelocityInstantaneous(RealVelocity)
-    end
+	rocket:Spawn()
+	rocket:Activate()
+	if not rocket.NoPhys and rocket:GetPhysicsObject():IsValid() then
+		rocket:SetCollisionGroup(rocket.CollisionGroup or COLLISION_GROUP_DEBRIS)
+		rocket:GetPhysicsObject():SetVelocityInstantaneous(RealVelocity)
+	end
 
-    if rocket.Launch and rocket.SetState then
-        rocket:SetState(1)
-        rocket:Launch()
-    end
+	if rocket.Launch and rocket.SetState then
+		rocket:SetState(1)
+		rocket:Launch()
+	end
 
-    ply:EmitSound("horde/player/carcass/aas.ogg")
+	ply:EmitSound("horde/player/carcass/aas.ogg")
 end
 
 function SWEP:Deploy()
 
-	local speed = GetConVarNumber( "sv_defaultdeployspeed" )
+	local speed = cvars.Number( "sv_defaultdeployspeed", 4)
 
-	local vm = self.Owner:GetViewModel()
+	local vm = self:GetOwner():GetViewModel()
 	vm:SendViewModelMatchingSequence( vm:LookupSequence( "fists_draw" ) )
 	vm:SetPlaybackRate( speed )
 
@@ -342,74 +347,71 @@ end
 
 function SWEP:DoTrace( endpos )
 	local trace = {}
-		trace.start = self.Owner:GetShootPos()
-		trace.endpos = trace.start + (self.Owner:GetAimVector() * 14096) --14096 is length modifier.
-		if(endpos) then trace.endpos = (endpos - self.Tr.HitNormal * 7) end
-		trace.filter = { self.Owner, self.Weapon }
+		trace.start = self:GetOwner():GetShootPos()
+		trace.endpos = trace.start + ( self:GetOwner():GetAimVector() * 14096 ) --14096 is length modifier.
+		if ( endpos ) then trace.endpos = ( endpos - self.Tr.HitNormal * 7 ) end
+		trace.filter = { self:GetOwner(), self }
 
 	self.Tr = nil
 	self.Tr = util.TraceLine( trace )
 end
 
 function SWEP:StartAttack()
-	local ply = self.Owner
-	if SERVER and ply:Horde_GetPerk("carcass_bio_thruster") then
+	local ply = self:GetOwner()
+	if SERVER and ply:Horde_GetPerk( "carcass_bio_thruster" ) then
 		if not ply:IsValid() then return end
 		if self.LastThrust > CurTime() then return end
 
-       if (ply:Health() <= (ply:GetMaxHealth() * 0.05 * math.max(1, ply.Horde_Bio_Thruster_Stack))) then
-		self.LastThrust = CurTime() + self.ThrustInterval
-		ply:EmitSound( sndTooFar )
-		return end
+		if ( ply:Health() <= ( ply:GetMaxHealth() * 0.05 * math.max( 1, ply.Horde_Bio_Thruster_Stack ))) then
+			self.LastThrust = CurTime() + self.ThrustInterval
+			ply:EmitSound( sndTooFar )
+			return
+		end
 
 		self.LastThrust = CurTime() + self.ThrustInterval
 		local id = ply:SteamID()
-		timer.Remove("Horde_BioThrusterDegen" .. id)
-		timer.Create("Horde_BioThrusterDegen" .. id, 3, 0, function ()
-			if !ply:IsValid() then
-                timer.Remove("Horde_BioThrusterDegen" .. id)
-                return
-            end
-            if !ply:Alive() then return end
-            ply.Horde_Bio_Thruster_Stack = math.max(0, ply.Horde_Bio_Thruster_Stack - 1)
-			ply:Horde_SyncStatus(HORDE.Status_Bio_Thruster, ply.Horde_Bio_Thruster_Stack)
-        end)
-		ply.Horde_Bio_Thruster_Stack = math.min(5, ply.Horde_Bio_Thruster_Stack + 1)
-		ply:Horde_SyncStatus(HORDE.Status_Bio_Thruster, ply.Horde_Bio_Thruster_Stack)
+		timer.Remove( "Horde_BioThrusterDegen" .. id )
+		timer.Create( "Horde_BioThrusterDegen" .. id, 4, 0, function ()
+			if not ply:IsValid() then
+				timer.Remove( "Horde_BioThrusterDegen" .. id )
+				return
+			end
+			if not ply:Alive() then return end
+			ply.Horde_Bio_Thruster_Stack = math.max( 0, ply.Horde_Bio_Thruster_Stack - 1 )
+			ply:Horde_SyncStatus( HORDE.Status_Bio_Thruster, ply.Horde_Bio_Thruster_Stack )
+		end)
+
+		ply.Horde_Bio_Thruster_Stack = math.min( 5, ply.Horde_Bio_Thruster_Stack + 1 )
+		ply:Horde_SyncStatus( HORDE.Status_Bio_Thruster, ply.Horde_Bio_Thruster_Stack )
 
 		local dir = ply:GetAimVector()
 		dir:Normalize()
 
 		local force = 800
-		if ply:IsSprinting() then
-			force = 800
-		else
-			force = 650
-		end
 		local vel = dir * force
-		ply:SetLocalVelocity(vel)
+		ply:SetLocalVelocity( vel )
 
-		ply:SetHealth(math.max(1,ply:Health() - ply:GetMaxHealth() * 0.05 * ply.Horde_Bio_Thruster_Stack))
-		ply:EmitSound("horde/player/carcass/biothruster" .. math.random(1,2) .. ".ogg")
-		ply:EmitSound("horde/player/carcass/pain.ogg")
+		ply:SetHealth( math.max( 1, ply:Health() - ply:GetMaxHealth() * 0.05 * ply.Horde_Bio_Thruster_Stack ))
+		ply:EmitSound( "horde/player/carcass/biothruster" .. math.random(1,2) .. ".ogg" )
+		ply:EmitSound( "horde/player/carcass/pain.ogg" )
 		return
 	end
 
-	if SERVER and ply:Horde_GetPerk("carcass_grappendix") then
+	if SERVER and ply:Horde_GetPerk( "carcass_grappendix" ) then
 	else
 		return
 	end
 	-- Get begining and end poins of trace.
-	local gunPos = self.Owner:GetShootPos() -- Start of distance trace.
-	local disTrace = self.Owner:GetEyeTrace() -- Store all results of a trace in disTrace.
+	local gunPos = ply:GetShootPos() -- Start of distance trace.
+	local disTrace = ply:GetEyeTrace() -- Store all results of a trace in disTrace.
 	local hitPos = disTrace.HitPos -- Stores Hit Position of disTrace.
 
 	-- Calculate Distance
 	-- Thanks to rgovostes for this code.
-	local x = (gunPos.x - hitPos.x)^2;
-	local y = (gunPos.y - hitPos.y)^2;
-	local z = (gunPos.z - hitPos.z)^2;
-	local distance = math.sqrt(x + y + z);
+	local x = ( gunPos.x - hitPos.x ) ^ 2;
+	local y = ( gunPos.y - hitPos.y ) ^ 2;
+	local z = ( gunPos.z - hitPos.z ) ^ 2;
+	local distance = math.sqrt( x + y + z );
 
 	-- Only latches if distance is less than distance CVAR, or CVAR negative
 	local distanceCvar = 1000
@@ -419,19 +421,18 @@ function SWEP:StartAttack()
 	end
 
 	if inRange then
-		if (SERVER) then
+		if SERVER then
 
-			if (!self.Horde_Intestine) then -- If the beam does not exist, draw the beam.
+			if not self.Horde_Intestine then -- If the beam does not exist, draw the beam.
 				-- grapple_beam
 				self.Horde_Intestine = ents.Create( "horde_intestine" )
-					self.Horde_Intestine:SetPos( self.Owner:GetShootPos() )
-					self.Horde_Intestine.Owner = self.Owner
+					self.Horde_Intestine:SetPos( ply:GetShootPos() )
+					self.Horde_Intestine.Owner = ply
 				self.Horde_Intestine:Spawn()
 			end
 
-			self.Horde_Intestine:SetParent( self.Owner )
-			self.Horde_Intestine:SetOwner( self.Owner )
-
+			self.Horde_Intestine:SetParent( ply )
+			self.Horde_Intestine:SetOwner( ply )
 		end
 
 		self:DoTrace()
@@ -440,7 +441,7 @@ function SWEP:StartAttack()
 		self.endTime = CurTime() + self.speed
 		self.dtt = -1
 
-		if (SERVER && self.Horde_Intestine) then
+		if ( SERVER and self.Horde_Intestine ) then
 			if self.Tr.Entity:IsNPC() then
 				self.Horde_Intestine:GetTable():SetEndPos( self.Tr.HitPos + self.Tr.Entity:OBBCenter() )
 			else
@@ -450,199 +451,203 @@ function SWEP:StartAttack()
 		end
 
 		self:UpdateAttack()
-        --hacky fix for the grappendix sound
-        if self:GetOwner():Health() <= 1 then
-        self:GetOwner():EmitSound( sndTooFar )
+		--hacky fix for the grappendix sound
+		if self:GetOwner():Health() <= 1 then
+		ply:EmitSound( sndTooFar )
 		return end
 
 	else
 		-- Play a sound
-		self:GetOwner():EmitSound( sndTooFar )
+		ply:EmitSound( sndTooFar )
 	end
 end
 
 function SWEP:UpdateAttack()
-	if !self.Owner then return end
-	if self.Owner:Horde_GetPerk("carcass_bio_thruster") then return end
-	if !(self.Owner:Horde_GetPerk("carcass_grappendix")) then return end
+	local owner = self:GetOwner()
+	if not owner then return end
+	if owner:Horde_GetPerk( "carcass_bio_thruster" ) then return end
+	if not ( owner:Horde_GetPerk( "carcass_grappendix" )) then return end
 
-	self.Owner:LagCompensation( true )
+	owner:LagCompensation( true )
 
-	if (!intestine_endpos) then
+	if not intestine_endpos then
 		intestine_endpos = self.Tr.HitPos
-		if IsValid(self.Tr.Entity) && self.Tr.Entity:IsNPC() then
+		if IsValid(self.Tr.Entity) and self.Tr.Entity:IsNPC() then
 			intestine_endpos = intestine_endpos + self.Tr.Entity:OBBCenter()
 		end
 		if pull == true then
-			target_pos = self.Owner:GetPos() + self.Owner:OBBCenter()
+			target_pos = owner:GetPos() + owner:OBBCenter()
 		else
 			target_pos = self.Tr.HitPos
 		end
 	end
 
-	if (SERVER && self.Horde_Intestine) then
+	if SERVER and self.Horde_Intestine then
 		self.Horde_Intestine:GetTable():SetEndPos( intestine_endpos )
 	end
 
-	if ( self.Tr.Entity:IsValid() ) then
+	if self.Tr.Entity:IsValid() then
 		intestine_endpos = self.Tr.Entity:GetPos()
 		if self.Tr.Entity:IsNPC() then
 			intestine_endpos = intestine_endpos + self.Tr.Entity:OBBCenter()
 		end
-		if ( SERVER ) then
+		if SERVER then
 			self.Horde_Intestine:GetTable():SetEndPos( intestine_endpos )
-			if pull == true then
-				if !HORDE:IsEnemy(self.Tr.Entity) then
-					return
-				end
+			if pull == true and not HORDE:IsEnemy( self.Tr.Entity ) then
+				return
 			end
 		end
 	end
 
 	local vVel, Distance
 	if pull == true then
-		vVel = ((self.Owner:GetPos() + self.Owner:OBBCenter()) - self.Tr.Entity:GetPos())
-		Distance = self.Tr.Entity:GetPos():Distance(self.Owner:GetPos()+ self.Owner:OBBCenter())
+		vVel = (( owner:GetPos() + owner:OBBCenter() ) - self.Tr.Entity:GetPos() )
+		Distance = self.Tr.Entity:GetPos():Distance( owner:GetPos() + owner:OBBCenter() )
 	else
-		vVel = (intestine_endpos - self.Owner:GetPos())
-		Distance = intestine_endpos:Distance(self.Owner:GetPos())
+		vVel = ( intestine_endpos - owner:GetPos() )
+		Distance = intestine_endpos:Distance( owner:GetPos() )
 	end
 
-	local et = (self.startTime + (Distance/self.speed))
-	if(self.dtt != 0) then
-		self.dtt = (et - CurTime()) / (et - self.startTime)
+	local et = ( self.startTime + (Distance / self.speed ))
+	if self.dtt ~= 0 then
+		self.dtt = ( et - CurTime() ) / ( et - self.startTime )
 	end
-	if(self.dtt < 0) then
+	if self.dtt < 0 then
 		self:GetOwner():EmitSound( sndPowerUp )
 		self.dtt = 0
 	end
 
-	if(self.dtt == 0) then
-		local zVel = self.Owner:GetVelocity().z
-		vVel = vVel:GetNormalized()*(math.Clamp(Distance,0,7))
-		if( SERVER ) then
-		local gravity = GetConVarNumber("sv_gravity")
-		vVel:Add(Vector(0,0,(gravity/100)*1.5)) -- Player speed. DO NOT MESS WITH THIS VALUE!
-		if(zVel < 0) then
-			vVel:Sub(Vector(0,0,zVel/100))
-		end
-		if pull == true then
-			self.Tr.Entity:SetVelocity(vVel)
-		else
-			self.Owner:SetVelocity(vVel * 1.5)
-		end
+	if self.dtt == 0 then
+		local zVel = owner:GetVelocity().z
+		vVel = vVel:GetNormalized() * ( math.Clamp( Distance, 0, 7 ) )
+		if SERVER then
+			local gravity = cvars.Number( "sv_gravity", 600 )
+			vVel:Add( Vector( 0, 0, ( gravity / 100 ) * 1.5 )) -- Player speed. DO NOT MESS WITH THIS VALUE!
+
+			if zVel < 0 then
+				vVel:Sub( Vector( 0, 0, zVel / 100 ))
+			end
+			if pull == true then
+				self.Tr.Entity:SetVelocity( vVel )
+			else
+				owner:SetVelocity( vVel * 1.5 )
+			end
 		end
 	end
 
 	intestine_endpos = nil
 
 	if self.LastDrain <= CurTime() then
-        self.Owner:SetHealth(math.max(1,self.Owner:Health() - self.Owner:GetMaxHealth() * 0.01))
-		if self.Owner:Health() <= 1 then
-            self:EndAttack( true )
-            --hacky workaround to make the weapon think it couldn't successfully find a trace to achieve the effect of forcibly stopping a grapple
+		owner:SetHealth( math.max( 1, owner:Health() - owner:GetMaxHealth() * 0.01 ))
+		if owner:Health() <= 1 then
+			self:EndAttack( true )
+			--hacky workaround to make the weapon think it couldn't successfully find a trace to achieve the effect of forcibly stopping a grapple
+			owner:LagCompensation( false ) --DO NOT REMOVE THIS
 			inRange = false
 			return
 		end
 		self.LastDrain = CurTime() + self.DrainInterval
 	end
 
-	self.Owner:LagCompensation( false )
-
+	owner:LagCompensation( false )
 end
 
 function SWEP:EndAttack( shutdownsound )
 
-	if ( CLIENT ) then return end
-	if ( !self.Horde_Intestine ) then return end
+	if CLIENT then return end
+	if not self.Horde_Intestine then return end
 
 	self.Horde_Intestine:Remove()
 	self.Horde_Intestine = nil
-
 end
 
+local Cur = CurTime()
 function SWEP:Think()
-
-	local vm = self.Owner:GetViewModel()
+	local owner = self:GetOwner()
+	local vm = owner:GetViewModel()
 	local curtime = CurTime()
 	local idletime = self:GetNextIdle()
 
-	if ( idletime > 0 && CurTime() > idletime ) then
-
+	if ( idletime > 0 and CurTime() > idletime ) then
 		vm:SendViewModelMatchingSequence( vm:LookupSequence( "fists_idle_0" .. math.random( 1, 2 ) ) )
-
 		self:UpdateNextIdle()
-
 	end
 
 	local meleetime = self:GetNextMeleeAttack()
 
-	if ( meleetime > 0 && CurTime() > meleetime ) then
-
+	if ( meleetime > 0 and CurTime() > meleetime ) then
 		self:DealDamage()
-
 		self:SetNextMeleeAttack( 0 )
-
 	end
 
-	if SERVER and self.Charging == 1 and !self.Owner:KeyDown( IN_ATTACK ) then
-        self:SetNextPrimaryFire( CurTime() + self.Delay )
-        self.Charging = 0
+	if self.Charging == 1 and not owner:KeyDown( IN_ATTACK ) and owner:KeyDownLast( IN_ATTACK ) and ( CurTime() >= Cur + self.Delay ) then
+		Cur = CurTime()
+		owner:SetAnimation( PLAYER_ATTACK1 )
+	end
+
+	if SERVER and self.Charging == 1 and not owner:KeyDown( IN_ATTACK ) then
+		self:SetNextPrimaryFire( CurTime() + self.Delay )
+		self.Charging = 0
 
 		if self.ChargingTimer <= CurTime() then
-			self:Punch(1)
+			self:Punch( 1 )
 		else
-			self:Punch(0)
+			self:Punch( 0 )
 		end
-    end
+	end
+
 
 	if SERVER and self.Charging == 1 then
 		self:SetNextPrimaryFire( CurTime() + self.Delay )
 	end
 
 	if SERVER and self.Charging == 1 and self.ChargingTimer <= CurTime() + 0.2 then
-		local vm = self.Owner:GetViewModel()
 		vm:SendViewModelMatchingSequence( vm:LookupSequence( "seq_admire" ) )
 	end
 
-	if ( SERVER && CurTime() > self:GetNextPrimaryFire() + 0.1 ) then
+	if ( SERVER and CurTime() > self:GetNextPrimaryFire() + 0.1 ) then
 
 		self:SetCombo( 0 )
 
 	end
 
-	if ( self.Owner:KeyPressed( IN_ATTACK2 ) ) then
-
+	if owner:KeyPressed( IN_ATTACK2 ) then
 		self:StartAttack()
-
-	elseif ( self.Owner:KeyDown( IN_ATTACK2 ) && inRange ) then
-
+	elseif owner:KeyDown( IN_ATTACK2 ) and inRange then
 		self:UpdateAttack()
-
-	elseif ( self.Owner:KeyReleased( IN_ATTACK2 ) && inRange ) then
-
+	elseif owner:KeyReleased( IN_ATTACK2 ) and inRange then
 		self:EndAttack( true )
-
 	end
 
 	if SERVER then
-		local ply = self.Owner
-		if ply.TwinHeartToggleOn and self.LastTransfer <= CurTime() then
-			if ply.TwinHeartToggleOn == true then
+		local ply = self:GetOwner()
+		if ply.TwinHeartToggleOn and self.LastTransfer <= CurTime() and ply.TwinHeartToggleOn == true then
+			if ply.Horde_TwinHeartStack <= 0 or ply:Horde_HasDebuff( HORDE.Status_Decay ) then
+				ply.TwinHeartToggleOn = false
+				ply:EmitSound( "items/suitchargeno1.wav" )
+				return
+			end
 
-
-				if ply.Horde_TwinHeartStack <= 0 or ply:Horde_HasDebuff(HORDE.Status_Decay) then
-					ply.TwinHeartToggleOn = false
-					ply:EmitSound("items/suitchargeno1.wav")
-					return
-				end
-				if ply:Health() < ply:GetMaxHealth() then
-				ply.Horde_TwinHeartStack = math.max(0, ply.Horde_TwinHeartStack - 1)
-				ply:Horde_SyncStatus(HORDE.Status_Twin_Heart, ply.Horde_TwinHeartStack)
-				local id = ply:SteamID()
-				--timer.Remove("Horde_TwinHeartStacking" .. id)
-				HORDE:SelfHeal(ply, ply:GetMaxHealth() * 0.01)
+			if ply:Health() < ply:GetMaxHealth() then
+				ply.Horde_TwinHeartStack = math.max( 0, ply.Horde_TwinHeartStack - 1 )
+				ply:Horde_SyncStatus( HORDE.Status_Twin_Heart, ply.Horde_TwinHeartStack )
+				ply:SetHealth( math.min( ply:GetMaxHealth(), ply:Health() + ply:GetMaxHealth() * 0.01 ))
 				self.LastTransfer = CurTime() + self.TransferInterval
+			end
+		end
+		if  ply.TwinHeartToggleOn and ply.TwinHeartToggleOn == true and ply.Horde_TwinHeartStack >= 1 and self.LastPulse <= CurTime() and self.LastToggle > CurTime() then
+			local rad, pos = 220, ply:GetPos()
+			local e = EffectData()
+			e:SetNormal( Vector( 0, 0, 1 ) )
+			e:SetOrigin( pos )
+			e:SetRadius( rad )
+			util.Effect( "horde_twin_heart", e, true, true )
+			self.LastPulse = CurTime() + 10
+			ply:EmitSound( "horde/player/life_diffuser.ogg", 100, 80, 1, CHAN_AUTO )
+
+			for _, target in ipairs( ents.FindInSphere( pos, rad ) ) do
+				if IsValid( target ) and HORDE:IsEnemy( target ) and target.Horde_Mutation and table.Count( target.Horde_Mutation ) > 0  then
+					target:Horde_UnsetMutations()
 				end
 			end
 		end

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_aas_perfume.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_aas_perfume.lua
@@ -1,8 +1,8 @@
 PERK.PrintName = "Tren Perfume"
 PERK.Description =
 [[Adds {1} maximum Hypertrophy stacks. Press R to shoot a lingering spore cloud.
-Cloud provides Hypertrophy to players and deals {4} Poison damage in an area.
-Effect lasts for {2} seconds and has a cooldown of {3} seconds.]]
+Cloud gives Hypertrophy to players, deals {4} Poison damage in an area.
+Cloud Weakens enemies. Cloud lasts for {2} seconds, {3} second coooldown.]]
 PERK.Icon = "materials/perks/carcass/aas_perfume.png"
 PERK.Params = {
     [1] = { value = 2 },

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
@@ -13,7 +13,8 @@ Each Hypertrophy stack regenerates {8} health per second.
 Equipped with Carcass Biosystem.
 Cannot use any other weapons other than medkits because your hands are fucked.
 LMB: Punch
-Hold for a charged punch that deals increased damage in an area.]]
+Hold for a charged punch that deals increased damage in an area.
+your punch damage is increased based on your velocity.]]
 PERK.Icon = "materials/subclasses/carcass.png"
 PERK.Params = {
     [1] = { percent = true, base = 0.25, level = 0.02, max = 0.75, classname = "Carcass" },

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_bio_thruster.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_bio_thruster.lua
@@ -23,7 +23,7 @@ if SERVER then
             net.WriteUInt(ply.Horde_Bio_Thruster_Stack, 8)
         net.Send(ply)
 
-        timer.Create("Horde_BioThrusterDegen" .. id, 3, 0, function ()
+        timer.Create("Horde_BioThrusterDegen" .. id, 4, 0, function ()
             if not ply:IsValid() then
                 timer.Remove("Horde_BioThrusterDegen" .. id)
                 return

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_grappendix.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_grappendix.lua
@@ -1,32 +1,32 @@
 PERK.PrintName = "Grappendix"
 PERK.Description =
-[[{1} increased maximum health.
-Adds {2} maximum Hypertrophy stack.
-Press RMB to use your appendix as a grapple hook.
-Drains your health when in use.]]
+[[Adds {1} maximum Hypertrophy stack.
+Press RMB to use your appendix as a grapple hook. Drains health when used.
+Multiplies your velocity based damage bonus by {2}, Multiplier Capped at 20x]]
 PERK.Icon = "materials/perks/carcass/grappendix.png"
 PERK.Params = {
-    [1] = { value = 0.2, percent = true },
-    [2] = { value = 1 },
+  --  [1] = { value = 0.2, percent = true },
+    [1] = { value = 2 },
+    [2] = { value = 0.8, percent = true},
 }
 PERK.Hooks = {}
 
 if not SERVER then return end
 
-PERK.Hooks.Horde_OnSetMaxHealth = function( ply, bonus )
+--[[PERK.Hooks.Horde_OnSetMaxHealth = function( ply, bonus )
     if not ply:Horde_GetPerk( "carcass_grappendix" ) then return end
 
     bonus.increase = bonus.increase + 0.2
-end
+end]]--
 
 PERK.Hooks.Horde_OnSetPerk = function( ply, perk )
     if perk ~= "carcass_grappendix" then return end
 
-    ply:Horde_SetMaxHypertrophyStack( ply:Horde_GetMaxHypertrophyStack() + 1 )
+    ply:Horde_SetMaxHypertrophyStack( ply:Horde_GetMaxHypertrophyStack() + 2 )
 end
 
 PERK.Hooks.Horde_OnUnsetPerk = function( ply, perk )
     if perk ~= "carcass_grappendix" then return end
 
-    ply:Horde_SetMaxHypertrophyStack( ply:Horde_GetMaxHypertrophyStack() - 1 )
+    ply:Horde_SetMaxHypertrophyStack( ply:Horde_GetMaxHypertrophyStack() - 2 )
 end

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
@@ -1,97 +1,90 @@
 PERK.PrintName = "Pneumatic Legs"
 PERK.Description =
-[[Adds {1} maximum Hypertrophy stacks.
+[[Adds {1} maximum Hypertrophy stacks. Gain immunity to fall damage.
 Press SPACE in air to descend, dealing area Physical damage based on your speed.
-Gain immunity to fall damage.]]
+Hinders and launches enemies away from you on impact.]]
 PERK.Icon = "materials/perks/carcass/pneumatic_legs.png"
 PERK.Params = {
-    [1] = {value = 1},
-    [2] = {value = 0.9, percent = true},
-    [3] = {value = 5},
+    [1] = { value = 1 },
+    [2] = { value = 0.9, percent = true },
+    [3] = { value = 5 },
 }
 PERK.Hooks = {}
 
-PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
+PERK.Hooks.Horde_OnSetPerk = function( ply, perk )
     if SERVER and perk == "carcass_pneumatic_legs" then
-        ply:Horde_SetMaxHypertrophyStack(ply:Horde_GetMaxHypertrophyStack() + 1)
+        ply:Horde_SetMaxHypertrophyStack( ply:Horde_GetMaxHypertrophyStack() + 1 )
         ply.Horde_Pneumatic_Leg_Ready = true
     end
 end
 
-PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
+PERK.Hooks.Horde_OnUnsetPerk = function( ply, perk )
     if SERVER and perk == "carcass_pneumatic_legs" then
-        ply:Horde_SetMaxHypertrophyStack(ply:Horde_GetMaxHypertrophyStack() - 1)
+        ply:Horde_SetMaxHypertrophyStack( ply:Horde_GetMaxHypertrophyStack() - 1 )
         ply.Horde_Pneumatic_Leg_Ready = nil
     end
 end
 
-PERK.Hooks.Horde_GetFallDamage = function(ply, speed, bonus)
-    if ply:Horde_GetPerk("carcass_pneumatic_legs") then
+PERK.Hooks.Horde_GetFallDamage = function( ply, speed, bonus )
+    if ply:Horde_GetPerk( "carcass_pneumatic_legs" ) then
         bonus.less = bonus.less * 0
-        local dmg = math.max(0, math.ceil(0.2418 * speed - 141.75)) * 4
+        local dmg = math.max( 0, math.ceil( 0.2418 * speed - 141.75 ) ) * 7
+        local rad, pos = 320, ply:GetPos()
         if dmg < 10 then return end
         local dmginfo = DamageInfo()
-        dmginfo:SetAttacker(ply)
-        dmginfo:SetInflictor(ply)
-        dmginfo:SetDamageType(DMG_GENERIC)
-        dmginfo:SetDamage(dmg)
-        dmginfo:SetDamagePosition(ply:GetPos())
-        util.BlastDamageInfo(dmginfo, ply:GetPos(), 250)
+        dmginfo:SetAttacker( ply )
+        dmginfo:SetInflictor( ply )
+        dmginfo:SetDamageType( DMG_GENERIC )
+        dmginfo:SetDamage( dmg )
+        dmginfo:SetDamagePosition( pos )
+        util.BlastDamageInfo( dmginfo, pos, rad )
+
         local e = EffectData()
-            e:SetNormal(Vector(0,0,1))
-            e:SetOrigin(ply:GetPos())
-            e:SetRadius(250)
+            e:SetNormal( Vector( 0, 0, 1 ) )
+            e:SetOrigin( pos )
+            e:SetRadius( rad )
         util.Effect("seismic_wave", e, true, true)
+
+         for _, target in ipairs( ents.FindInSphere( pos, rad ) ) do
+            if IsValid( target ) and HORDE:IsEnemy( target ) then
+                local bashKnockback
+                local targetPos, bashKnockUp = target:GetPos(), Vector( 0, 0, 100 )
+                local toTarget = ( targetPos - pos ):GetNormalized() * Vector( 1, 1, 0 )
+                local dist = ( rad - pos:Distance2D( targetPos ) ) * 0.01
+
+                if speed <= 400 then
+                    bashKnockback = 400 / 1.5
+                else
+                    bashKnockback = speed / 1.5
+                end
+
+                local knockbackForce = ( ( toTarget * bashKnockback ) * dist ) + bashKnockUp
+                target:SetVelocity( knockbackForce )
+                target:Horde_AddHinder( ply, ply:Horde_GetApplyDebuffDuration(), ply:Horde_GetApplyDebuffMore() )
+            end
+        end
+
         ply.Horde_Pneumatic_Leg_Ready = true
     end
 end
 
-PERK.Hooks.PlayerButtonDown = function (ply, key)
-    if key == KEY_SPACE and ply:Horde_GetPerk("carcass_pneumatic_legs") and !ply:IsOnGround() then
-        local dir = Vector(0,0,-1)
-        local vel = dir * math.max(590, (ply:GetVelocity():Length() + 250))
-        ply:SetLocalVelocity(vel)
+PERK.Hooks.PlayerButtonDown = function ( ply, key )
+    local velocity = ply:GetVelocity():Length()
+            local tr = util.TraceLine({
+            start = ply:GetPos(),
+            endpos = ply:GetPos() - Vector( 0, 0, 50 ),
+            mask = MASK_SOLID,
+            filter = ply
+        })
+        local Cur = 0
+    if key == KEY_SPACE and ply:Horde_GetPerk( "carcass_pneumatic_legs" ) and not ply:IsOnGround() and ( ( velocity >= 400 ) or not tr.Hit ) and ply.Horde_Pneumatic_Leg_Ready then
+        local dir = Vector( 0, 0, -1 )
+        local vel = dir * math.max( 590, velocity + 250 )
+        ply:SetLocalVelocity( vel )
+        ply.Horde_Pneumatic_Leg_Ready = false
+        Cur = CurTime()
+    end
+    if ply:Horde_GetPerk("carcass_pneumatic_legs") and not ply:IsOnGround() and not ply.Horde_Pneumatic_Leg_Ready and (Cur + 1.5) <= CurTime() then
+    ply.Horde_Pneumatic_Leg_Ready = true
     end
 end
-/*
-PERK.Hooks.PlayerButtonDown = function (ply, key)
-    if key == KEY_SPACE and ply:Horde_GetPerk("carcass_pneumatic_legs") and ply:IsOnGround() then
-        if ply.Horde_Pneumatic_Leg_Ready then
-            timer.Simple(0.1, function()
-                if not ply:IsValid() then return end
-                net.Start("Horde_SyncStatus")
-                    net.WriteUInt(HORDE.Status_Pneumatic_Legs, 8)
-                    net.WriteUInt(0, 8)
-                net.Send(ply)
-                local dir = ply:GetForward() * 0.7 + ply:GetUp() * 0.3
-                dir:Normalize()
-
-                local force = 800
-                if ply:IsSprinting() then
-                    force = 800
-                else
-                    force = 650
-                end
-                local vel = dir * force
-                ply:SetLocalVelocity(vel)
-                ply.Horde_Pneumatic_Leg_Ready = nil
-                ply.Horde_Pneumatic_Leg_Leaping = true
-                sound.Play("horde/player/pneumatic_legs.ogg", ply:GetPos())
-
-                local id = ply:SteamID()
-                timer.Remove("Horde_PneumaticLeg" .. id)
-                timer.Create("Horde_PneumaticLeg" .. id, 5, 1, function ()
-                    if (not ply:IsValid()) or (not ply:Horde_GetPerk("carcass_pneumatic_legs")) then return end
-                    net.Start("Horde_SyncStatus")
-                        net.WriteUInt(HORDE.Status_Pneumatic_Legs, 8)
-                        net.WriteUInt(1, 8)
-                    net.Send(ply)
-                    ply.Horde_Pneumatic_Leg_Ready = true
-                    ply.Horde_Pneumatic_Leg_Leaping = nil
-                end)
-            end)
-        else
-            ply.Horde_Pneumatic_Leg_Leaping = nil
-        end
-    end
-end*/

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_reinforced_arms.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_reinforced_arms.lua
@@ -1,11 +1,12 @@
 PERK.PrintName = "Reinforced Arms"
 PERK.Description =
 [[Adds {1} maximum Hypertrophy stacks.
-Your punch deals more damage based on your velocity.
+Increases Charged punch Area of effect radius by {2}
 Charged punch against surfaces provide speed boost.]]
 PERK.Icon = "materials/perks/carcass/reinforced_arms.png"
 PERK.Params = {
     [1] = {value = 1},
+    [2] = {value = 60}
 }
 PERK.Hooks = {}
 

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_twin_heart.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_twin_heart.lua
@@ -1,13 +1,13 @@
 PERK.PrintName = "Twin Heart"
 PERK.Description =
-[[{1} increased maximum health.
-Toggle R to recover your health from a synthetic heart.
-The heart stores health over time, up to {2} of your maximum health.]]
+[[{1} increased maximum health. Toggle R to recover health from a synthetic heart.
+The heart stores health over time, up to {2} of your maximum health.
+Toggling emits a pulse that removes mutations from enemies, {3} second cooldown.]]
 PERK.Icon = "materials/perks/carcass/twin_heart.png"
 PERK.Params = {
     [1] = {value = 0.25, percent = true},
     [2] = {value = 1, percent = true},
-    --[3] = {value = 30},
+    [3] = {value = 10},
 }
 PERK.Hooks = {}
 

--- a/gamemodes/horde/gamemode/sh_item.lua
+++ b/gamemodes/horde/gamemode/sh_item.lua
@@ -1057,7 +1057,8 @@ Hysteria lasts for 5 seconds and falls off sequentially.]],
     Leaves behind an unpleasant stench.
 
     LMB: Punch.
-    Hold for a charged punch that deals increased damage in an area.]],
+    Hold for a charged punch that deals increased damage in an area.
+    Upgrading increases damage and the area it affects]],
     { Carcass = true },
     -1, -1, nil, nil, nil, nil, { HORDE.DMG_PHYSICAL }, nil, { "Carcass" } )
 


### PR DESCRIPTION
Fists
• Increased base damage from 25 -> 35
• increased base damage per level from 8 -> 9
• increased hit distance from 90 -> 100
• made charged punch aoe increase by 5 per level
• made velocity based damage an innate part of the Fists, with a velocity requirement so you can't just bhop for free damage (this includes the aoe increase for charged punch) 
• made reinforced arms increase the base radius of the aoe from 140 -> 200 (reinforced arms is no longer required for velocity based damage) 
• added a separate velocity based damage formula for grappendix (and an exclusion for exoskeleton because it would deal 4k+ damage if timed right with it which somewhat goes against the intent of this change) 
• increased biothruster stack duration from 3 -> 4 
• removed non-telegraphed sprint check from biothruster for consistency reasons (it will always thrust you at 800 velocity instead of needing to hold sprint to do so, not holding sprint would thrust you at 650 velocity, which is never communicated to the player) 
• added a mutation cleansing pulse to twin heart that can be triggered when twin heart is activated, cooldown is 10 seconds 
• changed healing logic so you wouldn't get a seizure of green flashes from the healing overlay being spammed each time twin heart would heal health 
• fixed grappendix not ending its lagcompensation when it gets disabled from having low health 
• fixed thirdperson animations
• cleaned up a metric fuckton of formatting and deprecated functions

Grappendix
• some functions for the perk are handled in the fists weapon and are listed there • remove +20 health bonus
• added a second hypertrophy stack (this may affect the trout population)

Biothruster
• updated thruster stack decay timer to match decay time listed in fists

Pneumatic Legs
• Increased damage multiplier from 4 -> 7
• increased radius from 250 -> 320 ( fists aoe gets close to the old value with reinforced arms + upgrades, figured it needed a bump if its gonna be the weaker aoe) 
• added ability to knock back enemies with the slam (knockback is affected by distance away from the target, and the fall speed) 
• slam now applies Hinder to enemies
• improve logic for triggering slam attacks (players need to either be above a solid surface by 50 units or be above 400 vel to be able to trigger the downward slam, this prevents players from being able to spam the slam by simply jumping, also makes it less annoying to bhop and so on) 
• added check to prevent being able to spam spacebar to rapidly stack speed increases mid slam 
• added check to allow it to be used again after 1.5 seconds if the slam has been triggered but you're still in midair (like using grappendix) so you aren't completely locked out of it if you hold space when jumping but meet the requirements (or fail to touch the ground when in a downward slam) until you properly touch the ground again 
• cleaned up formatting
• remove commented out code block

Tren Perfume
• enemies within the cloud are Weakened
• fix entity causing collision rule changing errors 
• cleaned up code, formatting, and deprecated functions

Misc
• updated descriptions to reflect and better communicate changes