### PR TITLE
Make pressing F1 and F3 close their respective GUI's. Also, fix a minor issue with player ready between waves feature and fix carcass.

### DIFF
--- a/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
+++ b/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
@@ -388,6 +388,8 @@ net.Receive("Horde_RenderBreakCountDown", function()
                 HORDE.HelpPanel:SetVisible(false)
                 HORDE.TipPanel:SetVisible(false)
                 HORDE.leader_board:SetVisible(false)
+
+                HORDE.TipPanel:SetPos(ScrW() / 2 - ScrW() * 2 / 10, ScreenScale(6))
             end
             if num == 10 then
                 surface.PlaySound("hl1/fvox/ten.wav")
@@ -403,6 +405,8 @@ net.Receive("Horde_RenderBreakCountDown", function()
                 HORDE.PlayerReadyPanel:SetVisible(true)
                 HORDE.HelpPanel:SetVisible(true)
                 HORDE.TipPanel:SetVisible(true)
+                HORDE.TipPanel:MoveBelow(HORDE.PlayerReadyPanel, ScreenScale(2))
+
                 HORDE:ShowLeaderboardThenFadeOut()
             end
         end

--- a/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
+++ b/gamemodes/horde/gamemode/gui/cl_gameinfo.lua
@@ -384,7 +384,7 @@ net.Receive("Horde_RenderBreakCountDown", function()
     if num then
         if num >= 0 and num <= 10 then
             if HORDE.PlayerReadyPanel then
-                HORDE.PlayerReadyPanel:Remove()
+                HORDE.PlayerReadyPanel:SetVisible(false)
                 HORDE.HelpPanel:SetVisible(false)
                 HORDE.TipPanel:SetVisible(false)
                 HORDE.leader_board:SetVisible(false)
@@ -400,6 +400,7 @@ net.Receive("Horde_RenderBreakCountDown", function()
             end
         elseif num > 0 then
             if not HORDE.HelpPanel:IsVisible() then
+                HORDE.PlayerReadyPanel:SetVisible(true)
                 HORDE.HelpPanel:SetVisible(true)
                 HORDE.TipPanel:SetVisible(true)
                 HORDE:ShowLeaderboardThenFadeOut()

--- a/gamemodes/horde/gamemode/gui/cl_ready.lua
+++ b/gamemodes/horde/gamemode/gui/cl_ready.lua
@@ -71,6 +71,7 @@ local tip = ""
 HORDE.TipPanel = vgui.Create("DPanel")
 HORDE.TipPanel:SetSize(ScrW() * 2 / 5, ScreenScale(15))
 HORDE.TipPanel:SetPos(ScrW() / 2 - ScrW() * 2 / 10, ScreenScale(6))
+HORDE.TipPanel:MoveBelow(HORDE.PlayerReadyPanel, ScreenScale(2))
 HORDE.TipPanel.Paint = function (w,h)
     if tip == nil or tip == "" then return end
     draw.RoundedBox(10, 0, 0, ScrW() * 2 / 5, ScreenScale(15),  Color(40,40,40,200))

--- a/gamemodes/horde/gamemode/gui/cl_ready.lua
+++ b/gamemodes/horde/gamemode/gui/cl_ready.lua
@@ -84,6 +84,7 @@ net.Receive("Horde_SyncTip", function()
         HORDE.TipPanel:SetVisible(false)
     else
         HORDE.TipPanel:SetVisible(true)
+        HORDE.TipPanel:SetPos(ScrW() / 2 - ScrW() * 2 / 10, ScreenScale(6))
         HORDE:ShowLeaderboardThenFadeOut()
     end
 end)
@@ -119,7 +120,7 @@ end)
 
 net.Receive("Horde_RemoveReadyPanel", function()
     if HORDE.PlayerReadyPanel then
-        HORDE.PlayerReadyPanel:Remove()
+        HORDE.PlayerReadyPanel:SetVisible(false)
         HORDE.HelpPanel:SetVisible(false)
     end
 end)

--- a/gamemodes/horde/gamemode/gui/cl_shop.lua
+++ b/gamemodes/horde/gamemode/gui/cl_shop.lua
@@ -393,7 +393,6 @@ function PANEL:OnKeyCodePressed(key)
     if input.LookupKeyBinding(key) == "gm_showspare1" then
         HORDE:ToggleShop()
     end
-
 end
 
 function PANEL:OnRemove()

--- a/gamemodes/horde/gamemode/gui/cl_shop.lua
+++ b/gamemodes/horde/gamemode/gui/cl_shop.lua
@@ -307,6 +307,13 @@ function PANEL:Init()
         self:ReloadAttachments(attachments, container, description_panel)
         createBtn("Attachment", self.AttachmentTab, LEFT)
     end
+
+    hook.Add("OnPauseMenuShow", self, function()
+        if self and self:IsValid() and self:IsVisible() then
+            HORDE:ToggleShop()
+            return false
+        end
+    end)
 end
 
 function PANEL:ReloadAttachments(attachments, container, description_panel)
@@ -380,6 +387,17 @@ function PANEL:Paint(w, h)
     surface.SetMaterial(skull_mat)
     surface.SetDrawColor(Color(255,255,255))
     surface.DrawTexturedRect(self:GetWide() - surface.GetTextSize(text) + surface.GetTextSize(text2) - 55, 14, 20, 20)
+end
+
+function PANEL:OnKeyCodePressed(key)
+    if input.LookupKeyBinding(key) == "gm_showspare1" then
+        HORDE:ToggleShop()
+    end
+
+end
+
+function PANEL:OnRemove()
+    hook.Remove("OnPauseMenuShow", self)
 end
 
 vgui.Register("HordeShop", PANEL)

--- a/gamemodes/horde/gamemode/gui/cl_spellforge.lua
+++ b/gamemodes/horde/gamemode/gui/cl_spellforge.lua
@@ -342,6 +342,13 @@ function PANEL:Init()
     end
 
     createBtn("Class/Perks", ClassTab, RIGHT)
+
+    hook.Add("OnPauseMenuShow", self, function()
+        if self and self:IsValid() and self:IsVisible() then
+            HORDE:ToggleShop()
+            return false
+        end
+    end)
 end
 
 function PANEL:ReloadSpells(spells, container, description_panel)
@@ -411,6 +418,17 @@ function PANEL:Paint(w, h)
     surface.SetMaterial(skull_mat)
     surface.SetDrawColor(Color(255,255,255))
     surface.DrawTexturedRect(self:GetWide() - surface.GetTextSize(text) + surface.GetTextSize(text2) - 55, 14, 20, 20)
+end
+
+function PANEL:OnKeyCodePressed(key)
+    if input.LookupKeyBinding(key) == "gm_showspare1" then
+        HORDE:ToggleShop()
+    end
+
+end
+
+function PANEL:OnRemove()
+    hook.Remove("OnPauseMenuShow", self)
 end
 
 vgui.Register("HordeSpellForge", PANEL)

--- a/gamemodes/horde/gamemode/gui/cl_spellforge.lua
+++ b/gamemodes/horde/gamemode/gui/cl_spellforge.lua
@@ -424,7 +424,6 @@ function PANEL:OnKeyCodePressed(key)
     if input.LookupKeyBinding(key) == "gm_showspare1" then
         HORDE:ToggleShop()
     end
-
 end
 
 function PANEL:OnRemove()

--- a/gamemodes/horde/gamemode/gui/cl_stats.lua
+++ b/gamemodes/horde/gamemode/gui/cl_stats.lua
@@ -1019,6 +1019,13 @@ function PANEL:Init()
     if HORDE.has_new_update then
         learn_btn:DoClick()
     end
+
+    hook.Add("OnPauseMenuShow", self, function()
+        if self and self:IsValid() and self:IsVisible() then
+            HORDE:ToggleStats()
+            return false
+        end
+    end)
 end
 
 function PANEL:Paint(w, h)
@@ -1029,6 +1036,17 @@ function PANEL:Paint(w, h)
     else
         draw.RoundedBox(0, 0, 0, w, h, HORDE.color_hollow)
     end
+end
+
+function PANEL:OnKeyCodePressed(key)
+    if input.LookupKeyBinding(key) == "gm_showhelp" or input.LookupKeyBinding(key) == "gm_showteam" then
+        HORDE:ToggleStats()
+    end
+
+end
+
+function PANEL:OnRemove()
+    hook.Remove("OnPauseMenuShow", self)
 end
 
 vgui.Register("HordeStats", PANEL)

--- a/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
+++ b/gamemodes/horde/gamemode/perks/carcass/carcass_base.lua
@@ -58,6 +58,7 @@ end
 PERK.Hooks.Horde_OnPlayerDamageTaken = function (ply, dmginfo, bonus)
     if not ply:Horde_GetPerk("carcass_base") then return end
     if ply:Horde_GetMaxHypertrophyStack() <= 0 then return end
+    if dmginfo:GetDamage() == 0 then return end
     ply:Horde_AddHypertrophyStack()
 end
 

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -85,7 +85,10 @@ end
 --Skip trader time--
 function SkipTraderTime(ply)
     if HORDE.current_wave <= 0 then return end
-    if not HORDE:InBreak() then return end
+    if not HORDE:InBreak() then
+        HORDE:SendNotification("You can't skip right now!", 1, ply)
+        return
+    end
     if HORDE.current_break_time <= 10 then
         HORDE:SendNotification("Next wave is starting!", 1, ply)
         return
@@ -243,6 +246,7 @@ hook.Add("PlayerSay", "Horde_Commands", function(ply, input, public)
     if text[1] == "!help" then
         ply:PrintMessage(HUD_PRINTTALK, "'!ready' - Get ready")
         ply:PrintMessage(HUD_PRINTTALK, "'!shop' - Open shop")
+        ply:PrintMessage(HUD_PRINTTALK, "'!skip' - Skip trader time")
         ply:PrintMessage(HUD_PRINTTALK, "'!drop' - Drop weapon")
         ply:PrintMessage(HUD_PRINTTALK, "'!throwmoney <amount>' - Drop money")
         ply:PrintMessage(HUD_PRINTTALK, "'!rtv' -Initiate a map change vote")
@@ -250,6 +254,8 @@ hook.Add("PlayerSay", "Horde_Commands", function(ply, input, public)
         Start(ply)
     elseif text[1] == "!ready" then
         Ready(ply)
+    elseif text[1] == "!skip" then
+        SkipTraderTime(ply)
     elseif text[1] == "!end" then
         End(ply)
     elseif text[1] == "!shop" then
@@ -293,6 +299,10 @@ end)
 
 concommand.Add("horde_ready", function (ply, cmd, args)
     Ready(ply)
+end)
+
+concommand.Add("horde_skip_trader", function (ply, cmd, args)
+    SkipTraderTime(ply)
 end)
 
 concommand.Add("horde_end", function (ply, cmd, args)

--- a/gamemodes/horde/gamemode/sv_commands.lua
+++ b/gamemodes/horde/gamemode/sv_commands.lua
@@ -57,7 +57,7 @@ local function Start(ply)
 end
 
 function Ready(ply)
-    if HORDE.current_wave > 0 then return end
+    if HORDE.current_wave > 0 then SkipTraderTime(ply) return end
     if not ply:Alive() then
         HORDE:SendNotification("You can't get ready when you are dead!", 1, ply)
         return
@@ -80,6 +80,39 @@ function Ready(ply)
 
     if HORDE.start_game and HORDE.current_wave > 0 then return end
     HORDE:BroadcastPlayersReadyMessage(tostring(readyCount) .. "/" .. tostring(totalPlayers))
+end
+
+--Skip trader time--
+function SkipTraderTime(ply)
+    if HORDE.current_wave <= 0 then return end
+    if not HORDE:InBreak() then return end
+    if HORDE.current_break_time <= 10 then
+        HORDE:SendNotification("Next wave is starting!", 1, ply)
+        return
+    end
+    if not ply:Alive() then
+        HORDE:SendNotification("You can't get ready when you are dead!", 1, ply)
+        return
+    end
+    
+    
+    HORDE.player_ready[ply] = 1
+    local skip_count = 0
+    local total_player = 0
+    for _, skip_ply in pairs(player.GetAll()) do
+        if HORDE.player_ready[skip_ply] == 1 then
+            skip_count = skip_count + 1
+        end
+        total_player = total_player + 1
+    end
+    
+    if skip_count >= total_player then
+        HORDE.Skip_Wave_Timer = true
+    end
+
+    net.Start("Horde_PlayerReadySync")
+        net.WriteTable(HORDE.player_ready)
+    net.Broadcast()
 end
 
 local function End(ply)

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -1014,6 +1014,12 @@ function HORDE:StartBreak()
     net.Broadcast()
     timer.Create("Horder_Counter", 1, 0, function ()
         if not HORDE.start_game then return end
+
+        if HORDE.Skip_Wave_Timer then
+            HORDE.current_break_time = 10
+            HORDE.Skip_Wave_Timer = nil
+        end
+
         HORDE:BroadcastBreakCountDownMessage(HORDE.current_break_time, false)
 
         if 0 < HORDE.current_break_time then
@@ -1226,6 +1232,7 @@ function HORDE:WaveEnd()
     horde_boss_properties = nil
     horde_boss_reposition = false
     horde_boss_critical = false
+    HORDE.player_ready = {}
 
     HORDE:StartBreak()
     local enemies = HORDE:ScanEnemies()
@@ -1257,11 +1264,16 @@ function HORDE:WaveEnd()
     net.WriteUInt(HORDE.render_highlight_disable, 3)
     net.Broadcast()
 
-    for _, ply in pairs(player.GetAll()) do
+    for _, ply in ipairs(player.GetAll()) do
         if not ply:Alive() then ply:Spawn() end
+        
         HORDE.player_class_changed[ply:SteamID()] = false
         HORDE.player_ready[ply] = 0
     end
+
+    net.Start("Horde_PlayerReadySync")
+        net.WriteTable(HORDE.player_ready)
+    net.Broadcast()
 
     if GetConVarNumber("horde_npc_cleanup") == 1 then
         for _, ent in pairs(ents.GetAll()) do

--- a/gamemodes/horde/gamemode/sv_playerlifecycle.lua
+++ b/gamemodes/horde/gamemode/sv_playerlifecycle.lua
@@ -445,7 +445,7 @@ function HORDE:PlayerInit(ply)
         net.Start("Horde_Disable_Levels")
         net.Send(ply)
     end
-    if not HORDE.start_game then
+    if not HORDE.start_game or HORDE:InBreak() then
         HORDE.player_ready[ply] = 0
         net.Start("Horde_PlayerReadySync")
             net.WriteTable(HORDE.player_ready)
@@ -630,7 +630,7 @@ hook.Add("PlayerDisconnected", "Horde_PlayerDisconnect", function(ply)
         HORDE.player_money_wave[ply:SteamID()] = HORDE.current_wave
     end
 
-    if (not HORDE.start_game) and HORDE.player_ready[ply] then
+    if (not HORDE.start_game or HORDE:InBreak()) and HORDE.player_ready[ply] then
         HORDE.player_ready[ply] = nil
         net.Start("Horde_PlayerReadySync")
         net.WriteTable(HORDE.player_ready)


### PR DESCRIPTION
Applies 3 changes:
1. Pressing F1 and F3 will allow closing their respective GUI's. (i.e. stats menu and shop)
Suggestion from: https://discord.com/channels/539289943004938251/1535028736611586168

2. Fix a small issue with the player ready between waves feature that occurs when players join/leave during wave breaks.

3. Fix Carcass subclass giving hypertrophy stacks. Fix achieved by changing one of the player take damage's hooks, so that if the player with Carcass subclass "took" 0 damage, they will not receive any hypertrophy stacks. (Also happens when a player has stats menu open. This change fixes this issue.)

(Ignore the other 4 commits from August 5th, they are not relevant to the changes made in this pull request. They are also already committed on this repository.)