### PR TITLE
added velocity counter to carcass fists

### DIFF
--- a/gamemodes/horde/entities/weapons/horde_carcass.lua
+++ b/gamemodes/horde/entities/weapons/horde_carcass.lua
@@ -185,7 +185,7 @@ function SWEP:DealDamage()
 			bonus.more = bonus.more * math.min(20, vel / 100)
 		elseif grappendix and vel >= 400 and ((vel < 1000) or (vel > 1020 )) and owner:Horde_GetGadget() == "gadget_exoskeleton" then
 			bonus.more = bonus.more * math.min(20, owner:GetVelocity():Length() / 100)
-		elseif owner:GetVelocity():Length() >= 350 then
+		elseif owner:GetVelocity():Length() >= 360 then
 			bonus.more = bonus.more * math.max(1, owner:GetVelocity():Length() / 180)
 		end
 
@@ -652,5 +652,33 @@ function SWEP:Think()
 				end
 			end
 		end
+	end
+end
+
+if CLIENT then
+	surface.CreateFont("Carcass_velocity", { font = "Trebuchet18", size = ScreenScale(5.7), weight = 1000, extended = true, blursize = 0, scanlines = 0, antialias = false, underline = false, italic = false, strikeout = false, symbol = false, rotary = false, shadow = false, additive = false, outline = true, })
+end
+
+function SWEP:DrawHUD()
+	if CLIENT then
+		local CLR_W = Color(255, 255, 255, 230)
+		local owner = self:GetOwner()
+		local vel = owner:GetVelocity():Length()
+		local veltext = "Velocity:"
+		local velocity =  math.Truncate( vel, 0)
+		local grappendix = owner:Horde_GetPerk("carcass_grappendix")
+
+		draw.RoundedBoxEx(10, (ScrW() / 2) - ScreenScale(14), ScrH() / 1.8 + ScreenScale(1), ScreenScale(30), ScreenScale(12), Color(146,16,92,100), true, false, false, true)
+		draw.RoundedBoxEx(10, (ScrW() / 2) - ScreenScale(15), ScrH() / 1.8, ScreenScale(30), ScreenScale(12), Color(40,40,40,150), true, false, false, true)
+		if grappendix and vel >= 400 and owner:Horde_GetGadget() ~= "gadget_exoskeleton" then
+			CLR_W = Color(0, 255, 179, 230)
+		elseif grappendix and vel >= 400 and ((vel < 1000) or (vel > 1020 )) and owner:Horde_GetGadget() == "gadget_exoskeleton" then
+			CLR_W = Color(0, 255, 179, 230)
+		elseif vel >= 360 then
+			CLR_W = Color(21, 255, 0, 230)
+		else
+			CLR_W = Color(255, 0, 0, 230)
+		end
+		draw.DrawText(veltext .. "\n" .. velocity, "Carcass_velocity", ScrW() / 2, ScrH() / 1.8, CLR_W, TEXT_ALIGN_CENTER, true)
 	end
 end


### PR DESCRIPTION
added a velocity counter to carcass's fists to better communicate the damage multipliers to players without needing a console command to enable a debug display for position, angle and velocity

also increased the velocity threshold from 350 -> 360 since apparently during brief periods of bhopping it qualified for the velocity multiplier