### PR TITLE
LMG movement buffs + USAS movement buff

### DIFF
--- a/gamemodes/horde/entities/weapons/arccw_horde_m249.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m249.lua
@@ -19,6 +19,7 @@ SWEP.DamageMin = 41
 SWEP.Primary.ClipSize = 150
 SWEP.Delay = 60 / 900
 SWEP.RecoilPunch = 0
+SWEP.ShootSpeedMult = 0.85
 
 SWEP.FirstShootSound = "ArcCW_Horde.GSO.M249_Fire"
 SWEP.ShootSound = "ArcCW_Horde.GSO.M249_Fire"

--- a/gamemodes/horde/entities/weapons/arccw_horde_m2_browning.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_m2_browning.lua
@@ -84,10 +84,10 @@ SWEP.ShellScale = 2
 
 SWEP.MuzzleEffectAttachment = 1 -- which attachment to put the muzzle on
 SWEP.CaseEffectAttachment = 2 -- which attachment to put the case effect on
-SWEP.SpeedMult = 0.7
+SWEP.SpeedMult = 0.875
 SWEP.ShootSpeedMult = 0.6
-SWEP.SightedSpeedMult = 0.3
-SWEP.SightTime = 0.55
+SWEP.SightedSpeedMult = 0.35
+SWEP.SightTime = 0.22
 
 SWEP.IronSightStruct = {
     Pos = Vector(-5.902, -10.653, 4.796),
@@ -223,7 +223,7 @@ SWEP.Animations = {
         ShellEjectAt = 0
     },
     ["fire_iron"] = {
-        Source = "cya zoom",
+        Source = "nil",
         Time = .2,
         ShellEjectAt = 0
     },

--- a/gamemodes/horde/entities/weapons/arccw_horde_negev.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_negev.lua
@@ -19,6 +19,7 @@ SWEP.RecoilPunch = 0
 SWEP.Damage = 56
 SWEP.DamageMin = 46
 SWEP.Delay = 60 / 700
+SWEP.ShootSpeedMult = 0.85
 
 SWEP.FirstShootSound = "ArcCW_Horde.GSO.Negev_Fire"
 SWEP.ShootSound = "ArcCW_Horde.GSO.Negev_Fire"

--- a/gamemodes/horde/entities/weapons/arccw_horde_usas12.lua
+++ b/gamemodes/horde/entities/weapons/arccw_horde_usas12.lua
@@ -95,7 +95,7 @@ SWEP.MuzzleVelocity = 100000 -- projectile or phys bullet muzzle velocity
 
 -- Speed mult --
 
-SWEP.SpeedMult = 0.85
+SWEP.SpeedMult = 1
 SWEP.SightedSpeedMult = 0.7
 SWEP.SightTime = 0.42
 SWEP.IronSightStruct = {


### PR DESCRIPTION
###  SAW & Negev - Movement speed penalty when firing reduced from 50% to 15%
originally I was gonna remove the penalty entirely, but it allowed for some really devious stuff especially with the shotty & ripper kits. Might increase the penalty to 20% down the line later

### M2 Browning - Decreased base movement speed penalty from 30% to 13.5%, Increased ads time to 0.35 seconds, and removed the animation that plays while firing in ads to make scopes useable
ma deuce felt extremely sluggish, especially compared to the minigun, so it felt necessary to bring the speed up

### USAS-12 - Default movement speed penalty removed
probably won't make the weapon actually good but it's a start