### PR TITLE
Remove RENDERMODE_TRANSCOLOR of uneeded things

### DIFF
--- a/gamemodes/horde/entities/entities/npc_vj_mutated_hulk/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_mutated_hulk/init.lua
@@ -65,8 +65,6 @@ function ENT:CustomOnInitialize()
     self:SetCollisionBounds(Vector(18, 18, 90), Vector(-18, -18, 0))
     self:SetSkin(math.random(0,3))
     self:SetColor(Color(255,0,255,255))
--- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
- -- self:SetRenderMode(RENDERMODE_TRANSCOLOR)
     self:AddRelationship("npc_headcrab_poison D_LI 99")
 	self:AddRelationship("npc_headcrab_fast D_LI 99")
 end

--- a/gamemodes/horde/entities/entities/npc_vj_mutated_hulk/init.lua
+++ b/gamemodes/horde/entities/entities/npc_vj_mutated_hulk/init.lua
@@ -64,8 +64,9 @@ ENT.WorldShakeOnMoveFrequency = 100 -- Just leave it to 100
 function ENT:CustomOnInitialize()
     self:SetCollisionBounds(Vector(18, 18, 90), Vector(-18, -18, 0))
     self:SetSkin(math.random(0,3))
-    self:SetColor(Color(255,0,255))
-    self:SetRenderMode(RENDERMODE_TRANSCOLOR)
+    self:SetColor(Color(255,0,255,255))
+-- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
+ -- self:SetRenderMode(RENDERMODE_TRANSCOLOR)
     self:AddRelationship("npc_headcrab_poison D_LI 99")
 	self:AddRelationship("npc_headcrab_fast D_LI 99")
 end

--- a/gamemodes/horde/entities/entities/obj_vj_horde_homing_lightning/init.lua
+++ b/gamemodes/horde/entities/entities/obj_vj_horde_homing_lightning/init.lua
@@ -24,8 +24,8 @@ function ENT:Initialize()
 		phys:EnableGravity(false)
 		phys:Wake()
 	end
-
-	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
+-- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
+--	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
 	self:SetColor(Color(255,255,0,255))
 
 	self.delayRemove = CurTime() + 60

--- a/gamemodes/horde/entities/entities/obj_vj_horde_homing_lightning/init.lua
+++ b/gamemodes/horde/entities/entities/obj_vj_horde_homing_lightning/init.lua
@@ -24,8 +24,6 @@ function ENT:Initialize()
 		phys:EnableGravity(false)
 		phys:Wake()
 	end
--- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
---	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
 	self:SetColor(Color(255,255,0,255))
 
 	self.delayRemove = CurTime() + 60

--- a/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
@@ -21,8 +21,6 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetAngles(Angle(0, ply:GetAngles().y, 0))
     ply:Horde_AddDropEntity(ent:GetClass(), ent)
     ent:SetNWEntity("HordeOwner", ply)
-    -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
---   ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,0,0,255))
     ent:Spawn()
     ent.Horde_Is_Mini_Sentry = true

--- a/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
@@ -21,7 +21,8 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetAngles(Angle(0, ply:GetAngles().y, 0))
     ply:Horde_AddDropEntity(ent:GetClass(), ent)
     ent:SetNWEntity("HordeOwner", ply)
-    ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
+    -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
+ //   ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,0,0,255))
     ent:Spawn()
     ent.Horde_Is_Mini_Sentry = true

--- a/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_turret_pack.lua
@@ -22,7 +22,7 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ply:Horde_AddDropEntity(ent:GetClass(), ent)
     ent:SetNWEntity("HordeOwner", ply)
     -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
- //   ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
+--   ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,0,0,255))
     ent:Spawn()
     ent.Horde_Is_Mini_Sentry = true

--- a/gamemodes/horde/gamemode/gadgets/gadget_watchtower_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_watchtower_pack.lua
@@ -23,8 +23,6 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetPos(drop_pos)
     ent:SetAngles(Angle(0, ply:GetAngles().y, 0))
     ent:SetNWEntity("HordeOwner", ply)
-    -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
- --   ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,255,0,255))
     ent:Spawn()
     ply.Horde_Extra_Watchtower = ent

--- a/gamemodes/horde/gamemode/gadgets/gadget_watchtower_pack.lua
+++ b/gamemodes/horde/gamemode/gadgets/gadget_watchtower_pack.lua
@@ -23,7 +23,8 @@ GADGET.Hooks.Horde_UseActiveGadget = function (ply)
     ent:SetPos(drop_pos)
     ent:SetAngles(Angle(0, ply:GetAngles().y, 0))
     ent:SetNWEntity("HordeOwner", ply)
-    ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
+    -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
+ --   ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
     ent:SetColor(Color(255,255,0,255))
     ent:Spawn()
     ply.Horde_Extra_Watchtower = ent

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -444,7 +444,6 @@ concommand.Add("horde_testing_spawn_enemy", function (ply, cmd, args)
 
     if enemy.color then
         spawned_enemy:SetColor(enemy.color)
-        -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
         if (enemy.color.a != 255) then
             spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
         end

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -447,6 +447,7 @@ concommand.Add("horde_testing_spawn_enemy", function (ply, cmd, args)
         -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
         if (enemy.color.a != 255) then
             spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
+        end
     end
 
     if enemy.weapon then

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -444,7 +444,7 @@ concommand.Add("horde_testing_spawn_enemy", function (ply, cmd, args)
 
     if enemy.color then
         spawned_enemy:SetColor(enemy.color)
-        if (enemy.color.a != 255) then
+        if enemy.color.a ~= 255 then
             spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
         end
     end

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -444,7 +444,9 @@ concommand.Add("horde_testing_spawn_enemy", function (ply, cmd, args)
 
     if enemy.color then
         spawned_enemy:SetColor(enemy.color)
-        spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
+        -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
+        if (enemy.color.a != 255) then
+            spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
     end
 
     if enemy.weapon then

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -564,7 +564,7 @@ function HORDE:SpawnEnemy(enemy, pos)
 
     if enemy.color then
         spawned_enemy:SetColor(enemy.color)
-        if (enemy.color.a != 255) then
+        if enemy.color.a ~= 255 then
             spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
         end
     end

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -564,7 +564,6 @@ function HORDE:SpawnEnemy(enemy, pos)
 
     if enemy.color then
         spawned_enemy:SetColor(enemy.color)
-        -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
         if (enemy.color.a != 255) then
             spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
         end

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -564,7 +564,9 @@ function HORDE:SpawnEnemy(enemy, pos)
 
     if enemy.color then
         spawned_enemy:SetColor(enemy.color)
-        spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
+        -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
+        if (enemy.color.a != 255) then
+            spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
     end
 
     if enemy.weapon then

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -567,6 +567,7 @@ function HORDE:SpawnEnemy(enemy, pos)
         -- Dont set RENDERMODE_TRANSCOLOR if alpha isnt used to save up on alot of fps
         if (enemy.color.a != 255) then
             spawned_enemy:SetRenderMode(RENDERMODE_TRANSCOLOR)
+        end
     end
 
     if enemy.weapon then


### PR DESCRIPTION
Reason being is that the source engine is much more expensive on rendering things with RENDERMODE_TRANSCOLOR if alpha isnt used then RENDERMODE_TRANSCOLOR isnt neccecary.
This was tested before in TF2 in another gamemode i code and fps increase went up by alot, around 300% if its used on around 200+ entities.
This also fixes hulk not setting alpha ever.

Warning: I have never ever coded in lua, so please double check this.
Thank you.