### PR TITLE
fix: use collision group projectile instead of interactive debris for enemies

### DIFF
--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -479,9 +479,9 @@ function HORDE:SpawnEnemy(enemy, pos)
 	timer.Simple(0, function()
 		if not IsValid( spawned_enemy ) then return end
 		spawned_enemy:SetAngles(Angle(0, math.random(0, 360), 0))
-		spawned_enemy:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+		spawned_enemy:SetCollisionGroup(COLLISION_GROUP_PROJECTILE)
 	end)
-	spawned_enemy:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
+	spawned_enemy:SetCollisionGroup(COLLISION_GROUP_PROJECTILE)
 
     HORDE.spawned_enemies[spawned_enemy:EntIndex()] = true
     spawned_enemy:Horde_SetName(enemy.name)

--- a/gamemodes/horde/gamemode/sv_horde.lua
+++ b/gamemodes/horde/gamemode/sv_horde.lua
@@ -479,9 +479,9 @@ function HORDE:SpawnEnemy(enemy, pos)
 	timer.Simple(0, function()
 		if not IsValid( spawned_enemy ) then return end
 		spawned_enemy:SetAngles(Angle(0, math.random(0, 360), 0))
-		spawned_enemy:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE_DEBRIS)
+		spawned_enemy:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
 	end)
-	spawned_enemy:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE_DEBRIS)
+	spawned_enemy:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
 
     HORDE.spawned_enemies[spawned_enemy:EntIndex()] = true
     spawned_enemy:Horde_SetName(enemy.name)


### PR DESCRIPTION
interactive debris seems to be really buggy compared to every other collision group, projectile seems to work better and all projectiles seem to work (grenades, HL2 projectiles, ArcCW projectiles)