### PR TITLE
Fix #363 (Negative Burst)

### DIFF
--- a/gamemodes/horde/entities/effects/horde_negative_burst.lua
+++ b/gamemodes/horde/entities/effects/horde_negative_burst.lua
@@ -5,7 +5,7 @@ function EFFECT:Init(ed)
     local emitter2 = ParticleEmitter(vOrig, true)
     local normal = Vector(0,0,1)
     local radius = ed:GetRadius()
-    sound.Play("sound/horde/spells/negative_burst.ogg", vOrig, 80, math.random(70, 90), 0.75)
+    sound.Play("(horde/spells/negative_burst.ogg", vOrig, 100, math.random(70, 90))
 
     --sound.Play("horde/weapons/nether_relic/nether_star_explode.ogg", vOrig, 100, math.random(70, 90))
 

--- a/gamemodes/horde/gamemode/perks/warlock/warlock_negative_burst.lua
+++ b/gamemodes/horde/gamemode/perks/warlock/warlock_negative_burst.lua
@@ -13,13 +13,12 @@ PERK.Hooks.Horde_OnSpellFire = function( ply, wpn, stage, spell )
         local o = ply:GetPos() + Vector( 0, 0, 24 )
 
         for _, ent in pairs( ents.FindInSphere( o, r ) ) do
-            if IsValid( ent ) and ent ~= ply and ( ent:IsNPC() or ent:IsPlayer() ) then
+            if IsValid( ent ) and ent ~= ply and HORDE:IsEnemy( ent ) then
                 local dmg = DamageInfo()
                 dmg:SetAttacker( ply )
                 dmg:SetInflictor( wpn )
                 dmg:SetDamageType( DMG_DIRECT )
                 dmg:SetDamage( damage_amount )
-                dmg:SetDamageCustom( HORDE.DMG_PLAYER_FRIENDLY )
                 ent:TakeDamageInfo( dmg )
             end
         end


### PR DESCRIPTION
- Fixes a mistake I didn't catch before approving in #363
  - Fixed players and minions being valid targets for being damaged
- (unrelated) fixed sfx being inaudible