### PR TITLE
fix: ult count still being given on unset

### DIFF
--- a/gamemodes/horde/gamemode/perks/necromancer/necromancer_necromastery.lua
+++ b/gamemodes/horde/gamemode/perks/necromancer/necromancer_necromastery.lua
@@ -11,17 +11,22 @@ PERK.Hooks = {}
 
 PERK.Hooks.Horde_OnSetPerk = function(ply, perk)
     if CLIENT then return end
-    if perk == "necromancer_necromastery" then
-        UpdateSpectreMaxCount(ply)
-    end
+    if perk ~= "necromancer_necromastery" then return end
+
+    UpdateSpectreMaxCount(ply)
 end
 
 PERK.Hooks.Horde_OnUnsetPerk = function(ply, perk)
     if CLIENT then return end
-    if perk == "necromancer_necromastery" then
-        HORDE:RemoveSpectres(ply)
+    if perk ~= "necromancer_necromastery" then return end
+
+    HORDE:RemoveSpectres(ply)
+
+    timer.Simple(0, function()
+        if not IsValid(ply) then return end
+
         UpdateSpectreMaxCount(ply)
-    end
+    end)
 end
 
 PERK.Hooks.Horde_OnSpellCooldown = function ( ply, bonus, spell )


### PR DESCRIPTION
The perk is still "Active" on unset to the spectre max count calculation so we just run it a tick later to prevent this
Also improves styling