### PR TITLE
Exclude bosses from knockback related perks

### DIFF
--- a/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
@@ -59,7 +59,9 @@ PERK.Hooks.Horde_GetFallDamage = function( ply, speed, bonus )
                 end
 
                 local knockbackForce = ( ( toTarget * bashKnockback ) * dist ) + bashKnockUp
-                target:SetVelocity( knockbackForce )
+                if not ent:Horde_GetBossProperties() then
+                    target:SetVelocity( knockbackForce )
+                end
                 target:Horde_AddHinder( ply, ply:Horde_GetApplyDebuffDuration(), ply:Horde_GetApplyDebuffMore() )
             end
         end

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_pneumatic_legs.lua
@@ -59,7 +59,7 @@ PERK.Hooks.Horde_GetFallDamage = function( ply, speed, bonus )
                 end
 
                 local knockbackForce = ( ( toTarget * bashKnockback ) * dist ) + bashKnockUp
-                if not ent:Horde_GetBossProperties() then
+                if not target:Horde_GetBossProperties() then
                     target:SetVelocity( knockbackForce )
                 end
                 target:Horde_AddHinder( ply, ply:Horde_GetApplyDebuffDuration(), ply:Horde_GetApplyDebuffMore() )

--- a/gamemodes/horde/gamemode/perks/paladin/paladin_shield_bash.lua
+++ b/gamemodes/horde/gamemode/perks/paladin/paladin_shield_bash.lua
@@ -87,7 +87,9 @@ PERK.Hooks.Horde_UseActivePerk = function( ply )
                     target:TakeDamageInfo( bashDmginfo )
 
                     local knockbackForce = ply:GetForward() * bashKnockback + bashKnockUp
-                    target:SetVelocity( knockbackForce )
+                    if not ent:Horde_GetBossProperties() then
+                        target:SetVelocity( knockbackForce )
+                    end
                     target:Horde_AddDebuffBuildup( HORDE.Status_Stun, 19208, ply, targetPos )
 
                     hit = true

--- a/gamemodes/horde/gamemode/perks/paladin/paladin_shield_bash.lua
+++ b/gamemodes/horde/gamemode/perks/paladin/paladin_shield_bash.lua
@@ -87,7 +87,7 @@ PERK.Hooks.Horde_UseActivePerk = function( ply )
                     target:TakeDamageInfo( bashDmginfo )
 
                     local knockbackForce = ply:GetForward() * bashKnockback + bashKnockUp
-                    if not ent:Horde_GetBossProperties() then
+                    if not target:Horde_GetBossProperties() then
                         target:SetVelocity( knockbackForce )
                     end
                     target:Horde_AddDebuffBuildup( HORDE.Status_Stun, 19208, ply, targetPos )


### PR DESCRIPTION
as funny as this was some maps weren't design to handle this sorta chicanery and can cause harder to deal with softlocks

you can also cheese bosses on certain maps by yeeting them into the instakilling abyss, while funny, some players dislike this despite its difficulty to do so