### PR TITLE
Revert "Update horde difficulty names"

### DIFF
--- a/gamemodes/horde/gamemode/sh_difficulty.lua
+++ b/gamemodes/horde/gamemode/sh_difficulty.lua
@@ -51,7 +51,7 @@ HORDE.Difficulty = {
         xpMultiEnd = 5,
     },
     [3] = {
-        name = "SWARM", -- Swarm difficulty, more enemies.
+        name = "MEDIUM", -- Medium difficulty, more enemies.
         damageMultiplier = 1.8,
         enemyCountMultiplier = 1.4,
         rewardMultiplier = 0.3,
@@ -75,7 +75,7 @@ HORDE.Difficulty = {
         xpMultiEnd = 5,
     },
     [4] = {
-        name = "CHAOS", -- Chaos difficulty, 100% mutation for non-Elite.
+        name = "HARD", -- Hard difficulty, 100% mutation for non-Elite.
         damageMultiplier = 2,
         enemyCountMultiplier = 1.2,
         rewardMultiplier = 0.3,

--- a/gamemodes/horde/horde.txt
+++ b/gamemodes/horde/horde.txt
@@ -59,7 +59,7 @@
 		7
 		{
 			"name"		"horde_difficulty"
-			"text"		"Difficulty (1=CASUAL, 2=NORMAL, 3=SWARM, 4=CHAOS, 5=VETERAN, 6=ELITE-RUSH)"
+			"text"		"Difficulty (1=CASUAL, 2=NORMAL, 3=MEDIUM, 4=HARD, 5=VETERAN, 6=ELITE-RUSH)"
 			"type"		"Numeric"
 			"default"	"3"
 			"singleplayer" ""


### PR DESCRIPTION
Reverts npc-servers/horde#463

Most people still played veteran/elite rush anyways and the rename only caused confusion among players who were here after the difficulty rework so they didn't know what swarm/chaos was