### PR TITLE
reworked butane can + collision rule error fixes

### DIFF
--- a/gamemodes/horde/entities/entities/arccw_horde_butane_fire/shared.lua
+++ b/gamemodes/horde/entities/entities/arccw_horde_butane_fire/shared.lua
@@ -8,7 +8,7 @@ ENT.AdminSpawnable = false
 
 ENT.Model = "models/Items/AR2_Grenade.mdl"
 
-ENT.FireTime = 5
+ENT.FireTime = 3
 
 ENT.Armed = false
 
@@ -30,7 +30,7 @@ function entmeta:Horde_AddEffect_Molotov(ent)
     timer.Create("Horde_MolotovEffect" .. id, 0.5, 0, function ()
         if not self:IsValid() then timer.Remove("Horde_MolotovEffect" .. id) return end
         local d = DamageInfo()
-        d:SetDamage(13)
+        d:SetDamage(10)
         d:SetAttacker(ent.Owner)
         d:SetInflictor(ent)
         d:SetDamageType(DMG_BURN)
@@ -65,13 +65,13 @@ function ENT:EndTouch(ent)
 end
 
 function ENT:Initialize()
-    self:SetSolid( SOLID_OBB )
+   self:SetSolid( SOLID_OBB )
     self:SetMoveType( MOVETYPE_VPHYSICS )
     if SERVER then
         self:SetModel( self.Model )
         self:PhysicsInit(SOLID_OBB)
 
-        local maxs = Vector(150, 150, 100)
+        local maxs = Vector(100, 100, 100)
         local mins = -maxs
         self:SetCollisionBounds(mins, maxs)
         self:DrawShadow( false )
@@ -83,18 +83,13 @@ function ENT:Initialize()
         self.SpawnTime = CurTime()
         self:Detonate()
 
-        self.FireTime = math.Rand(4.5, 5.5)
+        self.FireTime = math.Rand(2.5, 3.5)
 
         timer.Simple(0.1, function()
             if not IsValid(self) then return end
             self:AddSolidFlags(FSOLID_TRIGGER)
             self:SetCollisionGroup(COLLISION_GROUP_PASSABLE_DOOR)
         end)
-    end
-    local owner = self:GetOwner()
-    self.has_burner = nil
-    if IsValid( owner ) and owner:Horde_GetGadget() == "gadget_hydrogen_burner" then
-        self.has_burner = true
     end
 end
 
@@ -112,7 +107,7 @@ end
 function ENT:Think()
     if not self.SpawnTime then self.SpawnTime = CurTime() end
     if SERVER then
-        for _, e in pairs( ents.FindInSphere( self:GetPos(), 300 ) ) do
+        for _, e in pairs( ents.FindInSphere( self:GetPos(), 200 ) ) do
             if e:GetClass() == "horde_butane_can" and self:GetOwner() == e.Horde_Owner then
                 e:Detonate()
             end
@@ -127,19 +122,15 @@ function ENT:Think()
         for i = 1, 4 do
             local fire = emitter:Add(GetFireParticle(), self:GetPos() + (VectorRand() * 30))
             fire:SetVelocity( VectorRand() * 500 * VectorRand() )
-            fire:SetGravity( Vector(0, 0, 1000) )
+            fire:SetGravity( Vector(0, 0, 2000) )
             fire:SetDieTime( math.Rand(0.2, 0.5) )
-            fire:SetStartAlpha( 85 )
+            fire:SetStartAlpha( 55 )
             fire:SetEndAlpha( 0 )
-            fire:SetStartSize( 0 )
-            fire:SetEndSize( 50 )
+            fire:SetStartSize( 25 )
+            fire:SetEndSize( 3 )
             fire:SetRoll( math.Rand(-180, 180) )
             fire:SetRollDelta( math.Rand(-0.2,0.2) )
-            if self.has_burner then
-                fire:SetColor( 0, 135, 255 )
-            else
-                fire:SetColor( 255, 255, 255 )
-            end
+            fire:SetColor( 255, 255, 255 )
             fire:SetAirResistance( 150 )
             local pos = VectorRand() * math.random(20,100)
             pos.z = 0
@@ -150,11 +141,8 @@ function ENT:Think()
             fire:SetNextThink( CurTime() + FrameTime() )
             fire:SetThinkFunction( function(pa)
                 if not pa then return end
-                local col1 = Color(255, 135, 0)
-                if self.has_burner then
-                    col1 = Color(0, 135, 255)
-                end
-                local col2 = Color(0, 0, 0)
+                local col1 = Color(255, 195, 117)
+                local col2 = Color(189, 38, 38)
 
                 local col3 = col1
                 local d = pa:GetLifeTime() / pa:GetDieTime()

--- a/gamemodes/horde/entities/entities/horde_butane_can/cl_init.lua
+++ b/gamemodes/horde/entities/entities/horde_butane_can/cl_init.lua
@@ -1,0 +1,7 @@
+include("shared.lua")
+
+function ENT:Draw()
+    self:DrawModel()
+end
+
+ENT.ColorModulation = Color(1, 0.25, 0.25)

--- a/gamemodes/horde/entities/entities/horde_butane_can/init.lua
+++ b/gamemodes/horde/entities/entities/horde_butane_can/init.lua
@@ -1,0 +1,121 @@
+AddCSLuaFile( "shared.lua" )
+AddCSLuaFile( "cl_init.lua" )
+include( "shared.lua" )
+
+function ENT:Initialize()
+    self:SetModel( "models/props_junk/gascan001a.mdl" )
+    self:PhysicsInit(SOLID_VPHYSICS)
+    self:SetMoveType(MOVETYPE_VPHYSICS)
+    self:SetCollisionGroup(COLLISION_GROUP_PLAYER_MOVEMENT)
+    self:SetUseType(SIMPLE_USE)
+
+    local phys = self:GetPhysicsObject()
+    if phys:IsValid() then
+        phys:Wake()
+        phys:EnableGravity(true)
+    end
+
+    timer.Simple( 2, function ()
+        if self:IsValid() then
+            self:SetTrigger( true )
+            self:UseTriggerBounds( true, 150 )
+
+            local expLight = ents.Create( "light_dynamic" )
+            expLight:SetKeyValue( "brightness", "1" )
+            expLight:SetKeyValue( "distance", "200" )
+            expLight:SetLocalPos( self:GetPos() )
+            expLight:SetLocalAngles( self:GetAngles() )
+            expLight:Fire( "Color", "255 0 0" )
+            expLight:SetParent( self )
+            expLight:Spawn()
+            expLight:Activate()
+            expLight:Fire( "TurnOn", "", 0 )
+            self:DeleteOnRemove( expLight )
+
+            self:EmitSound( "weapons/slam/mine_mode.wav", 100 )
+        end
+    end )
+
+    self.Removing = false
+    self:PhysWake()
+end
+function ENT:OnTakeDamage( dmginfo )
+    if dmginfo:GetAttacker() == self.Horde_Owner then
+        self:Detonate()
+    end
+-- DO NOT TRY TO GIVE THIS UNHOLY DEVICE HEALTH, CAUSES CRASHES, WHY? NO CLUE!
+end
+local snd = Sound( "npc/roller/mine/rmine_predetonate.wav" )
+function ENT:StartTouch( ent )
+    if self.Removing then return end
+    if ent:IsNPC() and ( not ent:GetNWEntity( "HordeOwner" ):IsValid() ) then
+        self.Removing = true
+        self:EmitSound( snd, 100 )
+
+        timer.Simple( 1, function ()
+            if not self:IsValid() then return end
+            self:Detonate()
+        end )
+    end
+end
+function ENT:PhysicsCollide( data, phys )
+    if ( data.Speed > 50 ) then self:EmitSound( Sound("Grenade.ImpactSoft") ) end
+    if (data.HitEntity:GetClass() == "projectile_horde_flaregun_flare") and data.HitEntity:GetOwner() == self.Horde_Owner then
+            if not self:IsValid() then return end
+            self:Detonate()
+    end
+
+end
+function ENT:Use(ply)
+    if ( self:IsPlayerHolding() ) then return end
+    if ply ~= self.Horde_Owner then return end
+    ply:PickupObject( self )
+end
+function ENT:Detonate()
+    if self.Detonated then return end
+    self.Detonated = true
+    self.Removing = true
+    local pos = self:GetPos()
+    local eff = EffectData()
+    eff:SetStart( pos )
+    eff:SetOrigin( pos )
+    util.Effect( "Explosion", eff )
+    util.BlastDamage( self, self.Horde_Owner, pos, 100, 200 )
+
+    for _, e in pairs( ents.FindInSphere( self:GetPos(), 200 ) ) do
+        if e:IsNPC() and ( not e:GetNWEntity( "HordeOwner" ):IsValid() ) then
+            local dmg = DamageInfo()
+            dmg:SetDamage( 375 )
+            dmg:SetDamageType( DMG_BURN )
+            dmg:SetAttacker( self.Horde_Owner )
+            dmg:SetInflictor( self )
+            dmg:SetDamagePosition( e:GetPos() )
+            e:TakeDamageInfo( dmg )
+        end
+    end
+
+    local ply = self.Horde_Owner
+        local cloud = ents.Create("arccw_horde_butane_fire")
+
+    if not IsValid(cloud) then return end
+
+    local vel = Vector(math.Rand(-1, 1), math.Rand(-1, 1), math.Rand(-1, 1)) * 1500
+
+    cloud:SetPos(self:GetPos() - (self:GetVelocity() * FrameTime()))
+    cloud:SetAbsVelocity(vel + self:GetVelocity())
+    cloud:SetOwner(ply)
+    cloud:Spawn()
+    self:Remove()
+end
+function ENT:OnRemove()
+    local ply = self.Horde_Owner
+ timer.Simple( 7, function ()
+        if not ply:IsValid() then return end
+        if ply:Horde_GetGadget() ~= "gadget_butane_can" then return end
+        if ply:Horde_GetGadgetCharges() >= 3 then
+            ply:Horde_SetGadgetCharges( 3 )
+        else
+            ply:Horde_SetGadgetCharges( ply:Horde_GetGadgetCharges() + 1 )
+        end
+    end )
+end

--- a/gamemodes/horde/entities/entities/horde_butane_can/shared.lua
+++ b/gamemodes/horde/entities/entities/horde_butane_can/shared.lua
@@ -1,0 +1,3 @@
+ENT.Type = "anim"
+ENT.Base = "base_anim"
+

--- a/gamemodes/horde/gamemode/gadgets/gadget_butane_can.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_butane_can.lua
@@ -1,37 +1,52 @@
 GADGET.PrintName = "Butane Can"
-GADGET.Description = "Drops a Butane Can that explodes on physical impact.\nExplosion deals {1} Fire damage.\nOnly 1 Butane Can can be spawned at a time."
+GADGET.Description = "Drops a Butane Can that explodes when shot or when an enemy gets near.\nExplosion deals {1} Blast damage when shot or {2} Fire damage when an Enemy triggers it.\nup to 3 Butane Cans can be spawned at a time.\nleaves behind a small pool of fire.\nhas 3 charges that regenerate after 7 seconds when a can detonates."
 GADGET.Icon = "items/gadgets/butane_can.png"
+--GADGET.Duration = 0
+--GADGET.Cooldown = 20
 GADGET.Duration = 0
-GADGET.Cooldown = 20
+GADGET.Cooldown = 0.5
+GADGET.Charges = 3
 GADGET.Active = true
 GADGET.Params = {
-    [1] = { value = 375 },
+    [1] = { value = 200 },
+    [2] = { value = 375 },
 }
 GADGET.Hooks = {}
 
 GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     if CLIENT then return end
     if ply:Horde_GetGadget() ~= "gadget_butane_can" then return end
-    if ply.Horde_Butane_Can and ply.Horde_Butane_Can:IsValid() then
-        ply.Horde_Butane_Can:Remove()
-        ply.Horde_Butane_Can = nil
+       if not ply.Horde_Butane_Cans then ply.Horde_Butane_Cans = {} end
+    if ply:Horde_GetGadgetCharges() <= 0 then return end
+    if ply:Horde_GetGadgetCharges() == 3 then
+        ply.Horde_Butane_Cans = {}
     end
-    local ent = ents.Create("prop_physics")
+    local ent = ents.Create("horde_butane_can")
     local pos = ply:EyePos()
     local dir = ply:GetAimVector()
     local drop_pos = pos + dir * 50
     drop_pos.z = pos.z
     ent:SetPos(drop_pos)
+    ent.Horde_Owner = ply
     ent:SetAngles(Angle(0, ply:GetAngles().y, 0))
-    ent:SetModel("models/props_c17/oildrum001_explosive.mdl")
     ent:Spawn()
-    ply.Horde_Butane_Can = ent
+        table.insert( ply.Horde_Butane_Cans, ent )
+    ply:Horde_SetGadgetCharges( ply:Horde_GetGadgetCharges() - 1 )
 end
 
-GADGET.Hooks.Horde_OnPlayerDamage = function (ply, npc, bonus, hitgroup, dmginfo)
-    if ply:Horde_GetGadget() ~= "gadget_butane_can" then return end
-    if dmginfo:GetInflictor():GetModel() == "models/props_c17/oildrum001_explosive.mdl" then
-        bonus.increase = bonus.increase + 10.0
-        dmginfo:SetDamageType(DMG_BURN)
+
+GADGET.Hooks.Horde_OnSetGadget = function ( ply, gadget )
+    if CLIENT or gadget ~= "gadget_butane_can" then return end
+    if not ply.Horde_Butane_Cans then ply.Horde_Butane_Cans = {} end
+    ply:Horde_SetGadgetCharges( 3 )
+end
+
+GADGET.Hooks.Horde_OnUnsetGadget = function ( ply, gadget )
+    if CLIENT or gadget ~= "gadget_butane_can" then return end
+    if ( not ply.Horde_Butane_Cans ) or table.IsEmpty( ply.Horde_Butane_Cans ) then return end
+    for _, cans in pairs( ply.Horde_Butane_Cans ) do
+        if cans:IsValid() then
+            cans:Detonate()
+        end
     end
 end

--- a/gamemodes/horde/gamemode/languages/english.lua
+++ b/gamemodes/horde/gamemode/languages/english.lua
@@ -1638,9 +1638,11 @@ Each shockwave deals 50 Lightning damage.
 -- Cremator Gadgets
 LANGUAGE["Gadget_gadget_butane_can"] = [[Butane Can]]
 LANGUAGE["Gadget_Desc_gadget_butane_can"] = [[
-Drops a Butane Can that explodes on physical impact.
-Explosion deals 375 Fire damage.
-Only 1 Butane Can can be spawned at a time.
+Drops a Butane Can that explodes when shot or when an enemy gets near.
+Explosion deals {1} Blast damage when shot or {2} Fire damage when an Enemy triggers it.
+Up to 3 Butane Cans can be spawned at a time.
+Leaves behind a small pool of fire on detonation.
+has 3 charges that regenerate after 7 seconds when a can detonates.
 ]]
 
 LANGUAGE["Gadget_gadget_projectile_launcher_fire"] = [[Projectile Launcher (Fire)]]


### PR DESCRIPTION
Reworked the butane can gadget so its essentially an IED ripoff that leaves behind a pool of fire (this means players can't minge with the barrel anymore)

shooting it detonates the can for 200 blast damage+leaving behind a weak short lived pool of fire

if an enemy gets close to it, it detonates for 375 Fire damage and leaves behind the same pool of fire

has 3 charges, cooldown is 7 seconds between a can detonating and a charge recharging (mainly to combat chain spamming what're essentially offbrand molotovs although players get punished for this anyway since cans can ignite other cans)

fixed a collision rule error on the molotov's fire