### PR TITLE
Add player ready up between waves

### DIFF
--- a/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
+++ b/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
@@ -388,6 +388,8 @@ net.Receive("Horde_RenderBreakCountDown", function()
                 HORDE.HelpPanel:SetVisible(false)
                 HORDE.TipPanel:SetVisible(false)
                 HORDE.leader_board:SetVisible(false)
+
+                HORDE.TipPanel:SetPos(ScrW() / 2 - ScrW() * 2 / 10, ScreenScale(6))
             end
             if num == 10 then
                 surface.PlaySound("hl1/fvox/ten.wav")
@@ -403,6 +405,8 @@ net.Receive("Horde_RenderBreakCountDown", function()
                 HORDE.PlayerReadyPanel:SetVisible(true)
                 HORDE.HelpPanel:SetVisible(true)
                 HORDE.TipPanel:SetVisible(true)
+                HORDE.TipPanel:MoveBelow(HORDE.PlayerReadyPanel, ScreenScale(2))
+
                 HORDE:ShowLeaderboardThenFadeOut()
             end
         end

--- a/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
+++ b/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
@@ -384,7 +384,7 @@ net.Receive("Horde_RenderBreakCountDown", function()
     if num then
         if num >= 0 and num <= 10 then
             if HORDE.PlayerReadyPanel then
-                HORDE.PlayerReadyPanel:Remove()
+                HORDE.PlayerReadyPanel:SetVisible(false)
                 HORDE.HelpPanel:SetVisible(false)
                 HORDE.TipPanel:SetVisible(false)
                 HORDE.leader_board:SetVisible(false)
@@ -400,6 +400,7 @@ net.Receive("Horde_RenderBreakCountDown", function()
             end
         elseif num > 0 then
             if not HORDE.HelpPanel:IsVisible() then
+                HORDE.PlayerReadyPanel:SetVisible(true)
                 HORDE.HelpPanel:SetVisible(true)
                 HORDE.TipPanel:SetVisible(true)
                 HORDE:ShowLeaderboardThenFadeOut()

--- a/gamemodes/horde/gamemode/gui/cl_ready.lua
+++ b/gamemodes/horde/gamemode/gui/cl_ready.lua
@@ -71,6 +71,7 @@ local tip = ""
 HORDE.TipPanel = vgui.Create("DPanel")
 HORDE.TipPanel:SetSize(ScrW() * 2 / 5, ScreenScale(15))
 HORDE.TipPanel:SetPos(ScrW() / 2 - ScrW() * 2 / 10, ScreenScale(6))
+HORDE.TipPanel:MoveBelow(HORDE.PlayerReadyPanel, ScreenScale(2))
 HORDE.TipPanel.Paint = function (w,h)
     if tip == nil or tip == "" then return end
     draw.RoundedBox(10, 0, 0, ScrW() * 2 / 5, ScreenScale(15),  Color(40,40,40,200))

--- a/gamemodes/horde/gamemode/gui/cl_ready.lua
+++ b/gamemodes/horde/gamemode/gui/cl_ready.lua
@@ -84,6 +84,7 @@ net.Receive("Horde_SyncTip", function()
         HORDE.TipPanel:SetVisible(false)
     else
         HORDE.TipPanel:SetVisible(true)
+        HORDE.TipPanel:SetPos(ScrW() / 2 - ScrW() * 2 / 10, ScreenScale(6))
         HORDE:ShowLeaderboardThenFadeOut()
     end
 end)
@@ -119,7 +120,7 @@ end)
 
 net.Receive("Horde_RemoveReadyPanel", function()
     if HORDE.PlayerReadyPanel then
-        HORDE.PlayerReadyPanel:Remove()
+        HORDE.PlayerReadyPanel:SetVisible(false)
         HORDE.HelpPanel:SetVisible(false)
     end
 end)

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -85,7 +85,10 @@ end
 --Skip trader time--
 function SkipTraderTime(ply)
     if HORDE.current_wave <= 0 then return end
-    if not HORDE:InBreak() then return end
+    if not HORDE:InBreak() then
+        HORDE:SendNotification("You can't skip right now!", 1, ply)
+        return
+    end
     if HORDE.current_break_time <= 10 then
         HORDE:SendNotification("Next wave is starting!", 1, ply)
         return
@@ -243,6 +246,7 @@ hook.Add("PlayerSay", "Horde_Commands", function(ply, input, public)
     if text[1] == "!help" then
         ply:PrintMessage(HUD_PRINTTALK, "'!ready' - Get ready")
         ply:PrintMessage(HUD_PRINTTALK, "'!shop' - Open shop")
+        ply:PrintMessage(HUD_PRINTTALK, "'!skip' - Skip trader time")
         ply:PrintMessage(HUD_PRINTTALK, "'!drop' - Drop weapon")
         ply:PrintMessage(HUD_PRINTTALK, "'!throwmoney <amount>' - Drop money")
         ply:PrintMessage(HUD_PRINTTALK, "'!rtv' -Initiate a map change vote")
@@ -250,6 +254,8 @@ hook.Add("PlayerSay", "Horde_Commands", function(ply, input, public)
         Start(ply)
     elseif text[1] == "!ready" then
         Ready(ply)
+    elseif text[1] == "!skip" then
+        SkipTraderTime(ply)
     elseif text[1] == "!end" then
         End(ply)
     elseif text[1] == "!shop" then
@@ -293,6 +299,10 @@ end)
 
 concommand.Add("horde_ready", function (ply, cmd, args)
     Ready(ply)
+end)
+
+concommand.Add("horde_skip_trader", function (ply, cmd, args)
+    SkipTraderTime(ply)
 end)
 
 concommand.Add("horde_end", function (ply, cmd, args)

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -57,7 +57,7 @@ local function Start(ply)
 end
 
 function Ready(ply)
-    if HORDE.current_wave > 0 then return end
+    if HORDE.current_wave > 0 then SkipTraderTime(ply) return end
     if not ply:Alive() then
         HORDE:SendNotification("You can't get ready when you are dead!", 1, ply)
         return
@@ -80,6 +80,39 @@ function Ready(ply)
 
     if HORDE.start_game and HORDE.current_wave > 0 then return end
     HORDE:BroadcastPlayersReadyMessage(tostring(readyCount) .. "/" .. tostring(totalPlayers))
+end
+
+--Skip trader time--
+function SkipTraderTime(ply)
+    if HORDE.current_wave <= 0 then return end
+    if not HORDE:InBreak() then return end
+    if HORDE.current_break_time <= 10 then
+        HORDE:SendNotification("Next wave is starting!", 1, ply)
+        return
+    end
+    if not ply:Alive() then
+        HORDE:SendNotification("You can't get ready when you are dead!", 1, ply)
+        return
+    end
+    
+    
+    HORDE.player_ready[ply] = 1
+    local skip_count = 0
+    local total_player = 0
+    for _, skip_ply in pairs(player.GetAll()) do
+        if HORDE.player_ready[skip_ply] == 1 then
+            skip_count = skip_count + 1
+        end
+        total_player = total_player + 1
+    end
+    
+    if skip_count >= total_player then
+        HORDE.Skip_Wave_Timer = true
+    end
+
+    net.Start("Horde_PlayerReadySync")
+        net.WriteTable(HORDE.player_ready)
+    net.Broadcast()
 end
 
 local function End(ply)

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -1014,6 +1014,12 @@ function HORDE:StartBreak()
     net.Broadcast()
     timer.Create("Horder_Counter", 1, 0, function ()
         if not HORDE.start_game then return end
+
+        if HORDE.Skip_Wave_Timer then
+            HORDE.current_break_time = 10
+            HORDE.Skip_Wave_Timer = nil
+        end
+
         HORDE:BroadcastBreakCountDownMessage(HORDE.current_break_time, false)
 
         if 0 < HORDE.current_break_time then
@@ -1226,6 +1232,7 @@ function HORDE:WaveEnd()
     horde_boss_properties = nil
     horde_boss_reposition = false
     horde_boss_critical = false
+    HORDE.player_ready = {}
 
     HORDE:StartBreak()
     local enemies = HORDE:ScanEnemies()
@@ -1257,11 +1264,16 @@ function HORDE:WaveEnd()
     net.WriteUInt(HORDE.render_highlight_disable, 3)
     net.Broadcast()
 
-    for _, ply in pairs(player.GetAll()) do
+    for _, ply in ipairs(player.GetAll()) do
         if not ply:Alive() then ply:Spawn() end
+        
         HORDE.player_class_changed[ply:SteamID()] = false
         HORDE.player_ready[ply] = 0
     end
+
+    net.Start("Horde_PlayerReadySync")
+        net.WriteTable(HORDE.player_ready)
+    net.Broadcast()
 
     if GetConVarNumber("horde_npc_cleanup") == 1 then
         for _, ent in pairs(ents.GetAll()) do


### PR DESCRIPTION
Adds a feature from Horde version 2.1.0 which allows players to skip intermission time to start the next wave earlier.

Suggestion from https://discord.com/channels/539289943004938251/1414666282527359130

PS: In this pull request, I thought 10s would be better instead of starting the next wave instantly to match the time just like when all the players are readied up before the first wave; while also giving players a chance to adjust their position before the wave would start.

Also, adjusts the Tips panel to be below the players ready panel, in order to avoid overlapping with the ready panel.